### PR TITLE
Hide more bits

### DIFF
--- a/BGAnimations/ScreenGameplay underlay/Danger.lua
+++ b/BGAnimations/ScreenGameplay underlay/Danger.lua
@@ -9,6 +9,7 @@ local prevHealth = "HealthState_Alive"
 local danger = Def.Quad{
 	Name="Danger" .. ToEnumShortString(Player),
 	InitCommand=function(self)
+		self:visible(not SL[ToEnumShortString(Player)].ActiveModifiers.HideLifebar)
 		self:diffusealpha(0)
 
 		if bDoubles then

--- a/Graphics/Player combo.lua
+++ b/Graphics/Player combo.lua
@@ -39,12 +39,12 @@ local t = Def.ActorFrame {
 		c = self:GetChildren();
 		c.Number:visible(false);
 		c.Label:visible(false);
+		self:visible(not SL[ToEnumShortString(player)].ActiveModifiers.HideCombo)
 	end;
 
 	ComboCommand=function(self, param)
 		local iCombo = param.Misses or param.Combo;
-		if SL[ToEnumShortString(player)].ActiveModifiers.HideCombo or
-				not iCombo or iCombo < ShowComboAt then
+		if not iCombo or iCombo < ShowComboAt then
 			c.Number:visible(false);
 			c.Label:visible(false);
 			return;

--- a/Scripts/SL-PlayerOptions.lua
+++ b/Scripts/SL-PlayerOptions.lua
@@ -205,7 +205,7 @@ function OptionRowHide()
 		SelectType = "SelectMultiple",
 		OneChoiceForAllPlayers = false,
 		ExportOnChange = false,
-		Choices = { "Targets", "Background", "Combo", "Lifebar", "Score" },
+		Choices = { "Targets", "Background", "Combo", "Life", "Score" },
 		LoadSelections = function(self, list, pn)
 			local mods = SL[ToEnumShortString(pn)].ActiveModifiers
 			list[1] = mods.HideTargets or false


### PR DESCRIPTION
Hides combo splash along with combo, and hides danger flash along with lifebar (seemed to make sense with hiding current life status).