### PR TITLE
validate bannerpath

### DIFF
--- a/BGAnimations/ScreenEvaluation common/default.lua
+++ b/BGAnimations/ScreenEvaluation common/default.lua
@@ -51,14 +51,16 @@ local t = Def.ActorFrame{
 				SongOrCouse = GAMESTATE:GetCurrentSong()
 			end
 
-			if song then
+			if SongOrCouse then
 				 bannerpath = SongOrCouse:GetBannerPath()
 			end
 
 			if bannerpath then
-				self:LoadBanner(bannerpath)
-				self:setsize(418,164)
-				self:zoom(0.7)
+				if FILEMAN:DoesFileExist(bannerpath) then
+					self:LoadBanner(bannerpath)
+					self:setsize(418,164)
+					self:zoom(0.7)
+				end
 			end
 		end
 	},

--- a/BGAnimations/ScreenEvaluationSummary overlay/stageStats.lua
+++ b/BGAnimations/ScreenEvaluationSummary overlay/stageStats.lua
@@ -23,9 +23,11 @@ local t = Def.ActorFrame{
 			end
 
 			if bannerpath then
-				self:LoadBanner(bannerpath)
-				self:setsize(418,164)
-				self:zoom(0.333)
+				if FILEMAN:DoesFileExist(bannerpath) then
+					self:LoadBanner(bannerpath)
+					self:setsize(418,164)
+					self:zoom(0.333)
+				end
 			end
 		end
 	},

--- a/BGAnimations/ScreenNameEntryTraditional underlay/default.lua
+++ b/BGAnimations/ScreenNameEntryTraditional underlay/default.lua
@@ -132,9 +132,11 @@ if GAMESTATE:IsCourseMode() then
 			end
 
 			if bannerpath then
-				self:LoadBanner(bannerpath)
-				self:setsize(418,164)
-				self:zoom(0.7)
+				if FILEMAN:DoesFileExist(bannerpath) then
+					self:LoadBanner(bannerpath)
+					self:setsize(418,164)
+					self:zoom(0.7)
+				end
 			end
 		end
 	}
@@ -186,9 +188,11 @@ else
 				end
 
 				if bannerpath then
-					self:LoadBanner(bannerpath)
-					self:setsize(418,164)
-					self:zoom(0.7)
+					if FILEMAN:DoesFileExist(bannerpath) then
+						self:LoadBanner(bannerpath)
+						self:setsize(418,164)
+						self:zoom(0.7)
+					end
 				end
 			end
 		}


### PR DESCRIPTION
Prior to loading the bannerpath as an Actor, check the path actually
exists. If the path does not exist the fallback 3-heart banner will be
shown, as per ScreenSelectMusic.