### PR TITLE
Negative mini options in SL-PlayerOptions.lua

### DIFF
--- a/Scripts/SL-PlayerOptions.lua
+++ b/Scripts/SL-PlayerOptions.lua
@@ -160,7 +160,7 @@ local Overrides = {
 	Mini = {
 		Choices = function()
 
-			local first	= 0
+			local first	= -100
 			local last 	= 150
 			local step 	= 5
 


### PR DESCRIPTION
The original SL theme allowed negative mini sizes, change increases range from -100 to 150. Increasing the arrow size helps solve for 1920x1080 displays where arrows can appear smaller than standard.