### PR TITLE
Reinstate Audio Calibration Menu

### DIFF
--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -293,6 +293,7 @@ Appearance Options=♥  Appearance Options
 Timing Window Options=♥  Timing Window Options
 Theme Options=♥  Simply Love Options
 Set BG Fit Mode=♥  Set Background Fit
+Calibrate Machine Sync=♥  Sync Audio
 
 # System Options
 Editor Noteskin=Editor Noteskin

--- a/metrics.ini
+++ b/metrics.ini
@@ -782,9 +782,10 @@ PrevScreen=Branch.TitleMenu()
 NextScreen=Branch.TitleMenu()
 
 NumRowsShown=10
-LineNames="System,KeyConfig,TestInput,Appearance,BGFit,GraphicsSound,Arcade,Theme,Advanced,Profiles,Reload"
+LineNames="System,KeyConfig,TestInput,Sync,Appearance,BGFit,GraphicsSound,Arcade,Theme,Advanced,Profiles,Reload"
 LineSystem="gamecommand;screen,ScreenSelectGame;name,System Options"
 LineTestInput="gamecommand;screen,ScreenTestInput;name,Test Input"
+LineSync="gamecommand;screen,ScreenGameplaySyncMachine;name,Calibrate Machine Sync"
 LineAppearance="gamecommand;screen,ScreenAppearanceOptions;name,Appearance Options"
 LineGraphicsSound="gamecommand;screen,ScreenOptionsGraphicsSound;name,Graphics/Sound Options"
 LineArcade="gamecommand;screen,ScreenOptionsArcade;name,Arcade Options"
@@ -923,6 +924,9 @@ NextScreen="ScreenOptionsService"
 HeaderOnCommand=visible,false
 FooterOnCommand=visible,false
 
+[ScreenGameplaySyncMachine]
+PrevScreen="ScreenOptionsService"
+NextScreen="ScreenOptionsService"
 
 [ScreenOptionsManageProfiles]
 OptionRowNormalMetricsGroup="OptionRowProfile"


### PR DESCRIPTION
Now that StepMania's audio sync chart has finally been corrected (stepmania/stepmania#86), it seemed like a good time to reinstate the sync menu in SL. Not sure if you'll want to include or not, but I think it would be incredibly helpful to those playing on home setups.