### PR TITLE
Fix player/machine pacemaker graphs

### DIFF
--- a/Scripts/SL-Utilities.lua
+++ b/Scripts/SL-Utilities.lua
@@ -203,7 +203,7 @@ function GetTopScore(pn, kind)
 
 		if scorelist then
 			local topscore = scorelist:GetHighScores()[1]
-			if topsore then
+			if topscore then
 				return topscore:GetPercentDP()
 			end
 		end


### PR DESCRIPTION
Typo "topsore" was giving nil instead of topscore