### PR TITLE
Fix ScreenSelectMusic in Marathon Mode

### DIFF
--- a/BGAnimations/ScreenSelectMusic overlay/PerPlayer/Cursor.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/PerPlayer/Cursor.lua
@@ -102,11 +102,13 @@ return Def.Sprite{
 			elseif RowIndex < 1 then RowIndex = 1
 			end
 
-			-- update cursor y position
-			local sdl = self:GetParent():GetParent():GetChild("StepsDisplayList")
-			if sdl then
-				local grid = sdl:GetChild("Grid")
-				self:y(sdl:GetY() + grid:GetY() + grid:GetChild("Blocks_"..RowIndex):GetY() + 1 )
+			-- update cursor y position (only in non-course mode)
+			if GAMESTATE:IsCourseMode() == false then
+				local sdl = self:GetParent():GetParent():GetChild("StepsDisplayList")
+				if sdl then
+					local grid = sdl:GetChild("Grid")
+					self:y(sdl:GetY() + grid:GetY() + grid:GetChild("Blocks_"..RowIndex):GetY() + 1 )
+				end
 			end
 		end
 	end

--- a/BGAnimations/ScreenSelectMusic overlay/PerPlayer/StepArtist.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/PerPlayer/StepArtist.lua
@@ -64,7 +64,7 @@ return Def.ActorFrame{
 	--STEPS label
 	Def.BitmapText{
 		Font="_miso",
-		OnCommand=cmd(diffuse, color("0,0,0,1"); horizalign, left; x, 30; settext, Screen.String("STEPS"))
+		OnCommand=cmd(diffuse, color("0,0,0,1"); horizalign, left; x, 30; settext, GAMESTATE:IsCourseMode() and Screen.String("SONGS") or Screen.String("STEPS"))
 	},
 
 	--stepartist text

--- a/BGAnimations/ScreenSelectMusic overlay/StepsDisplayList/Grid.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/StepsDisplayList/Grid.lua
@@ -46,18 +46,13 @@ local t = Def.ActorFrame{
 					--Load the songs from the course
 					local course_entries = SongOrCourse:GetCourseEntries()
 					local songList = ""
-
+					
+					local songs = {}
 					for i=1,#course_entries do
-						local song = course_entries[i]:GetSong()
-						--TODO: Figure out why the above statement returns nil/null
-						if song then
-							songList = songList .. "\n" .. song
-						else 
-							songList = songList .. "\n" .. "null song"
-						end
-
+						songs[i] = course_entries[i]:GetSong()
 					end
-					SCREENMAN:SystemMessage(songList)
+					--TODO: course_entries[i]:GetSong() returns nil for every course entry, why?
+					SM(songs)
 				end
 			end
 		else

--- a/BGAnimations/ScreenSelectMusic overlay/StepsDisplayList/Grid.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/StepsDisplayList/Grid.lua
@@ -43,7 +43,7 @@ local t = Def.ActorFrame{
 						end
 					end
 				else
-					--Get the list of songs by the MasterPlayerNumber
+					--Get the list of songs by the MasterPlayerNumber (better way to do this?)
 					local player = GAMESTATE:GetMasterPlayerNumber()
 					local trail_entries = GAMESTATE:GetCurrentTrail(player):GetTrailEntries()
 					local songsToDisplay = {}

--- a/BGAnimations/ScreenSelectMusic overlay/StepsDisplayList/Grid.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/StepsDisplayList/Grid.lua
@@ -43,20 +43,19 @@ local t = Def.ActorFrame{
 						end
 					end
 				else
-					--Get the list of songs by the MasterPlayerNumber (better way to do this?)
+					--Get the current trail based on the Master Player Number 
+					--It shouldn't matter if it's P1 or P2 since Marathon mode locks you to the same difficulty
 					local player = GAMESTATE:GetMasterPlayerNumber()
 					local trail_entries = GAMESTATE:GetCurrentTrail(player):GetTrailEntries()
+
 					local songsToDisplay = {}
 
 					for i=1, #trail_entries do
-						local songTitle = trail_entries[i]:GetSong():GetDisplayMainTitle()
-						local songDifficulty = trail_entries[i]:GetSteps():GetDifficulty()
-						local songMeter = trail_entries[i]:GetSteps():GetMeter()
-
 						local song = {}
-						song["Title"] = songTitle
-						song["DifficultyColor"] = DifficultyColor(songDifficulty)
-						song["Meter"] = songMeter
+						song["Title"] = trail_entries[i]:GetSong():GetDisplayMainTitle()
+						song["DifficultyColor"] = DifficultyColor( trail_entries[i]:GetSteps():GetDifficulty() )
+						song["Meter"] = trail_entries[i]:GetSteps():GetMeter()
+						
 						songsToDisplay[i] = song
 					end
 

--- a/BGAnimations/ScreenSelectMusic overlay/StepsDisplayList/Grid.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/StepsDisplayList/Grid.lua
@@ -45,8 +45,7 @@ local t = Def.ActorFrame{
 				else
 					--Load the songs from the course
 					local course_entries = SongOrCourse:GetCourseEntries()
-					local songList = ""
-					
+
 					local songs = {}
 					for i=1,#course_entries do
 						songs[i] = course_entries[i]:GetSong()

--- a/BGAnimations/ScreenSelectMusic overlay/StepsDisplayList/Grid.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/StepsDisplayList/Grid.lua
@@ -43,15 +43,24 @@ local t = Def.ActorFrame{
 						end
 					end
 				else
-					--Load the songs from the course
-					local course_entries = SongOrCourse:GetCourseEntries()
+					--Get the list of songs by the MasterPlayerNumber
+					local player = GAMESTATE:GetMasterPlayerNumber()
+					local trail_entries = GAMESTATE:GetCurrentTrail(player):GetTrailEntries()
+					local songsToDisplay = {}
 
-					local songs = {}
-					for i=1,#course_entries do
-						songs[i] = course_entries[i]:GetSong()
+					for i=1, #trail_entries do
+						local songTitle = trail_entries[i]:GetSong():GetDisplayMainTitle()
+						local songDifficulty = trail_entries[i]:GetSteps():GetDifficulty()
+						local songMeter = trail_entries[i]:GetSteps():GetMeter()
+
+						local song = {}
+						song["Title"] = songTitle
+						song["DifficultyColor"] = DifficultyColor(songDifficulty)
+						song["Meter"] = songMeter
+						songsToDisplay[i] = song
 					end
-					--TODO: course_entries[i]:GetSong() returns nil for every course entry, why?
-					SM(songs)
+
+					SM(songsToDisplay)
 				end
 			end
 		else

--- a/BGAnimations/ScreenSelectMusic overlay/StepsDisplayList/Grid.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/StepsDisplayList/Grid.lua
@@ -65,8 +65,6 @@ local t = Def.ActorFrame{
 						 	self:GetChild("Grid"):GetChild("CourseSongName"..i):playcommand("Set", {SongToDisplay=song})
 						end
 					end
-
-					SM("# Songs: " .. #trail_entries)
 				end
 			end
 		else

--- a/BGAnimations/ScreenSelectMusic overlay/StepsDisplayList/Grid.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/StepsDisplayList/Grid.lua
@@ -55,7 +55,7 @@ local t = Def.ActorFrame{
 						song["Title"] = trail_entries[i]:GetSong():GetDisplayMainTitle()
 						song["DifficultyColor"] = DifficultyColor( trail_entries[i]:GetSteps():GetDifficulty() )
 						song["Meter"] = trail_entries[i]:GetSteps():GetMeter()
-						
+
 						songsToDisplay[i] = song
 					end
 
@@ -162,6 +162,9 @@ if GAMESTATE:IsCourseMode() == false then
 			UnsetCommand=cmd(settext, ""; diffuse,color("#182025")),
 		}
 	end
+
+else
+	--TODO: Add the Grid Children for the Course song list here
 end
 
 t[#t+1] = Grid

--- a/BGAnimations/ScreenSelectMusic overlay/songDescription.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/songDescription.lua
@@ -171,6 +171,7 @@ local t = Def.ActorFrame{
 					if SongOrCourse then
 						if GAMESTATE:IsCourseMode() then
 							if SongOrCourse:HasMods() then
+								self:settext("HAS MODS")
 							else 
 								self:settext("")
 							end

--- a/BGAnimations/ScreenSelectMusic overlay/songDescription.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/songDescription.lua
@@ -141,13 +141,21 @@ local t = Def.ActorFrame{
 			LoadActor("bubble.png")..{
 				InitCommand=cmd(diffuse,GetCurrentColor(); visible, false; zoom, 0.9; y, 30),
 				SetCommand=function(self)
-					local song = GAMESTATE:GetCurrentSong()
+					local SongOrCourse = GAMESTATE:IsCourseMode() and GAMESTATE:GetCurrentCourse() or GAMESTATE:GetCurrentSong()
 
-					if song then
-						if song:IsLong() or song:IsMarathon() then
-							self:visible(true)
+					if SongOrCourse then
+						if GAMESTATE:IsCourseMode() then
+							if SongOrCourse:HasMods() then
+								self:visible(true)
+							else
+								self:visible(false)
+							end
 						else
-							self:visible(false)
+							if SongOrCourse:IsLong() or SongOrCourse:IsMarathon() then
+								self:visible(true)
+							else
+								self:visible(false)
+							end
 						end
 					else
 						self:visible(false)
@@ -158,15 +166,22 @@ local t = Def.ActorFrame{
 			LoadFont("_miso")..{
 				InitCommand=cmd(diffuse, Color.Black; zoom,0.8; y, 34),
 				SetCommand=function(self)
-					local song = GAMESTATE:GetCurrentSong()
+					local SongOrCourse = GAMESTATE:IsCourseMode() and GAMESTATE:GetCurrentCourse() or GAMESTATE:GetCurrentSong()
 
-					if song then
-						if song:IsLong() then
-							self:settext("COUNTS AS 2 ROUNDS")
-						elseif song:IsMarathon() then
-							self:settext("COUNTS AS 3 ROUNDS")
+					if SongOrCourse then
+						if GAMESTATE:IsCourseMode() then
+							if SongOrCourse:HasMods() then
+							else 
+								self:settext("")
+							end
 						else
-							self:settext("")
+							if SongOrCourse:IsLong() then
+								self:settext("COUNTS AS 2 ROUNDS")
+							elseif SongOrCourse:IsMarathon() then
+								self:settext("COUNTS AS 3 ROUNDS")
+							else
+								self:settext("")
+							end
 						end
 					else
 						self:settext("")

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -66,6 +66,7 @@ Options=Options
 
 # StepArtist
 STEPS=STEPS
+SONGS=SONGS
 
 # SortMenu
 Group=Group


### PR DESCRIPTION
Now lists the songs in the course as opposed to the difficulty blocks and the broken cursor, the songs are displayed in 2 columns of 4.
