### PR TITLE
ScreenOptionsAdvanced: add AxisFix preference

### DIFF
--- a/metrics.ini
+++ b/metrics.ini
@@ -949,7 +949,7 @@ LineNameEntry="lua,ThemePrefsRows.GetRow('ScreenNameEntryMenuTimer')"
 
 
 [ScreenOptionsAdvanced]
-LineNames="3,4,8,11,13,15,16,28,29,30,PercentageScoring"
+LineNames="3,4,8,11,13,15,16,28,29,30,PercentageScoring,AxisFix"
 Line3="conf,TimingWindowScale"
 Line4="conf,LifeDifficulty"
 Line8="conf,DefaultFailType"
@@ -961,6 +961,7 @@ Line28="conf,AutogenSteps"
 Line29="conf,AutogenGroupCourses"
 Line30="conf,FastLoad"
 LinePercentageScoring="conf,PercentageScoring"
+LineAxisFix="conf,AxisFix"
 
 
 


### PR DESCRIPTION
This preference fixes controllers (namely console adapters) that map arrows to an axis, thereby making opposing arrow presses (Left+Right or Up+Down) impossible. Playing on such controllers without this preference On is... unenjoyable.

Feel free to suggest better places to put this option!