### PR TITLE
Fix up some small inconsistencies

### DIFF
--- a/BGAnimations/ScreenGameplay overlay/SubtractiveScoring.lua
+++ b/BGAnimations/ScreenGameplay overlay/SubtractiveScoring.lua
@@ -10,7 +10,7 @@ if SL[ToEnumShortString(player)].ActiveModifiers.SubtractiveScoring then
   local x_position = GetNotefieldX( player )
 
   -- a flag to determine if we are using a GameMode that utilizes FA+ timing windows
-  local FAplus = (SL.Global.GameMode == "StomperZ" or SL.Global.GameMode == "ECFA")
+  local FAplus = (SL.Global.GameMode == "ECFA")
   local undesirable_judgment = FAplus and "W3" or "W2"
 
   -- flag to determine whether to bother to continue counting excellents
@@ -68,7 +68,7 @@ if SL[ToEnumShortString(player)].ActiveModifiers.SubtractiveScoring then
         end
 
       -- else if this wouldn't subtract from percentage (W1 or mine miss)
-      elseif ((FAplus and tns ~= "W1" and tns ~= "W2") or (not FAplus and tns ~= "W1") and tns ~= "AvoidMine") or
+      elseif (((FAplus and tns ~= "W1" and tns ~= "W2") or (not FAplus and tns ~= "W1")) and tns ~= "AvoidMine") or
              -- unless it actually would subtract from percentage (W1 + let go)
              (hns and ToEnumShortString(hns) == "LetGo") or
              -- or we're already dead (and so can't gain any percentage.)

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -338,7 +338,7 @@ Graphics/Sound Options=♥  Graphics/Sound Options
 Test Input=♥  Test Input
 Appearance Options=♥  Appearance Options
 Visual Options=♥  Visual Options
-Overscan Correction=♥ Overscan Correction
+Overscan Correction=♥  Overscan Correction
 Timing Window Options=♥  Timing Window Options
 Theme Options=♥  Simply Love Options
 MenuTimer Options=♥  MenuTimer Options
@@ -425,7 +425,6 @@ System Options=Change the game mode, the theme, the language, and more.
 Arcade Options=Change options typically associated with arcade games.
 Visual Options=Change the way lyrics, backgrounds, etc. are displayed during gameplay; adjust overscan.
 Appearance Options=Change the way things are displayed during gameplay (lyrics, backgrounds, etc.)
-Timing Window Options=Adjust the size of your timing windows to match those of other games.
 Theme Options=Adjust settings that only apply to this Simply Love theme.
 MenuTimer Options=Set the MenuTimer values for various screens.\nHas no effect if the MenuTimer is disabled.
 
@@ -457,7 +456,7 @@ AutoStyle=Set this to "None" if you always want to choose a style like "1 Player
 MusicWheelStyle=Set this to 'IIDX' if you want the MusicWheel to hide other, inactive song groups when actively browsing one.
 AllowDanceSolo=Set this to 'Yes' if you want to enable Solo style.\nThis only impacts 'Dance' game mode.
 HideStockNoteSkins=Set this to 'Hide' if you want to hide all NoteSkins\nthat come with SM5 from the modifier menu.
-TimingWindowAdd=Apply this controversial setting at your own discretion.  This has no impact on StomperZ GameMode.
+TimingWindowAdd=Apply this controversial setting at your own discretion.\nThe StomperZ and ECFA GameModes ignore this setting.
 AllowFailingOutOfSet=If 'Yes' players can potentially fail out of a set early.\nIf 'No' players will always be able to play all their songs.
 VisualTheme=Choose the visual icon/emblem for this theme.
 RainbowMode=Turn Rainbow Mode on or off.  Rainbow Mode disables ScreenSelectColor by default.
@@ -471,9 +470,6 @@ ScreenNameEntryMenuTimer=Set the MenuTimer value for ScreenNameEntry
 
 # Advanced Options
 AllowW1=Enable or disable fantastic judgement. NEVER - never show Fantastic.\nCOURSES ONLY - only during course modes. ALWAYS - all modes of play.
-
-# ScreenOptionsTimingWindows
-CustomTimingWindow=
 
 # ScreenPlayerOptions
 JudgmentGraphic=Pick your judgment font.
@@ -505,15 +501,15 @@ PlayerAutoPlay=Toggle AutoPlay.
 Hide=Hide various gameplay elements. [m]
 Persp=Change the notefield perspective.
 Remove=Remove notes [m].
-TargetStatus=Show the Pacemaker Bars or Live Step Statistics  
-TargetBar=Choose the target score for your pacemaker
-GameplayExtras=Toggle the appearance of advanced gameplay helpers.
+TargetStatus=Show the pacemaker graph or step statistics on the side of the playfield.
+TargetBar=Choose the target score for your pacemaker.
+GameplayExtras=Show advanced gameplay helpers and statistics.
 MeasureCounterPosition=Change the x-offset of the measure counter\nto be aligned to the left of the playfield or centered.
-MeasureCounter=Diplay a count of how long you have been streaming a specific type of note.
+MeasureCounter=Display a count of how long you have been streaming a specific type of note.
 DecentsWayOffs=Blame the pad for form errors.
-TimingWindowScale=Shrink the timing window,\nmaking gameplay require more precise accuracy.
+TimingWindowScale=Increase this value to shrink the timing windows, making gameplay require more precise accuracy.\nThis also scales hold and roll timing windows! # Why is this here?
 ScreenAfterPlayerOptions2=Select a different song OR change your modifiers.
-ReceptorArrowsPosition=Change the y-offset of the ReceptorArrows\nto be higher (like in Stomperz) or lower (like in ITG).
+ReceptorArrowsPosition=Change the y-offset of the ReceptorArrows\nto be higher (like in StomperZ) or lower (like in ITG).
 LifeMeterType=Choose "Surround" to emulate Rhythm Horizon's LifeMeter.
 #'
 

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -507,7 +507,6 @@ GameplayExtras=Show advanced gameplay helpers and statistics.
 MeasureCounterPosition=Change the x-offset of the measure counter\nto be aligned to the left of the playfield or centered.
 MeasureCounter=Display a count of how long you have been streaming a specific type of note.
 DecentsWayOffs=Blame the pad for form errors.
-TimingWindowScale=Increase this value to shrink the timing windows, making gameplay require more precise accuracy.\nThis also scales hold and roll timing windows! # Why is this here?
 ScreenAfterPlayerOptions2=Select a different song OR change your modifiers.
 ReceptorArrowsPosition=Change the y-offset of the ReceptorArrows\nto be higher (like in StomperZ) or lower (like in ITG).
 LifeMeterType=Choose "Surround" to emulate Rhythm Horizon's LifeMeter.

--- a/Scripts/SL-Helpers.lua
+++ b/Scripts/SL-Helpers.lua
@@ -23,7 +23,7 @@ end
 -- helper function used to detmerine which timing_window a given offset belongs to
 function DetermineTimingWindow(offset)
 	for i=1,5 do
-		if math.abs(offset) < SL.Preferences[SL.Global.GameMode]["TimingWindowSecondsW"..i] then
+		if math.abs(offset) < SL.Preferences[SL.Global.GameMode]["TimingWindowSecondsW"..i] + SL.Preferences[SL.Global.GameMode]["TimingWindowAdd"] then
 			return i
 		end
 	end

--- a/Scripts/SL_Init.lua
+++ b/Scripts/SL_Init.lua
@@ -136,7 +136,7 @@ SL = {
 	},
 	Preferences = {
 		Casual = {
-			TimingWindowAdd=0.001500,
+			TimingWindowAdd=ThemePrefs.Get("TimingWindowAdd"),
 			RegenComboAfterMiss=0,
 			MaxRegenComboAfterMiss=0,
 			MinTNSToHideNotes="TapNoteScore_W3",
@@ -168,7 +168,7 @@ SL = {
 			TimingWindowSecondsRoll=0.350000,
 		},
 		ECFA = {
-			TimingWindowAdd=0.0015,
+			TimingWindowAdd=0.0015, -- per AIJ ECFA posts
 			RegenComboAfterMiss=5,
 			MaxRegenComboAfterMiss=10,
 			MinTNSToHideNotes="TapNoteScore_W4",


### PR DESCRIPTION
For TWA: it now affects Casual and ECFA (as the TWA setting says in settings).
It also now is properly computed in DetermineTimingWindow.
This should prevent, e.g. FEC but the timing graphs show a stray Great here or there.

en.ini: small spelling checks.