### PR TITLE
Add MenuLeft-MenuRight to Screenshot

### DIFF
--- a/BGAnimations/ScreenEvaluation common/ScreenshotHandler.lua
+++ b/BGAnimations/ScreenEvaluation common/ScreenshotHandler.lua
@@ -24,7 +24,7 @@ if SL.Global.GameMode ~= "Casual" then
 		-- (Using a lua-based InputCallback would also have worked here.)
 		CodeMessageCommand=function(self, params)
 
-			if params.Name == "Screenshot" then
+			if params.Name == "Screenshot1" or params.Name == "Screenshot2" then
 				-- organize Screenshots take using Simply Love into directories, like...
 				-- ./Screenshots/Simply_Love/2015/06-June/2015-06-05_121708.png
 				local prefix = "Simply_Love/" .. Year() .. "/"

--- a/metrics.ini
+++ b/metrics.ini
@@ -1478,8 +1478,9 @@ ShowCreditDisplay=false
 BannerWidth=334
 BannerHeight=132
 
-CodeNames="Screenshot"
-CodeScreenshot="Select"
+CodeNames="Screenshot1,Screenshot2"
+CodeScreenshot1="Select"
+CodeScreenshot2="MenuLeft-MenuRight"
 
 [ScreenEvaluationStage]
 Fallback="ScreenEvaluation"
@@ -1504,7 +1505,7 @@ ShowCreditDisplay=false
 # for exmaple, all W1 values are summed, all W2 values are summed, etc.
 Summary=false
 
-CodeNames="MenuLeft,MenuRight,MenuUp,MenuDown,Left,Right,Up,Down,Screenshot"
+CodeNames="MenuLeft,MenuRight,MenuUp,MenuDown,Left,Right,Up,Down,Screenshot1,Screenshot2"
 CodeMenuLeft="MenuLeft"
 CodeMenuRight="MenuRight"
 CodeMenuUp="MenuUp"
@@ -1513,7 +1514,8 @@ CodeLeft="Left"
 CodeRight="Right"
 CodeUp="Up"
 CodeDown="Down"
-CodeScreenshot=SL.Global.GameMode~="Casual" and "Select" or ""
+CodeScreenshot1=SL.Global.GameMode~="Casual" and "Select" or ""
+CodeScreenshot2=SL.Global.GameMode~="Casual" and "MenuLeft-MenuRight" or ""
 
 
 [RollingNumbersEvaluation]


### PR DESCRIPTION
I have a JCab, so no select/back button for me. I added an additional code to the screenshot call that triggers with "MenuLeft-MenuRight".

Now I was disappointed as there was no way to use `CodeScreenshot="Select" or "MenuLeft-MenuRight"`. Am I missing something about Stepmania's enigine? In addition why do you compare `"Select"` to `""`?

Thanks Dan for all the hard work as usual. 