### PR TITLE
Fix the last measure being missing

### DIFF
--- a/Scripts/SL-ChartParser.lua
+++ b/Scripts/SL-ChartParser.lua
@@ -60,7 +60,7 @@ local function GetSimfileChartString(SimfileString, StepsType, Difficulty, Filet
 			-- Find the chart that matches our difficulty and game type
 			if(chart:match("#STEPSTYPE:"..regexEncode(StepsType)) and chart:match("#DIFFICULTY:"..regexEncode(Difficulty))) then
 				--Find just the notes and remove comments
-				measuresString = chart:match("#NOTES:[\r\n]+([^;]*)\n?$"):gsub("\\[^\r\n]*","")
+				measuresString = chart:match("#NOTES:[\r\n]+([^;]*)\n?$"):gsub("\\[^\r\n]*","") .. ";"
 			end
 		end
 	elseif Filetype == "sm" then
@@ -69,7 +69,7 @@ local function GetSimfileChartString(SimfileString, StepsType, Difficulty, Filet
 		for chart in SimfileString:gmatch("#NOTES[^;]*") do
 			if(chart:match(regexEncode(StepsType)..":") and chart:match(regexEncode(Difficulty)..":")) then
 				-- Find just the notes and remove comments
-				measuresString = chart:match("#NOTES:.*:[\r\n]+(.*)\n?$"):gsub("//[^\r\n]*","")
+				measuresString = chart:match("#NOTES:.*:[\r\n]+(.*)\n?$"):gsub("//[^\r\n]*","") .. ";"
 			end
 		end
 	end


### PR DESCRIPTION
Alright, digging through some changes made in my fork, time to make a good faith effort to upstream them... Let's start with this.

Chart parser code attempts to retrieve all note data *before* semicolon. This is fine, but `getStreamMeasures` expects to hit a comma or a semicolon at the end of the measure, which it won't because last measure won't have a comma and the semicolon is parsed out. This results the last measure being missing.

The fix itself is silly - better way would probably be to check in `getStreamMeasures` whether we are on the last line. Also might want to double check the problem and the fix, especially with .ssc files that I don't have - just wanted to get this out there in *some* form so the issue won't be hidden in my fork :)