### PR TITLE
Fix GetNPSperMeasure if any 0 second measures

### DIFF
--- a/Scripts/SL-ChartParser.lua
+++ b/Scripts/SL-ChartParser.lua
@@ -213,7 +213,11 @@ function GetNPSperMeasure(Song, StepsType, Difficulty)
 		if(line:match("^[,;]%s*")) then
 
 			DurationOfMeasureInSeconds = TimingData:GetElapsedTimeFromBeat((measureCount+1)*4) - TimingData:GetElapsedTimeFromBeat(measureCount*4)
-			NPSforThisMeasure = NotesInThisMeasure/DurationOfMeasureInSeconds
+			if (DurationOfMeasureInSeconds == 0) then
+				NPSforThisMeasure = 0
+			else
+				NPSforThisMeasure = NotesInThisMeasure/DurationOfMeasureInSeconds
+			end
 
 			-- measureCount in SM truly starts at 0, but indexed Lua tables start at 1
 			-- add 1 now to the table behaves and subtract 1 later when drawing the histogram


### PR DESCRIPTION
Sometimes measure length can be 0 seconds (timing gimmick charts, for example). This causes interesting things with NPS calculations since it will be dividing by zero, making the NPS `inf` and breaking the density graph :-)

"AiAe" from ITG WC 2017 Precision Pack is an example of this.

PS. Merry Christmas 🎅 