### PR TITLE
Fix header inconsistency

### DIFF
--- a/Graphics/_header.lua
+++ b/Graphics/_header.lua
@@ -9,7 +9,7 @@ return Def.ActorFrame{
 		Name="HeaderText",
 		Font="_wendy small",
 		Text=ScreenString("HeaderText"),
-		InitCommand=cmd(diffusealpha,0; zoom,0.6; horizalign, left; xy, 10, 14 ),
+		InitCommand=cmd(diffusealpha,0; zoom,WideScale(0.5,0.6); horizalign, left; xy, 10, 15 ),
 		OnCommand=cmd(sleep, 0.1; decelerate,0.33; diffusealpha,1),
 		OffCommand=cmd(accelerate,0.33; diffusealpha,0)
 	}


### PR DESCRIPTION
The leftmost master header (part of most screens) was using values different from "ScreenSelectMusic header.lua". This should be fixed now.

![example](https://user-images.githubusercontent.com/21373281/34920369-3bcdb5b8-f937-11e7-84d0-ae61ae75bbff.png)
