### PR TITLE
Fix hang when preferred style is 1P/Double, the Profile screen is enabled, and 2 profiles are selected.

### DIFF
--- a/Scripts/SL-Branches.lua
+++ b/Scripts/SL-Branches.lua
@@ -42,8 +42,11 @@ end
 Branch.AfterScreenSelectColor = function()
 	local preferred_style = ThemePrefs.Get("AutoStyle")
 	if preferred_style ~= "none" then
-		-- If "versus" ensure that both players are actually considered joined.
-		if preferred_style == "versus" then
+		-- If 2 profiles are selected, ensure the style is versus.
+		-- Otherwise, if "versus" ensure that both players are actually considered joined.
+		if #GAMESTATE:GetEnabledPlayers() == 2 then
+			preferred_style = "versus"
+		elseif preferred_style == "versus" then
 			GAMESTATE:JoinPlayer(PLAYER_1)
 			GAMESTATE:JoinPlayer(PLAYER_2)
 		end


### PR DESCRIPTION
Instead of hanging, force the style to "versus".
Fixes Issue #115 .