### PR TITLE
Sync song highlight animation to BPM, to match behavior of SL 3.95.

### DIFF
--- a/metrics.ini
+++ b/metrics.ini
@@ -1230,9 +1230,9 @@ MusicWheelItemSortOffCommand=decelerate,0.2;zoomy,0
 # Highlight Commands
 HighlightOnCommand=%function(self) \
 	if ThemePrefs.Get("RainbowMode") then \
-		self:diffuseshift():effectcolor1(0.1,0.1,0.1,0.35):effectcolor2(0.8,0.8,0.8,0.35) \
+		self:diffuseshift():effectcolor1(0.8,0.8,0.8,0.35):effectcolor2(0.1,0.1,0.1,0.35):effectclock("beatnooffset"):effectperiod(2) \
 	else \
-		self:diffuseshift():effectcolor1(0.8,0.8,0.8,0.3):effectcolor2(0.8,0.8,0.8,0.05) \
+		self:diffuseshift():effectcolor1(0.8,0.8,0.8,0.3):effectcolor2(0.8,0.8,0.8,0.05):effectclock("beatnooffset"):effectperiod(2) \
 	end \
 end
 HighlightOffCommand=decelerate,0.2;diffusealpha,0


### PR DESCRIPTION
In [hurtpiggypig's SL theme preview](https://www.youtube.com/watch?v=OtcWy5m6-CQ), the song highlight animation is synced to the BPM. See 0:31, 0:34, and 1:00.
This pull request implements this BPM sync behavior for SL-SM5.