### PR TITLE
Typo Fix for CustomSongsMaxSeconds

### DIFF
--- a/Languages/es.ini
+++ b/Languages/es.ini
@@ -532,6 +532,7 @@ HideStockNoteSkins=NoteSkins\nPredeterminados
 ShowGradesInMusicWheel=Mostrar Grados\nEn Rueda
 VisualTheme=Tema Visual
 RainbowMode=Modo Arcoíris
+UseImageCache=Usar ImageCache
 
 # MenuTimer Options
 ScreenSelectMusicMenuTimer=Selección de Música
@@ -671,6 +672,8 @@ CasualMaxMeter=Las dificultades mayores que este serán filtradas del modo Casua
 VisualTheme=Escoge el icono/emblema visual para el tema.
 RainbowMode=Enciende o Apaga el modo arcoíris.\n\nEsto desactivará la pantalla ScreenSelectColor.
 
+UseImageCache=El Modo Casual correrá mucho mejor con el sistema de ImageCache "Encendido", pero StepMania usará MUCHA más RAM en consecuencia. Es recomendable que tengas al menos 8GB de RAM para usar el sistema de ImageCache.\n\nNecesitarás reiniciar StepMania después de cambiar esta opción para que tome efecto.
+
 # USB Profile CustomSongs Options
 CustomSongsEnable=Permite cargar canciones adicionales de perfiles portátiles de USB.\n\nToma en cuenta que debes configurar antes tu Sistema Operativo para montar y reconocer la memoria USB para que esto funcione.\n\nConsulta la Wiki de StepMania para instrucciones en Linux o hackmycab.com para instrucciones en Windows.
 #'
@@ -761,6 +764,8 @@ AllowScreenSelectProfile=Esto debería estar en 'No' para las maquinas publicas.
 AllowDanceSolo=Esto debería estar en 'No' al menos que tengas un tapete de 6 paneles.
 CasualMaxMeter=10 is lo suficiente para las maquinas publicas.
 nice=Esta opción es mejor "Apagada" para las maquinas publicas.
+
+UseImageCache=No hay necesidad de encender esto si nunca utilizas el Modo Casual.
 
 # Appearance Options
 ShowLyrics=Ocultar

--- a/Languages/es.ini
+++ b/Languages/es.ini
@@ -532,7 +532,6 @@ HideStockNoteSkins=NoteSkins\nPredeterminados
 ShowGradesInMusicWheel=Mostrar Grados\nEn Rueda
 VisualTheme=Tema Visual
 RainbowMode=Modo Arcoíris
-UseImageCache=Usar ImageCache
 
 # MenuTimer Options
 ScreenSelectMusicMenuTimer=Selección de Música
@@ -672,8 +671,6 @@ CasualMaxMeter=Las dificultades mayores que este serán filtradas del modo Casua
 VisualTheme=Escoge el icono/emblema visual para el tema.
 RainbowMode=Enciende o Apaga el modo arcoíris.\n\nEsto desactivará la pantalla ScreenSelectColor.
 
-UseImageCache=El Modo Casual correrá mucho mejor con el sistema de ImageCache "Encendido", pero StepMania usará MUCHA más RAM en consecuencia. Es recomendable que tengas al menos 8GB de RAM para usar el sistema de ImageCache.\n\nNecesitarás reiniciar StepMania después de cambiar esta opción para que tome efecto.
-
 # USB Profile CustomSongs Options
 CustomSongsEnable=Permite cargar canciones adicionales de perfiles portátiles de USB.\n\nToma en cuenta que debes configurar antes tu Sistema Operativo para montar y reconocer la memoria USB para que esto funcione.\n\nConsulta la Wiki de StepMania para instrucciones en Linux o hackmycab.com para instrucciones en Windows.
 #'
@@ -765,8 +762,6 @@ AllowDanceSolo=Esto debería estar en 'No' al menos que tengas un tapete de 6 pa
 CasualMaxMeter=10 is lo suficiente para las maquinas publicas.
 nice=Esta opción es mejor "Apagada" para las maquinas publicas.
 
-UseImageCache=No hay necesidad de encender esto si nunca utilizas el Modo Casual.
-
 # Appearance Options
 ShowLyrics=Ocultar
 ShowBanners=Activado
@@ -804,7 +799,7 @@ EasterEggs=On
 # InputOptions
 InputDebounceTime=50ms era el estándar para maquinas de ITG y funciona bien para la mayoria de los tapetes físicos.\n\n0ms es (aparentemente) mejor para el juego en teclado.
 # USB Profile CustomSongs Options
-CustomSongsMaxSeconds=Para máquinas públicas, deberías ajustar esto para que coincida con el corte de 2 rondas en Opciones Avanzadas.\n\nSi una ronda puede durar 2:30, entonces ajusta esto a 150.
+CustomSongsMaxSeconds=Para máquinas públicas, deberías ajustar esto para que coincida con el corte de 2 rondas en Opciones de Arcade.\n\nSi una ronda puede durar 2:30, entonces ajusta esto a 150.
 
 ##############################################
 [MusicWheelSpeed]


### PR DESCRIPTION
After analizing Sora's commit (#121), I found out a small typo in CustomSongsMaxSeconds's recommendation.

`... deberías ajustar esto para que coincida con el corte de 2 rondas en Opciones Avanzadas.`

It has changed back to:

`... deberías ajustar esto para que coincida con el corte de 2 rondas en Opciones de Arcade.`

To match with the actual location of `Long Time`, which is in Arcade Options.