### PR TITLE
Add time bar for pressing START for more options

### DIFF
--- a/BGAnimations/ScreenSelectMusic out.lua
+++ b/BGAnimations/ScreenSelectMusic out.lua
@@ -14,4 +14,34 @@ return Def.ActorFrame{
 		ShowEnteringOptionsCommand=cmd(linear,0.125; diffusealpha,0; queuecommand, "NewText"),
 		NewTextCommand=cmd(hibernate,0.1; settext,THEME:GetString("ScreenSelectMusic", "Entering Options..."); linear,0.125; diffusealpha,1; hurrytweening,0.1; sleep,1)
 	},
+
+	-- my additions (time bar)
+	Def.ActorFrame{
+		InitCommand=function(self)
+			self:y(_screen.cy + 50)
+		end,
+
+		Border(150+4, 25+4, 2)..{
+			OnCommand=function(self)
+				self:CenterX()
+			end
+		},
+
+		Def.Quad{
+			InitCommand=function(self)
+				self:zoomto(150, 25)
+				self:diffuse(color("0,1,0,1"))
+				self:horizalign(left)
+			end,
+
+			OnCommand=function(self)
+				self:x(_screen.cx - 75)
+				self:linear(1.5)
+				self:zoomx(0)
+			end
+		},
+
+		--InitCommand=cmd(zoomx,100;zoomy,25; diffuse,Color.White; CenterX; y,_screen.cy + 40; diffusealpha, 0.5),
+		ShowEnteringOptionsCommand=cmd(linear,0.125; diffusealpha,0)
+	}
 }

--- a/BGAnimations/ScreenSelectMusic out.lua
+++ b/BGAnimations/ScreenSelectMusic out.lua
@@ -15,7 +15,7 @@ return Def.ActorFrame{
 		NewTextCommand=cmd(hibernate,0.1; settext,THEME:GetString("ScreenSelectMusic", "Entering Options..."); linear,0.125; diffusealpha,1; hurrytweening,0.1; sleep,1)
 	},
 
-	-- my additions (time bar)
+	-- Time bar for pressing START for more player options
 	Def.ActorFrame{
 		InitCommand=function(self)
 			self:y(_screen.cy + 50)
@@ -41,7 +41,6 @@ return Def.ActorFrame{
 			end
 		},
 
-		--InitCommand=cmd(zoomx,100;zoomy,25; diffuse,Color.White; CenterX; y,_screen.cy + 40; diffusealpha, 0.5),
 		ShowEnteringOptionsCommand=cmd(linear,0.125; diffusealpha,0)
 	}
 }


### PR DESCRIPTION
This adds a time bar below the text "Press &START for options"
A demo:
![untitled](https://user-images.githubusercontent.com/36245205/45855094-20145880-bd14-11e8-8d76-4ca2367553af.png)