### PR TITLE
fix vertical lifebar on doubles, Center1Player

### DIFF
--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/LifeMeter/Vertical.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/LifeMeter/Vertical.lua
@@ -3,7 +3,13 @@ local player = ...
 local width = 16
 local height = 250
 local _x = width * WideScale(1, 3.5)
-if PREFSMAN:GetPreference("Center1Player") and #GAMESTATE:GetHumanPlayers() == 1 then _x = width * WideScale(10,16) end
+if PREFSMAN:GetPreference("Center1Player") and #GAMESTATE:GetHumanPlayers() == 1 then
+	if SL.Global.Gamestate.Style == "double" then
+		_x = width * WideScale(3, 9)
+	else
+		_x = width * WideScale(10, 16)
+	end
+end
 if player == PLAYER_2 then _x = _screen.w - _x end
 
 


### PR DESCRIPTION
This should fix the lifebar location problem (shown below) if Center1Player is enabled and when you're playing doubles with lifebar on Vertical mode: (assuming aspect ratio range is from 4:3 to 16:9)

![screen shot 2018-10-19 at 2 08 06 am](https://user-images.githubusercontent.com/36245205/47210545-d772ae00-d358-11e8-8475-62151792e179.png)
