### PR TITLE
Update Hash Generating Code to round BPMs to 3 significant places.

### DIFF
--- a/Scripts/SL-HashGenerator.lua
+++ b/Scripts/SL-HashGenerator.lua
@@ -84,11 +84,11 @@ local function MinimizeChart(ChartString)
 	return table.concat(finalChartData, '\n')
 end
 
--- 3.95 usually uses three digits after the decimal point while
--- SM5 uses 6. We normalize everything here to 6. If for some reason
--- there are more than 6, we just remove the trailing ones.
 local function NormalizeFloatDigits(param)
 	-- V1, Deprecated.
+	-- 3.95 usually uses three digits after the decimal point while
+	-- SM5 uses 6. We normalize everything here to 6. If for some reason
+	-- there are more than 6, we just remove the trailing ones.
 	-- local function NormalizeDecimal(decimal)
 	-- 	local int, frac = decimal:match('(.+)%.(.+)')
 	-- 	if frac ~= nil then
@@ -105,6 +105,8 @@ local function NormalizeFloatDigits(param)
 
 	-- V2, uses string.format to round all the decimals to 3 decimal places.
 	local function NormalizeDecimal(decimal)
+		-- Remove any control characters from the string to prevent conversion failures.
+		decimal = decimal:gsub("%c", "")
 		return string.format("%.3f", tonumber(decimal))
 	end
 	local paramParts = {}
@@ -146,7 +148,7 @@ function GenerateHash(stepsType, difficulty)
 			local minimizedChart = MinimizeChart(notes[7])
 			local chartDataAndBpm = minimizedChart .. bpms
 			local hash = sha256(chartDataAndBpm)
-			Trace('Style: ' .. notes[2] .. '\tDifficulty: ' .. notes[4] .. '\tHash: ' .. hash)
+			-- Trace('Style: ' .. notes[2] .. '\tDifficulty: ' .. notes[4] .. '\tHash: ' .. hash)
 			return hash
 		end
 	end

--- a/Scripts/SL-MsdFileParser.lua
+++ b/Scripts/SL-MsdFileParser.lua
@@ -16,32 +16,6 @@
 -- we'll recover.
 
 function ParseMsdFile(SongDir)
-	-- 3.95 usually uses three digits after the decimal point while
-	-- SM5 uses 6. We normalize everything here to 6. If for some reason
-	-- there are more than 6, we just remove the trailing ones.
-	local function NormalizeFloatDigits(param)
-		local function NormalizeDecimal(decimal)
-			local int, frac = decimal:match('(.+)%.(.+)')
-			if frac ~= nil then
-				local zero = '0'
-				if frac:len() <= 6 then
-					frac = frac .. zero:rep(6 - frac:len())
-				else
-					frac = frac:sub(1, 6 - frac:len() - 1)
-				end
-				return int .. '.' .. frac
-			end
-			return decimal
-		end
-
-		local paramParts = {}
-		for beat_bpm in param:gmatch('[^,]+') do
-			beat, bpm = beat_bpm:match('(.+)=(.+)')
-			table.insert(paramParts, NormalizeDecimal(beat) .. '=' .. NormalizeDecimal(bpm))
-		end
-		return table.concat(paramParts, ',')
-	end
-
 	local function AddParam(t, p, plen)
 		-- table.concat(table_name, separator, start, end)
 		local param = table.concat(p, '', 1, plen)
@@ -59,7 +33,7 @@ function ParseMsdFile(SongDir)
 			param = param:gsub(' ', '')
 		elseif((#t[#t] == 1 and t[#t][1] == 'BPMS')) then
 			-- Line endings and spaces don't matter for BPMs, remove them all.
-			param = NormalizeFloatDigits(param:gsub('\n', ''):gsub(' ', ''))
+			param = param:gsub('\n', ''):gsub(' ', '')
 		end
 
 		table.insert(t[#t], param)


### PR DESCRIPTION
3.95 uses 3 decimal places for Beat + BPM while SM5 uses 6. Because of this there were were Hash failures for the same chart since (e.g) 190.730 and 190.729996 are different BPMs.

The solution we implement is to round all the decimals in the BPM string to 3 decimals using the string.formatter.