### PR TITLE
Prevent density graph breaking out of bounds from left

### DIFF
--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/StepStatistics/DensityGraph.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/StepStatistics/DensityGraph.lua
@@ -22,7 +22,7 @@ local scaled_width = width
 -- height is how tall, in pixels, the density graph will be
 local height = width/2.25
 
-local UpdateRate, last_second
+local UpdateRate, first_second, last_second
 
 local af = Def.ActorFrame{
 	InitCommand=function(self)
@@ -94,6 +94,7 @@ local graph_and_lifeline = Def.ActorFrame{
 
 	CurrentSongChangedMessageCommand=function(self)
 		local song = GAMESTATE:GetCurrentSong()
+		first_second = song:GetTimingData():GetElapsedTimeFromBeat(0)
 		last_second = song:GetLastSecond()
 		-- reset scaled_width now to be only as wide as the notefield
 		scaled_width = width
@@ -136,7 +137,7 @@ local graph_and_lifeline = Def.ActorFrame{
 		local seconds_past_one_fourth = current_second-(max_seconds*0.25)
 
 		if seconds_past_one_fourth > 0 then
-			local offset = scale(seconds_past_one_fourth, 0, last_second-(max_seconds*0.25), 0, scaled_width-(width*0.75))
+			local offset = scale(seconds_past_one_fourth, first_second, last_second-(max_seconds*0.25), 0, scaled_width-(width*0.75))
 			self:x(-offset)
 		end
 	end,
@@ -155,7 +156,7 @@ local graph_and_lifeline = Def.ActorFrame{
 		end,
 		UpdateCommand=function(self)
 			if GAMESTATE:GetCurMusicSeconds() > 0 then
-				x = scale( GAMESTATE:GetCurMusicSeconds(), 0, last_second, 0, scaled_width )
+				x = scale( GAMESTATE:GetCurMusicSeconds(), first_second, last_second, 0, scaled_width )
 				y = scale( LifeMeter:GetLife(), 1, 0, 0, height )
 
 				-- if the slopes of the newest line segment is similar

--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/UpperNPSGraph.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/UpperNPSGraph.lua
@@ -17,7 +17,7 @@ if styletype == "OnePlayerTwoSides" or styletype == "TwoPlayersSharedSides" then
 	width = width/2
 end
 
-local song_percent, last_second
+local song_percent, first_second, last_second
 
 return Def.ActorFrame{
 	InitCommand=function(self)
@@ -30,6 +30,7 @@ return Def.ActorFrame{
 	end,
 	-- called at the start of each new song in CourseMode, and once at the start of regular gameplay
 	CurrentSongChangedMessageCommand=function(self)
+		first_second = GAMESTATE:GetCurrentSong():GetTimingData():GetElapsedTimeFromBeat(0)
 		last_second = GAMESTATE:GetCurrentSong():GetLastSecond()
 		self:queuecommand("Size")
 	end,
@@ -60,9 +61,8 @@ return Def.ActorFrame{
 				:queuecommand("Update")
 		end,
 		UpdateCommand=function(self)
-			song_percent = scale( GAMESTATE:GetCurMusicSeconds(), 0, last_second, 0, width )
-			-- song_percent can be negative but we don't want to draw this Quad during that time, so use math.max()
-			self:zoomtowidth( math.max(song_percent, 0) ):sleep(0.25):queuecommand("Update")
+			song_percent = scale( GAMESTATE:GetCurMusicSeconds(), first_second, last_second, 0, width )
+			self:zoomtowidth(clamp(song_percent, 0, width)):sleep(0.25):queuecommand("Update")
 		end,
 		CurrentSongChangedMessageCommand=function(self) self:zoomto(0, height) end
 	}

--- a/Scripts/SL-Histogram.lua
+++ b/Scripts/SL-Histogram.lua
@@ -39,10 +39,7 @@ NPS_Histogram = function(player, _w, _h)
 			if (PeakNPS and NPSperMeasure and #NPSperMeasure > 1) then
 
 				local TimingData = Steps:GetTimingData()
-
-				-- Don't use Song:MusicLengthSeconds() because it includes time
-				-- at the beginning before beat 0 has occurred
-				local FirstSecond =  Song:GetFirstSecond()
+				local FirstSecond = TimingData:GetElapsedTimeFromBeat(0)
 				local LastSecond = Song:GetLastSecond()
 
 				-- magic numbers obtained from Photoshop's Eyedrop tool
@@ -60,7 +57,7 @@ NPS_Histogram = function(player, _w, _h)
 						-- subtract 1 from i now to get the actual measure number to calculate time
 						t = TimingData:GetElapsedTimeFromBeat((i-1)*4)
 
-						x = scale(t,  0, LastSecond, 0, _w)
+						x = scale(t, FirstSecond, LastSecond, 0, _w)
 						y = round(-1 * scale(nps, 0, PeakNPS, 0, _h))
 
 						-- if the height of this measure is the same as the previous two measures


### PR DESCRIPTION
With current `master`, there are some cases where the density graph will break out of it's background from left.

![out-of-boundary-density-graph](https://user-images.githubusercontent.com/1458918/58905592-c6718400-8712-11e9-8320-8eb07fe78914.PNG)

(the picture is pretty dark for some reason, so it's very subtle - but it's there!)

This is because of an incorrect assumption that start of the beat 0 can't be less than 0. This is not true - on the chart in question (*Speed of Light* from *Tachyon Alpha*), the arrows start mid-measure BUT at the beginning of music. My assumption is that, in these cases, the beginning of the measure starts before the beginning of the audio (which I assume would be second 0).

I fixed this by using `GetElapsedTimeFromBeat(0)` instead of hardcoded `0`. It needed to be changed in a few places, because if only fixed in histogram itself, the different overlays would be in a slightly incorrect position.