### PR TITLE
Allow MemoryCard switching in event mode

### DIFF
--- a/BGAnimations/ScreenProfileLoad overlay.lua
+++ b/BGAnimations/ScreenProfileLoad overlay.lua
@@ -1,5 +1,15 @@
 local tweentime = 0.325
 
+if GAMESTATE:IsEventMode() == true then
+	for pn in ivalues( GAMESTATE:GetHumanPlayers() ) do
+		state = MEMCARDMAN:GetCardState(pn)
+		if state == "MemoryCardState_late" or state == "MemoryCardState_error" or state == 'MemoryCardState_removed' then
+			GAMESTATE:UnjoinPlayer(pn)
+			GAMESTATE:JoinPlayer(pn)
+		end
+	end
+end
+
 return Def.ActorFrame{
 	InitCommand=function(self)
 		self:Center():draworder(101)

--- a/BGAnimations/ScreenSelectMusic overlay/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/default.lua
@@ -2,6 +2,7 @@ local t = Def.ActorFrame{
 	ChangeStepsMessageCommand=function(self, params)
 		self:playcommand("StepsHaveChanged", params)
 	end,
+	StorageDevicesChangedMessageCommand=ReloadProfiles,
 
 	-- make the MusicWheel appear to cascade down
 	LoadActor("./MusicWheelAnimation.lua"),

--- a/Scripts/SL-Branches.lua
+++ b/Scripts/SL-Branches.lua
@@ -252,3 +252,14 @@ Branch.AfterProfileSaveSummary = function()
 		return Branch.AfterInit()
 	end
 end
+
+Branch.AfterProfileLoad = function()
+	screen = "ScreenSelectPlayMode"
+
+	if not SL.Global.BranchOverride == nil then
+		screen = SL.Global.BranchOverride
+		SL.Global.BranchOverride = nil
+	end
+
+	return screen
+end

--- a/Scripts/SL-CustomProfiles.lua
+++ b/Scripts/SL-CustomProfiles.lua
@@ -79,6 +79,9 @@ end
 
 -- Hook called during profile save
 function SaveProfileCustom(profile, dir)
+	if GAMESTATE:IsEventMode() == false then
+		return
+	end
 
 	local path =  dir .. filename
 
@@ -106,4 +109,19 @@ function ReadProfileCustom(profile, dir)
 		return IniFile.ReadFile(path)[theme_name]
 	end
 	return false
+end
+
+function ReloadProfiles()
+	change = true
+	for pn in ivalues( GAMESTATE:GetHumanPlayers() ) do
+		state = MEMCARDMAN:GetCardState(pn)
+		if state == "MemoryCardState_late" or state == "MemoryCardState_error" or state == 'MemoryCardState_removed' then
+			change = true
+		end
+	end
+
+	if change == true then
+		SL.Global.BranchOverride = "ScreenSelectMusic"
+		SCREENMAN:SetNewScreen("ScreenProfileLoad")
+	end
 end


### PR DESCRIPTION
This commit allows to change memory loaded cards while on ScreenSelectMusic, with the Padmiss card system this is really nice since players can check in/out as they please while the cab can stay on the menu and still have their scores submitted under their account.

Online scores:
https://app.itgec2019.com/#/scores

Padmiss client:
https://github.com/electromuis/padmiss-daemon

Reference:
https://github.com/stepmania/stepmania/pull/1771