### PR TITLE
Show DensityGraph on ScreenSelectMusic

### DIFF
--- a/BGAnimations/ScreenSelectMusic overlay/PerPlayer/DensityGraph.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/PerPlayer/DensityGraph.lua
@@ -1,0 +1,146 @@
+local player = ...
+local pn = ToEnumShortString(player)
+local p = PlayerNumber:Reverse()[player]
+local show = false
+
+local function getInputHandler(actor)
+    return (function (event)
+        if (event.GameButton == "Up" or event.GameButton == "MenuUp") and event.PlayerNumber == player and GAMESTATE:IsPlayerEnabled(player) then
+            if event.type == "InputEventType_FirstPress" then
+                show = true
+                actor:queuecommand("UpdateGraphState")
+            elseif event.type == "InputEventType_Release" then
+                show = false
+                actor:queuecommand("UpdateGraphState")
+            end
+        end
+
+        return false
+    end)
+end
+
+local bannerWidth = 418
+local bannerHeight = 164
+local padding = 10
+
+local histogramWidth = bannerWidth - (padding * 2)
+local histogramHeight = bannerHeight / 2 - (padding * 1.5)
+local histogram = NPS_Histogram(player, histogramWidth, histogramHeight)
+ 
+-- don't do anything when song changes
+histogram.CurrentSongChangedMessageCommand=nil
+
+return Def.ActorFrame {
+    InitCommand=function(self)
+        local zoom, xPos
+        local yPos = 112
+
+        if IsUsingWideScreen() then
+            zoom = 0.7655
+            xPos = 170
+        else
+            zoom = 0.75
+            xPos = 166
+        end
+        
+        local histogramCenterXPosition = histogramWidth / 2
+        local histogramCenterYPosition = bannerHeight / 2 - padding
+
+        self:zoom(zoom)
+        self:xy(_screen.cx - xPos - histogramCenterXPosition * zoom, yPos - histogramCenterYPosition * zoom)
+
+        if (player == PLAYER_2) then
+            self:addy((histogramHeight + padding) * zoom)
+        end
+
+        self:diffusealpha(0)
+        self:queuecommand("Capture")
+    end,
+
+    CaptureCommand=function(self)
+        SCREENMAN:GetTopScreen():AddInputCallback(getInputHandler(self))
+    end,
+    
+    StepsHaveChangedCommand=function(self, params)
+        if show then
+            self:queuecommand("UpdateGraphState")
+        end
+    end,
+
+    UpdateGraphStateCommand=function(self, params)
+        if show and not GAMESTATE:IsCourseMode() and GAMESTATE:GetCurrentSong() then
+            self:stoptweening()
+            self:linear(0.1):diffusealpha(0.9)
+        else
+            self:stoptweening()
+            self:linear(0.1):diffusealpha(0)
+        end
+    end,
+
+    -- background for whole thing
+    Def.Quad{
+        InitCommand=function(self)
+            self:zoomto(histogramWidth,histogramHeight)
+                :align(0, 0)
+                :diffuse(color("#4D6677"))
+        end
+    },
+
+    histogram..{
+        UpdateGraphStateCommand=function(self)
+            self:y(histogramHeight)
+
+            if show and not GAMESTATE:IsCourseMode() and GAMESTATE:GetCurrentSong() then
+                histogram:Initialize(self)
+            end
+        end
+    },
+
+    -- background for the text
+    Def.Quad {
+        InitCommand=function(self)
+            self:zoomto(histogramWidth, 20)
+                :diffuse(color("#000000"))
+                :diffusealpha(0.8)
+                :align(0, 0)
+                :y(histogramHeight - 20)
+        end,
+    },
+    
+    Def.BitmapText{
+        Font="Common Normal",
+        InitCommand=function(self)
+            self:diffuse(color("#ffffff"))
+                :horizalign("left")
+                :y(histogramHeight - 20 + 2)
+                :x(5)
+                :maxwidth(histogramWidth - 10)
+                :align(0, 0)
+                :Stroke(color("#000000"))
+        end,
+
+        StepsHaveChangedCommand=function(self, params)
+            if show then
+                self:queuecommand("UpdateGraphState")
+            end
+        end,
+
+        UpdateGraphStateCommand=function(self)
+            if show and not GAMESTATE:IsCourseMode() and GAMESTATE:GetCurrentSong() then
+                local song_dir = GAMESTATE:GetCurrentSong():GetSongDir()
+                local steps = GAMESTATE:GetCurrentSteps(player)
+                local steps_type = ToEnumShortString( steps:GetStepsType() ):gsub("_", "-"):lower()
+                local difficulty = ToEnumShortString( steps:GetDifficulty() )
+                local breakdown = GetStreamBreakdown(song_dir, steps_type, difficulty)
+                
+                if breakdown == "" then
+                    self:settext("No streams!")
+                else
+                    self:settext("Streams: " .. breakdown)
+                end
+                
+                return true
+            end
+        end
+    }
+}

--- a/BGAnimations/ScreenSelectMusic overlay/PerPlayer/npsgraph.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/PerPlayer/npsgraph.lua
@@ -1,0 +1,9 @@
+local t = Def.ActorFrame{InitCommand=function(self) self:draworder(1) end}
+
+for player in ivalues({PLAYER_1, PLAYER_2}) do
+        -- npsgraph when up is pressed (so people with no back button can use it)
+	t[#t+1] = LoadActor("./DensityGraph.lua", player)
+end
+
+return t
+

--- a/BGAnimations/ScreenSelectMusic overlay/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/default.lua
@@ -22,6 +22,9 @@ local t = Def.ActorFrame{
 	LoadActor("./StepsDisplayList/default.lua"),
 	-- elements we need two of that draw over the StepsDisplayList (just the bouncing cursors, really)
 	LoadActor("./PerPlayer/Over.lua"),
+        -- and the NPSgraph
+        LoadActor("./PerPlayer/npsgraph.lua"),
+
 
 	-- make the MusicWheel appear to cascade down
 	LoadActor("./MusicWheelAnimation.lua"),

--- a/Scripts/SL-ChartParser.lua
+++ b/Scripts/SL-ChartParser.lua
@@ -303,3 +303,28 @@ function GetStreams(SongDir, StepsType, Difficulty, NotesPerMeasure, MeasureSequ
 	-- Which sequences of measures are considered a stream?
 	return (getStreamSequences(StreamMeasures, MeasureSequenceThreshold, totalMeasures))
 end
+
+
+
+function GetStreamBreakdown(SongDir, StepsType, Difficulty)
+       local NotesPerMeasure = 16
+       local MeasureSequenceThreshold = 2
+       local streams = GetStreams(SongDir, StepsType, Difficulty, NotesPerMeasure, MeasureSequenceThreshold)
+
+       if not streams then
+               return ""
+       end
+
+       local streamLengths = {}
+
+       for i, stream in ipairs(streams) do
+               local streamCount = tostring(stream.streamEnd - stream.streamStart)
+
+               if not stream.isBreak then
+                       streamLengths[#streamLengths + 1] = streamCount
+               end
+       end
+
+       return table.concat(streamLengths, "/")
+end
+


### PR DESCRIPTION
This is a feature that the Finnish fork has had for a long time and I think it would be a nice thing to have here. Pressing Up or MenuUp on screenselectmusic will show the npsgraph for the selected difficulty over the banner with an autogenerated stream breakdown just below it.