### PR TITLE
Utilize math.floor to fix off-by-0.01 errors when displaying Subtactive Scoring

### DIFF
--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/SubtractiveScoring.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/SubtractiveScoring.lua
@@ -110,7 +110,7 @@ return LoadFont("_wendy small")..{
 			local actual_dp = math.max(pss:GetActualDancePoints(), 0)
 
 			local score = current_possible_dp - actual_dp
-			score = ((possible_dp - score) / possible_dp) * 100
+			score = math.floor(((possible_dp - score) / possible_dp) * 10000) / 100
 
 			self:settext("-" .. string.format("%.2f", 100-score) .. "%" )
 		end


### PR DESCRIPTION
%.2f will actually round the number calculated by 100-score (both up and down). This can cause a slight error in the number displayed by the
subtractive scoring as demonstrated here: https://www.youtube.com/watch?v=8267phFvhO8&t=142s

This change fixes that issue which can see here:
https://imgur.com/a/xcYq5IO