### PR TITLE
Add missing Spanish strings

### DIFF
--- a/Languages/es.ini
+++ b/Languages/es.ini
@@ -49,9 +49,10 @@ HeaderText=Seleccionar color
 [ScreenSelectProfile]
 PressStartToJoin=¡Presiona &START; para unirte!
 NoProfile=Sin Perfil
+GuestProfile=[ INVITADO ]
 Card=TARJETA
-
-[ScreenSelectProfile]
+MostRecentSong=Canción Reciente
+MostFrequentGrade=Grado Más Frecuente
 HeaderText=Seleccionar Perfil
 SingularSongPlayed=%d Canción Jugada
 SeveralSongsPlayed=%d Canciones Jugadas
@@ -178,6 +179,7 @@ Combo=Combo
 Lifebar=Vida
 Score=Puntuación
 Danger=Peligro
+ComboExplosions=Explosiones de Combo
 
 # DataVisualizations
 Disabled=Deshabilitado
@@ -212,13 +214,14 @@ Restart=Reiniciar Canción
 # GameplayExtras
 ColumnFlashOnMiss=Brillar Columnas Perdidas
 SubtractiveScoring=Sustraer Puntuación
-Pacemaker=Pacemaker
-MissBecauseHeld=Contador de held misses
-NPSGraphAtTop=Gráfico de densidad en la parte superior
+Pacemaker=Marcapasos
+MissBecauseHeld=Contador de perdidas sostenidas
+NPSGraphAtTop=Gráfico de densidad
 
 # MeasureCounterPosition
 MeasureCounterLeft=Izquierda
 MeasureCounterUp=Arriba
+HideRestCounts=Esconder Descansos
 
 # MeasureCounter
 None=Nada
@@ -238,11 +241,15 @@ Vertical=Vertical
 
 Gameplay=Juego
 Select Music=Seleccionar Música
-Extra Modifiers=Modificadores Adicionales
-Normal Modifiers=Modificadores Normales
+Options1=Modificadores Normales
+Options2=Modificadores Adicionales
+Options3=Modificadores No Comunes
 
 [ScreenPlayerOptions2]
 HeaderText=Seleccionar Modificadores Adicionales
+
+[ScreenPlayerOptions3]
+HeaderText=Seleccionar Modificadores No Comunes
 
 [ScreenGameplay]
 PeakNPS=NPS Tope
@@ -591,17 +598,20 @@ Perspective=Perspectiva
 MusicRate=Vel. de Canción
 BackgroundFilter=Filtro de Pantalla
 JudgmentGraphic=Fuente De Juez
+ComboFont=Fuente de Combo
 
 SpeedModType=Tipo de Velocidad
 SpeedMod=Velocidad
 Mini=Mini
 NoteSkin=NoteSkin
 ScreenAfterPlayerOptions=Siguiente Pantalla
+ScreenAfterPlayerOptions2=Siguiente Pantalla
+ScreenAfterPlayerOptions3=Siguiente Pantalla
 
 # ScreenPlayerOptions2
 DataVisualizations=Visualización de Datos
 TargetScore=Objetivo
-ActionOnMissedTarget=Acción cuando fallas el objetivo
+ActionOnMissedTarget=Acción cuando fallas\nel objetivo
 ScreenAfterPlayerOptions2=Siguiente Pantalla
 Vocalization=Lector de Puntuación
 TimingWindowScale=Escala de Ventana\nde Tiempo
@@ -640,13 +650,15 @@ Clear Credits=Borrar todos los créditos.
 Game=Cambia el modo de juego.\n\n• dance es 4 paneles (DDR y ITG).\n• pump es 5 paneles (Pump It Up).\n• techno es 8 paneles (TechnoMotion).\n\nPara y kb7 no son 100% compatibles en Simply Love pero deberían ser jugables.\n\nbeat, kickbox y luces no funcionarán en Simply Love.
 Announcer=Elige a un comentarista de esta lista de los que tengas instalado.
 Theme=Cambia el look de Stepmania.
-Language=Elige tu idioma.
+Language=Elige tu idioma.\nSimply Love soporta oficialmente:\n\n• Inglés\n• Español\n• Francés\n• Portugés Brasileño (pt-br)\n• Japonés\n• Aleman\n\nOtros idiomas tienen soporte limitado en Simply Love, pero probablemente tienen mayor soporte en otros temas.
 DefaultNoteSkin=Selecciona el NoteSkin predeterminado para el juego.\n\nLos jugadores pueden cambiar esto en las Opciones de Jugador, antes de la partida.
 Editor Noteskin=Selecciona el NoteSkin predeterminado para el editor.
 
 # Graphic / Sound Options
 SmoothLines=Escoge si algunos componentes del tema son renderizados con lineas suaves.\n\nEspecificamente, cualquier tema o simfile que utiliza un ActorMultiVertex en el modo 'LineStrip' será impactado por este ajuste.
 FastNoteRendering=Si es habilitado, el z buffer no será reiniciado despues de cada nota. Esto causa que NoteSkins en 3D colisionen, pero mejora substancialmente el rendimiento durante la partida.
+ShowStats=Muestra estadísticas de rendimiento en la esquina superior derecha de la pantalla y muestra saltos de cuadros en la inferior derecha.\n\nFPS = Cuadros por segundo\nVPF = Vertices por cuadro\n\nUna gran cantidad de VPF indica que el tema está dibujando cosas complejas y requiere mejor hardware (o mejor programación) para mantener un FPS constante.\nEsta función se habilita usando F3+6.
+VisualDelaySeconds=Añade o Sustrae esta cantidad de segundos de latencia visual durante la partida. Esto puede usarse para compensar por una pantalla LCD o una TV con un montón de "lag" o latencia.\n\nSi quieres intentar usar valores con decimales, tendrás que editar el archivo Preferences.ini manualmente.
 
 # Appearance Options
 ShowLyrics=Cambia la visualización de la letra de la canción durante la partida si son disponibles.\n\nLas letras pueden ser añadidas en la canción por medio de un archivo .lrc.
@@ -655,6 +667,7 @@ BGBrightness=Controla que tan brilloso el fondo se mostrará durante la partida.
 RandomBackgroundMode=• Apagado - Solamente muestra el fondo de la canción, nada más.\n\n• Animaciones al Azar - Muestra animaciones al azar provenientes de la carpeta BGAnimations.\n\n• Vídeos aleatorios - Muestra vídeos al azar provenientes de la carpeta de RandomMovies.
 NumBackgrounds=Elige el número de fondos al azar que se mostrarán por canción.\n\nSi Fondos al Azar está en "Apagado", esto no tendrá efecto.
 Center1Player=Enciende esta opción para centrar el area de juego durante la partida si solamente está un jugador activo.
+ShowDancingCharacters=Si tienes bailarines instalados, los jugadores pueden seleccionar uno en la tercera pantalla de Opciones de Jugador en Simply Love.\n\nOtros temas pueden usar "Select" para mostrar una pantalla de selección de personaje, pero Simply Love no hace esto.\n\nSi no tienes bailarines instalados, este ajuste no tendrá efeccto en cualquier tema.
 
 # Arcade Options
 CoinMode=• Casa - Las opciones son mostradas en el Menu Principal.\n\n• Pago - Las opciones del Menu Principal son escondidas; los jugadores deben insertar créditos antes de jugar.\n\n• Partidas gratis - Las opciones del Menu Principal son escondidas; no se requieren créditos para jugar.
@@ -730,6 +743,7 @@ SimplyLoveCredits=Celebra a los que hicieron este tema posible.
 StepMania Credits=Celebra a los que hicieron StepMania posible.
 
 # ScreenPlayerOptions
+ComboFont=Escoge la fuente para contar tu combo. Esta fuente tambien se utilizará para el Medidor de Pasos si está habilitado.
 JudgmentGraphic=Elige tu fuente de Juez preferida.
 Vocalization=Selecciona una voz que dicte tu puntuación.
 
@@ -763,10 +777,12 @@ DataVisualizations=Muestra la grafica de puntuación\no las estadisticas de nota
 TargetScore=Escoge tu objetivo para la grafica de puntuación.
 ActionOnMissedTarget=Acción para realizar cuando la Puntuación objetivo ya no se puede lograr.
 GameplayExtras=Muestra ayuda e información avanzada durante la partida.
+MeasureCounterOptions=Usa esto para cambiar cómo el Contador de Pasos es mostrado. De manera predeterminada es centrada y detrás del gráfico de Juez.
 # MeasureCounterPosition=
 MeasureCounter=Muestra un contador mostrando cuanto has pisado en racha\nen un tipo especifico de notas.
 WorstTimingWindow=Echale la culpa al panel por los errores.
 ScreenAfterPlayerOptions2=Escoge otra canción, O selecciona tus modificadores.
+ScreenAfterPlayerOptions3=Vuelve para escoger otra canción, O selecciona modificadores adicionales.
 ReceptorArrowsPosition=Cambia la posición Y de los receptores\npara ser más alto (como StomperZ) o más bajo (como ITG).
 LifeMeterType=Escoge "Surround" para posicionar el medidor de vida verticalmente atras del area de juego.
 #'
@@ -829,6 +845,7 @@ EasterEggs=On
 InputDebounceTime=50ms era el estándar para maquinas de ITG y funciona bien para la mayoria de los tapetes físicos.\n\n0ms es (aparentemente) mejor para el juego en teclado.
 # USB Profile CustomSongs Options
 CustomSongsMaxSeconds=Para máquinas públicas, deberías ajustar esto para que coincida con el corte de 2 rondas en Opciones de Arcade.\n\nSi una ronda puede durar 2:30, entonces ajusta esto a 150.
+CustomSongsLoadTimeout=El fantasma del pasado de RoXoR deja una lagrima cada vez que una maquina publica usa USB 1.0 para cargar Canciones Personalizadas.\n\nHaz ZiGZaG orgulloso; usa USB 2.0 o mejor.
 
 ##############################################
 [MusicWheelSpeed]

--- a/Languages/es.ini
+++ b/Languages/es.ini
@@ -662,7 +662,7 @@ Editor Noteskin=Selecciona el NoteSkin predeterminado para el editor.
 # Graphic / Sound Options
 SmoothLines=Escoge si algunos componentes del tema son renderizados con lineas suaves.\n\nEspecificamente, cualquier tema o simfile que utiliza un ActorMultiVertex en el modo 'LineStrip' será impactado por este ajuste.
 FastNoteRendering=Si es habilitado, el z buffer no será reiniciado despues de cada nota. Esto causa que NoteSkins en 3D colisionen, pero mejora substancialmente el rendimiento durante la partida.
-ShowStats=Muestra estadísticas de rendimiento en la esquina superior derecha de la pantalla y muestra saltos de cuadros en la inferior derecha.\n\nFPS = Cuadros por segundo\nVPF = Vertices por cuadro\n\nUna gran cantidad de VPF indica que el tema está dibujando cosas complejas y requiere mejor hardware (o mejor programación) para mantener un FPS constante.\nEsta función se habilita usando F3+6.
+ShowStats=Muestra estadísticas de rendimiento en la esquina superior derecha de la pantalla y muestra saltos de cuadros en la inferior derecha.\n\nFPS = Cuadros por segundo\nVPF = Vértices por cuadro\n\nUna gran cantidad de VPF indica que el tema está dibujando cosas complejas y requiere mejor hardware (o mejor programación) para mantener un FPS constante.\nEsta función se habilita usando F3+6.
 VisualDelaySeconds=Añade o Sustrae esta cantidad de segundos de latencia visual durante la partida. Esto puede usarse para compensar por una pantalla LCD o una TV con un montón de "lag" o latencia.\n\nSi quieres intentar usar valores con decimales, tendrás que editar el archivo Preferences.ini manualmente.
 
 # Appearance Options

--- a/Languages/es.ini
+++ b/Languages/es.ini
@@ -144,6 +144,9 @@ Double=Dobles
 Single=Individual
 Versus=Versus
 
+FeelingSalty=¿Sientes Ira?
+TestInput=Probar Botones
+
 [SongDescription]
 Artist=ARTIS.
 BPM=BPM
@@ -280,6 +283,8 @@ Median=mediana
 MeanTimingError=error de tiempo media
 
 QRInstructions=Escanea con tu teléfono para subir este puntaje a tu cuenta de Groovestats.
+TestInput=Probar Botones
+TestInputInstructions=Usa esto para diágnosticar problemas del panel que hayas experimentado durante la partida.
 
 PressStartToContinue=Presiona &START; Para Continuar
 


### PR DESCRIPTION
This adds Spanish strings that never got translated on the 4.8.0 and 4.8.5 release. The PR also fixes strings that cut off the screen, and renamed some as there are better wordings for them.

![Captura de Pantalla 2019-09-12 a la(s) 8 04 48](https://user-images.githubusercontent.com/23246027/64786439-06c37800-d534-11e9-9fc8-94ce4dc87cf9.png)
![Captura de Pantalla 2019-09-12 a la(s) 8 04 07](https://user-images.githubusercontent.com/23246027/64786440-06c37800-d534-11e9-9fab-e5c74b9f1998.png)
![Captura de Pantalla 2019-09-12 a la(s) 8 05 10](https://user-images.githubusercontent.com/23246027/64786450-0d51ef80-d534-11e9-88a5-32b63fad7483.png)
![Captura de Pantalla 2019-09-12 a la(s) 8 08 00](https://user-images.githubusercontent.com/23246027/64786780-daf4c200-d534-11e9-98f9-e6a9859d6c54.png)
![Captura de Pantalla 2019-09-12 a la(s) 8 11 54](https://user-images.githubusercontent.com/23246027/64786842-0081cb80-d535-11e9-9fc9-8c516b4d224f.png)