### PR TITLE
Fix missing a in diffusealpha on TargetScore

### DIFF
--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/TargetScore/default.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/TargetScore/default.lua
@@ -427,7 +427,7 @@ if SL[pn].ActiveModifiers.DataVisualizations == "Target Score Graph" then
 			-- pretty explody things for grade changes
 			LoadActor(THEME:GetPathG("","_VisualStyles/"..ThemePrefs.Get("VisualTheme").."/GameplayIn splode"))..{
 				InitCommand=function(self) self:visible(false):diffusealpha(0) end,
-				GradeChangedCommand=function(self) self:visible(true):y(getYFromGradeEnum(currentGrade)):diffuse(GetCurrentColor()):rotationz(10):diffusealpha(0):zoom(0):diffusealpha(0.9):linear(0.6):rotationz(0):zoom(0.5):diffusealph(0):queucommand("Init") end,
+				GradeChangedCommand=function(self) self:visible(true):y(getYFromGradeEnum(currentGrade)):diffuse(GetCurrentColor()):rotationz(10):diffusealpha(0):zoom(0):diffusealpha(0.9):linear(0.6):rotationz(0):zoom(0.5):diffusealpha(0):queucommand("Init") end,
 			},
 			LoadActor(THEME:GetPathG("","_VisualStyles/"..ThemePrefs.Get("VisualTheme").."/GameplayIn splode"))..{
 				InitCommand=function(self) self:visible(false):diffusealpha(0) end,

--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/TargetScore/default.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/TargetScore/default.lua
@@ -427,15 +427,15 @@ if SL[pn].ActiveModifiers.DataVisualizations == "Target Score Graph" then
 			-- pretty explody things for grade changes
 			LoadActor(THEME:GetPathG("","_VisualStyles/"..ThemePrefs.Get("VisualTheme").."/GameplayIn splode"))..{
 				InitCommand=function(self) self:visible(false):diffusealpha(0) end,
-				GradeChangedCommand=function(self) self:visible(true):y(getYFromGradeEnum(currentGrade)):diffuse(GetCurrentColor()):rotationz(10):diffusealpha(0):zoom(0):diffusealpha(0.9):linear(0.6):rotationz(0):zoom(0.5):diffusealpha(0):queucommand("Init") end,
+				GradeChangedCommand=function(self) self:visible(true):y(getYFromGradeEnum(currentGrade)):diffuse(GetCurrentColor()):rotationz(10):diffusealpha(0):zoom(0):diffusealpha(0.9):linear(0.6):rotationz(0):zoom(0.5):diffusealpha(0):queuecommand("Init") end,
 			},
 			LoadActor(THEME:GetPathG("","_VisualStyles/"..ThemePrefs.Get("VisualTheme").."/GameplayIn splode"))..{
 				InitCommand=function(self) self:visible(false):diffusealpha(0) end,
-				GradeChangedCommand=function(self) self:visible(true):y(getYFromGradeEnum(currentGrade)):diffuse(GetCurrentColor()):rotationy(180):rotationz(-10):diffusealpha(0):zoom(0.2):diffusealpha(0.8):decelerate(0.6):rotationz(0):zoom(0.7):diffusealpha(0):queucommand("Init") end,
+				GradeChangedCommand=function(self) self:visible(true):y(getYFromGradeEnum(currentGrade)):diffuse(GetCurrentColor()):rotationy(180):rotationz(-10):diffusealpha(0):zoom(0.2):diffusealpha(0.8):decelerate(0.6):rotationz(0):zoom(0.7):diffusealpha(0):queuecommand("Init") end,
 			},
 			LoadActor(THEME:GetPathG("","_VisualStyles/"..ThemePrefs.Get("VisualTheme").."/GameplayIn minisplode"))..{
 				InitCommand=function(self) self:visible(false):diffusealpha(0) end,
-				GradeChangedCommand=function(self) self:visible(true):y(getYFromGradeEnum(currentGrade)):diffuse(GetCurrentColor()):rotationz(10):diffusealpha(0):zoom(0):diffusealpha(1):decelerate(0.8):rotationz(0):zoom(0.4):diffusealpha(0):queucommand("Init") end,
+				GradeChangedCommand=function(self) self:visible(true):y(getYFromGradeEnum(currentGrade)):diffuse(GetCurrentColor()):rotationz(10):diffusealpha(0):zoom(0):diffusealpha(1):decelerate(0.8):rotationz(0):zoom(0.4):diffusealpha(0):queuecommand("Init") end,
 			},
 
 			-- white graph border


### PR DESCRIPTION
Incredibly small thing, but breaks heavily.
This bug affected the explosion animation that occurred every time a milestone was reached (such as getting ahead of the target/record or getting to the next grade), and made it stay in place instead of fading back to fully transparent.

EDIT: Turns out there is more misspelled commands, as _`queuecommand`_ is eaten three times.