### PR TITLE
Respect BGBrightness when StepStatistics are on

### DIFF
--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/StepStatistics/SongBackground.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/StepStatistics/SongBackground.lua
@@ -38,6 +38,10 @@ if SL[ToEnumShortString(player)].ActiveModifiers.HideSongBG then
 -- otherwise, load the Song's background into a Sprite and use that to hide the scrolling graph
 else
 	bg = Def.Sprite{
+		OnCommand=function(self)
+			local brightness = PREFSMAN:GetPreference("BGBrightness")
+			self:diffuse(brightness, brightness, brightness, brightness)
+		end,
 		CurrentSongChangedMessageCommand=function(self)
 			-- Background scaling and cropping is handled by the _fallback theme via
 			-- scale_or_crop_background(), which is defined in _fallback/Scripts/02 Actor.lua


### PR DESCRIPTION
Currently the background is displayed at full brightness when the step statistics are on, which can be quite distracting.

It took me quite a while to find the right diffuse value (couple of hours of reading SM source and trying stuff out), but it seems to visually match with what the StepMania BG implementation does. I compared some screenshots with step statistics on and off at different brightness values.

I usually play with HideSongBG, but I noticed that this is wrong, so I wanted to fix it. It wasn't trivial for me, so I thought it might be worth sharing it. ;)
