### PR TITLE
Fix use of undefined variable in GetDisplayBPMs()

### DIFF
--- a/Scripts/SL-BPMDisplayHelpers.lua
+++ b/Scripts/SL-BPMDisplayHelpers.lua
@@ -86,7 +86,7 @@ GetDisplayBPMs = function(player, StepsOrTrail, MusicRate)
 	-- 2. trying to accommodate it themeside is complicated and error-prone
 	-- so get the honest BPM data from the step's TimingData
 	if bpms[1] <= 0 or bpms[2] <= 0 then
-		bpms = song:GetTimingData():GetActualBPM()
+		bpms = StepsOrTrail:GetTimingData():GetActualBPM()
 		-- again, ensure there are 2 values
 		if not bpms[1] or not bpms[2] then return end
 	end


### PR DESCRIPTION
I found errors like this in my SM logs:
```
/////////////////////////////////////////
WARNING: Error playing command:/Themes/Simply-Love-SM5/Scripts/SL-BPMDisplayHelpers.lua:89: attempt to index global 'song' (a nil value)
WARNING: /Themes/Simply-Love-SM5/Scripts/SL-BPMDisplayHelpers.lua:89: GetDisplayBPMs(player = PlayerNumber_P1,StepsOrTrail = (null),MusicRate = 1,bpms = (null),(*temporary) = (null),(*temporary) = (null),(*temporary) = 0,(*temporary) = attempt to index global 'song' (a nil value))
WARNING: /Themes/Simply-Love-SM5/Scripts/SL-BPMDisplayHelpers.lua:116: StringifyDisplayBPMs(player = PlayerNumber_P1,StepsOrTrail = (null),MusicRate = 1)
WARNING: /Themes/Simply-Love-SM5/BGAnimations/ScreenSelectMusic overlay/SongDescription.lua:103: unknown(self = (null))
/////////////////////////////////////////
```

They were caused by the use of an undefined variable in the fallback code that handles negative values in display BPMs. Let's use the correct variable name instead!