### PR TITLE
Improve German translations

### DIFF
--- a/Languages/de.ini
+++ b/Languages/de.ini
@@ -15,7 +15,7 @@ WindowTitle=Simply Love
 
 [ScreenInit]
 ThemeDesign=Theme Design von hurtpiggypig & dbk2
-UnsupportedGame=%s ist im Simply Love nicht spielbar.\nBitte wählen Sie ein anderes Spiel.
+UnsupportedGame=%s ist in Simply Love nicht spielbar.\nBitte wähle ein anderes Spiel.
 
 
 #' Attract Loop
@@ -33,7 +33,7 @@ HeaderText=Lied Highscores - Doppel
 
 [ScreenMemoryCard]
 Top=USB-Karte verwenden
-Bottom=um Noten und Einstellungen zu speichern.
+Bottom=um Ergebnisse und Einstellungen zu speichern.
 
 
 # TitleMenu appears in Home mode
@@ -78,12 +78,12 @@ Regular=Regulär
 Marathon=Marathon
 
 
-CasualDescription=Geniessen Sie Tanzspiele mit\neinem Freund!\n\nGegeneinander spielen order\neinfach nur Spass haben,\ndie Wahl liegt bei Ihen!
-ITGDescription=Spielen Sie ernsthaft mit den\nIn The Groove-Standards.\n\nDie Lebensenergie ist in diesem\nModus aktiviert. Seien Sie also\nvorsichtig,denn sie können\nausfallen!
-FA+Description=Dieser Modus erfordert eine\nhöhere Präzision und Genauigkeit\ndurch engere Zeitfenster.\n\nSie können damit an der jährlichen\nECFA-Veranstaltung teilnehmen.
-StomperZDescription=Testen Sie die experimentellen\n“StomperZ” -Funktionen.\n\nDie Lebensdaueranzeige ist in\ndiesem Modus Aktiviert. Seien\nSie also vorsichtig, da Sie songs\nausfallen können.
-RegularDescription=Wahlen sie ihre Lieder mit\neiner kurzen Pause inzwischen.\n\nDies sind Tanzspiele, wie wir\nsie kennen und lieben!
-MarathonDescription=Spielen Sie eine vorgegebene\nReihe von Songs ohne\nUnterbrechung. \n\nViele Kursen haben Modifikatoren!
+CasualDescription=Geniesse Tanzspiele mit\neinem Freund!\n\nGegeneinander spielen oder\neinfach nur Spass haben,\ndie Wahl liegt bei dir!
+ITGDescription=Spiele ernsthaft mit den\nIn The Groove-Standards.\n\nDie Lebensenergie ist in diesem\nModus aktiviert. Sei also\nvorsichtig, denn du kannst\nausfallen!
+FA+Description=Dieser Modus erfordert eine\nhöhere Präzision und Genauigkeit\ndurch engere Zeitfenster.\n\nDu kannst damit an der jährlichen\nECFA-Veranstaltung teilnehmen.
+StomperZDescription=Teste die experimentellen\n“StomperZ” -Funktionen.\n\nDie Lebensdaueranzeige ist in\ndiesem Modus Aktiviert. Sei\nalso vorsichtig, da du \nausfallen kannst.
+RegularDescription=Wähle deine Lieder mit\neiner kurzen Pause dazwischen.\n\nDas sind Tanzspiele, wie wir\nsie kennen und lieben!
+MarathonDescription=Spiele eine vorgegebene\nReihe von Songs ohne\nUnterbrechung. \n\nViele Kursen haben Modifikatoren!
 
 
 [ScreenSelectStyle]
@@ -122,14 +122,14 @@ FooterTextSongs=Wähl ein andere Lied mit  &MENULEFT;  und &MENURIGHT;          
 FooterTextSingleSong=Wähl ein anderes Lied durch  &SELECT;  Drücken
 FooterTextSingleSong3Key=Wähl ein anderes Lied durch  &MENULEFT; und  &MENURIGHT;  gleichzeitig drucken
 
-NoValidSongs=Es scheint, dass es auf diesem machine keine Lieder gibt die für Casual spiele sind. \n\nBitte erfragen Sie ihren Maschinenbediener nach mehr einfacher Inhalt hinzufügen. \n\nDrucken Sie jetzt &START; um dieses Spiel zu beenden :(
+NoValidSongs=Es scheint, dass es auf dieser Maschine keine Lieder gibt die für Casual geeignet sind. \n\nBitte frage deinen Maschinenbetreiber mehr einfache Inhalte hinzuzufügen. \n\nDrücke jetzt &START; um dieses Spiel zu beenden :(
 
 
 [ScreenSelectMusic]
-Press Start for Options=Drück &START; für optionen
+Press Start for Options=Drücke &START; für Optionen
 
 
-Entering Options...=Optionen aufrufen...
+Entering Options...=Optionen werden aufgerufen...
 Options=Optionen
 
 
@@ -160,7 +160,7 @@ DoubleChallengeMeter=Experte
 
 FeelingSalty=Feeling salty?
 TestInput=Test Input
-TestInputHelpText=Drück &START; um zur Liedauswahl zurückzukehren.
+TestInputHelpText=Drücke &START; um zur Liedauswahl zurückzukehren.
 
 
 SortBy=Sortieren Nach
@@ -242,7 +242,7 @@ Median=medianwert
 MeanTimingError=mittelwert Timing-Fehler
 
 
-QRInstructions=Scannen Sie mit Ihrem Handy, um diesen Score in Ihr GrooveStats-Konto hochzuladen
+QRInstructions=Scanne mit deinem Handy, um diesen Score in dein GrooveStats-Konto hochzuladen
 
 # there are many reasons a score might not be considered valid for GrooveStats ranking
 # these strings are used to help players understand which settings invalidated their score
@@ -323,8 +323,8 @@ HeaderText=Systemoptionen
 
 
 [ScreenPromptToResetPreferencesToStock]
-Paragraph1=Vielen Dank, dass Sie Simply Love verwenden, und noch mehr, dass Sie sich jetzt es nicht mehr verwenden. \n\nSimply Love hat viele Ihrer globalen StepMania-Einstellung (z. B. Timing-Fenster) um das ITG-Verhalten zu simulieren. Möchten Sie diese Einstellung auf ihre Standardwerte zurücksetzen, bevor Sie das Theme wechseln?
-Paragraph2=Wenn Sie “Ja” wählen werden nur die Einstellungen zurückgesetzt, die Simply Love geändert hat. Es werden keine Einstellung geändert, die Sie\n\nselbst geändert haben. Wenn Sie “Nein” wählen, blieben die Einstellung von Simply Love in Ihrem nächsten Thema erhalten.
+Paragraph1=Vielen Dank, dass du Simply Love verwendet hast, und noch mehr, dass du es jetzt nicht mehr verwendest. \n\nSimply Love hat viele deiner globalen StepMania-Einstellung modifiziert (z. B. Timing-Fenster) um das ITG-Verhalten zu simulieren. Möchtest du diese Einstellung auf ihre Standardwerte zurücksetzen, bevor du das Theme wechselst?
+Paragraph2=Wenn du “Ja” wählst werden nur die Einstellungen zurückgesetzt, die Simply Love geändert hat. Es werden keine Einstellung geändert, die du\n\nselbst geändert hast. Wenn du “Nein” wählst, bleiben die Einstellung von Simply Love in deinem nächsten Theme erhalten.
 #'
 Yes=Ja
 YesInfo=mach es wie SM5
@@ -517,7 +517,7 @@ HoldsToRolls=Rollen Halten
 NextRow=&NEXTROW;
 Animations=Zufällige Animationen
 # HACK?
-On (recommended)=Auf
+On (recommended)=An
 Blender=Blender
 Five Key Menu=Aus
 Three Key Menu=An
@@ -526,22 +526,22 @@ Cover=Verstecke HG
 
 [OptionTitles]
 # Top-level Service menu items
-System Options=♥  System Optionen
-Key Joy Mappings=♥  Konfiguriere  Tasten/Joystick-Belegungen
-Profiles=♥  Verwalten Lokal Profile
-Reload Songs=♥  Lieder/Kurse Neuladen
+System Options=♥  System-Optionen
+Key Joy Mappings=♥  Tasten/Joystick-Belegungen konfigurieren
+Profiles=♥  Lokale Profile verwalten
+Reload Songs=♥  Lieder/Kurse neuladen
 Advanced Options=♥  Erweiterte Optionen
-Arcade Options=♥  Arkade Optionen
-Graphics/Sound Options=♥  Grafik/Sound Optionen
-Test Input=♥  Eingabe Prüfen
-Appearance Options=♥  Aussehen Optionen
-Visual Options=♥  Visual Optionen
+Arcade Options=♥  Arcade-Optionen
+Graphics/Sound Options=♥  Grafik/Sound-Optionen
+Test Input=♥  Eingabe testen
+Appearance Options=♥  Erscheinungsbild-Optionen
+Visual Options=♥  Visuelle Optionen
 Overscan Correction=♥  Overscan-Korrektur
 Timing Window Options=♥  Timing-Fenster Optionen
 Theme Options=♥  Simply Love Optionen
-MenuTimer Options=♥  Menü Timer Optionen
-USB Custom Songs Options=♥  USB Custom Songs Options
-Set BG Fit Mode=♥  Hintergrund anpassen
+MenuTimer Options=♥  Menü-Timer Optionen
+USB Custom Songs Options=♥  USB-Lieder Optionen
+Set BG Fit Mode=♥  Hintergrund Anpassen
 Input Options=♥  Eingabe-Optionen
 Acknowledgments=♥  Danksagung
 Clear Credits=♥  Credits Löschen
@@ -565,23 +565,23 @@ ThreeKeyNavigation=Drei Tasten Navigation
 
 # Simply Love Options
 AutoStyle=Bevorzugter Stil
-DefaultGameMode=Standard\nSpiel Modus
+DefaultGameMode=Standard-\nSpielmodus
 AllowFailingOutOfSet=Allow Players\nTo Fail Set
 NumberOfContinuesAllowed=Number Of\nContinues Allowed
 NumberOfCoinsPerCredit=Münzen pro Credit
-AllowScreenSelectProfile=Bildschirm Zulassen\nProfil auswählen
-AllowScreenSelectColor=Bildschirm Zulassen\nFarbe auswahlen
-AllowScreenEvalSummary=Bildschirm Zulassen\nBewertungszusammenfassung
-AllowScreenNameEntry=Bildschirm Zulassen\nNamenseingabe
-AllowScreenGameOver=Bildschirm Zulassen\nGame Over
+AllowScreenSelectProfile=Profilauswahl\nerlauben
+AllowScreenSelectColor=Farbauswahl\nerlauben
+AllowScreenEvalSummary=Bewertungszusammenfassung\nerlauben
+AllowScreenNameEntry=Namenseingabe\nerlauben
+AllowScreenGameOver=Game Over\nerlauben
 MusicWheelStyle=Musikrad-Stil
-AllowDanceSolo=Allow Dance Solo
+AllowDanceSolo=Dance Solo erlauben
 HideStockNoteSkins=Stock NoteSkins
 ShowGradesInMusicWheel=Zeig Noten\nIm Musikrad
 nice=nice
-CasualMaxMeter=Max Schwierigkeit\nIm Casual Modus
-VisualTheme=Theme Stil
-RainbowMode=Regenbogen Modus
+CasualMaxMeter=Max. Schwierigkeit\nim Casual Modus
+VisualTheme=Themen-Stil
+RainbowMode=Regenbogen-Modus
 UseImageCache=ImageCache benutzen
 
 
@@ -595,10 +595,10 @@ ScreenNameEntryMenuTimer=Namenseingabe
 
 
 # USB Profile CustomSongs Options
-CustomSongsMaxCount=Max Lieder pro USB
-CustomSongsLoadTimeout=Max Lieder Ladezeit
-CustomSongsMaxSeconds=Max Lieder Länge
-CustomSongsMaxMegabytes=Max Lieder Dateien Grösse
+CustomSongsMaxCount=Max. Lieder pro USB
+CustomSongsLoadTimeout=Max. Ladezeit
+CustomSongsMaxSeconds=Max. Liedlänge
+CustomSongsMaxMegabytes=Max. Datei-Größe
 
 
 # Advanced Options
@@ -668,16 +668,16 @@ No=Nein
 
 [OptionExplanations]
 # Top-level Service menu items
-System Options=Ändern Sie den Spieltyp, das Thema, die Sprache und noch mehr.
-Arcade Options=Ändern Sie die Optionen für typischen Arcade-Spiele.
-Visual Options=Ändern die Art und Weise, wie Texte, Hintergründe usw. während des Spiels angezeigt werden. Overscan ändern.
-Appearance Options=Ändern die Art und Weise, wie Dinge während des Spiels angezeigt werden (Texte, Hintergründe usw.).
-Theme Options=Ändern die Einstellungen, die nur für dieses Simply Love-Thema gelten
-USB Custom Songs Options=Ändern die Einstellungen für USB-Lieder , einschließlich der Aktivierung oder Deaktivierung der Funktion insgesamt.
-MenuTimer Options=Schalte die MenuTimer ein oder aus und stellen Sie die MenuTimer-Werte für verschiedene Bildschirme ein.
-Input Options=Ändern die Eingabeoptionen an, z. B. Joystick-Automapping, dedizierte Menütasten und Eingabeentprellung.
+System Options=Ändere den Spieltyp, das Thema, die Sprache und noch mehr.
+Arcade Options=Ändere die Optionen für typische Arcade-Spiele.
+Visual Options=Ändere die Art und Weise, wie Texte, Hintergründe usw. während des Spiels angezeigt werden. Overscan ändern.
+Appearance Options=Ändere die Art und Weise, wie Dinge während des Spiels angezeigt werden (Texte, Hintergründe usw.).
+Theme Options=Ändere die Einstellungen, die nur für dieses Simply Love-Thema gelten
+USB Custom Songs Options=Ändere die Einstellungen für USB-Lieder, einschließlich der Aktivierung oder Deaktivierung der Funktion insgesamt.
+MenuTimer Options=Schalte den Menü-Timer ein oder aus und stelle die MenuTimer-Werte für verschiedene Bildschirme ein.
+Input Options=Ändere die Eingabeoptionen an, z. B. automatische Joystick-Belegung, dedizierte Menütasten und Eingabeentprellung.
 Acknowledgments=Danksagungen und Credits für Simply Love, StepMania und mehr anzeigen.
-Clear Credits=Credits auf 0 zurucksetzen.
+Clear Credits=Credits auf 0 zurücksetzen.
 
 
 
@@ -686,9 +686,9 @@ Clear Credits=Credits auf 0 zurucksetzen.
 Game=Ändere den aktuellen Spieltyp.\n\n• dance ist 4-Panel (DDR und ITG).\n• pump ist 5-Panel (Pump It Up).\n• techno ist 8-Panel (TechnoMotion).\n\npara und kb7 werden in Simply Love nicht zu 100% unterstützt, sollten aber spielbar sein.\n\nbeat, kickbox, und lights sind im Simply Love nicht spielbar.
 Theme=Ändern das Aussehen und Gefühl von StepMania. \n\nThemen erweitern die Basisfunktionalität von SM5 häufig auf einzigartige Weise
 Language=Wähle deine Sprache.\n\nSimply Love unterstützt:\n\n• English\n• Español\n• Français\n• Português Brasileiro (pt-br)\n• 日本語\n • Deutsch\n\nAndere Sprachen werden in Simply Love nur wenig unterstützt, in anderen Themen jedoch möglicherweise besser.
-Announcer=Wählen Sie aus dieser Liste der installierten Pakete einen Gameplay-Ansager aus.
-DefaultNoteSkin=Wählen Sie die Standardnotenskin, die beim Spielen verwendet werden soll.\n\nDiese Einstellung kann von den Spielern vor dem Spielen im Menü "Player Options" geändert werden.
-Editor Noteskin=Wählen Sie die Standardnotenskin für Bearbeitungsmodus.
+Announcer=Wähle aus dieser Liste der installierten Pakete einen Gameplay-Ansager aus.
+DefaultNoteSkin=Wähle den Standardnotenskin, der beim Spielen verwendet werden soll.\n\nDiese Einstellung kann von den Spielern vor dem Spielen im Menü "Player Options" geändert werden.
+Editor Noteskin=Wähle den Standardnotenskin für den Bearbeitungsmodus.
 
 
 # Visual Options
@@ -753,7 +753,7 @@ AllowDanceSolo=Set this to 'Yes' if you want to enable Solo as a selectable opti
 HideStockNoteSkins=Set this to 'Hide' if you want to hide all NoteSkins that come with SM5 from the modifier menu.
 
 
-nice=Diese Einstellung sucht nach der nummer “69” auf dem Evaluierung Bildschirm und zeigt dass sie “nice” sind 👌
+nice=Diese Einstellung sucht nach der Nummer “69” auf dem Evaluierungs-Bildschirm und zeigt dass sie “nice” sind 👌
 
 
 
@@ -795,8 +795,8 @@ EasterEggs=Enable or disable some secret surprises a theme author may or may not
 
 
 # Acknowledgments Menu
-StepMania Credits=Feiern Sie die Leute, die StepMania möglich gemacht haben.
-SimplyLoveCredits=Feiern Sie die Leute, dieses Thema möglich gemacht haben.
+StepMania Credits=Feiere die Leute, die StepMania möglich gemacht haben.
+SimplyLoveCredits=Feiere die Leute, die dieses Thema möglich gemacht haben.
 RabbitHole=Alice was beginning to get very tired of sitting by her sister on the bank and of having nothing to do.
 
 
@@ -871,7 +871,7 @@ AllowScreenSelectProfile=This should be 'No' for public machines.
 AllowDanceSolo=This should be 'No' unless you have a 6-panel dance pad.
 CasualMaxMeter=10 is about right for most public machines.
 nice=This is probably best left 'Off' for public machines.
-UseImageCache=Sie müssen dies nicht aktivieren, wenn Sie den Casual-Modus nicht verwenden.
+UseImageCache=Du musst dies nicht aktivieren, wenn du den Casual-Modus nicht verwendest.
 
 
 # Appearance Options
@@ -895,10 +895,10 @@ FailOffInBeginner=You'll want this 'Off' if you intend to attempt Tachyon Epsilo
 LockCourseDifficulties=Aus
 MaxHighScoresPerListForMachine=10
 MaxHighScoresPerListForPlayer=3
-Premium=Doppelspieler werden Sie lieben, wenn Sie mindestens ‘Double for 1 Credit’ aktivieren.
+Premium=Doppelspieler werden dich lieben, wenn du mindestens ‘Double for 1 Credit’ aktivierst.
 # Advanced Options
 AllowW1=Immer
-PercentageScoring=Stellen Sie es einfach auf “An”. Ich verstehe es auch nicht.\n(ノ°□°)ノ  ┻━┻
+PercentageScoring=Stelle es einfach auf “An”. Ich verstehe es auch nicht.\n(ノ°□°)ノ  ┻━┻
 #'
 AutogenSteps=Aus
 DefaultFailType=ImmediateContinue
@@ -912,8 +912,8 @@ EasterEggs=An
 # InputOptions
 InputDebounceTime=50ms waren Standard für ITG-Dedicabs und funktioniert gut genug für die meisten physischen Dance-Pads.\n\n0ms ist (vermutlich) besser für das Keyboardspiel
 # USB Profile CustomSongs Options
-CustomSongsLoadTimeout=Der Geist von Roxor weint jedesmals ein offentliche Machine benutzt USB 1.0 um Custom Lieder zu laden.\n\nMach ZiGZaG stolz, nutz USB 2.0 order neuer.
-CustomSongsMaxSeconds=Für öffentliche Maschinen sollten Sie dies so einstellen, dass es dem 2-Runden-Cutoff unter Arcade-Optionen entspricht.\n\nWenn ein 1-Runden-Song 2:30 sein kann, sollten Sie dies auf 2:30 einstellen.
+CustomSongsLoadTimeout=Der Geist von Roxor weint jedesmals wenn eine öffentliche Maschine USB 1.0 benutzt um Custom Lieder zu laden.\n\nMach ZiGZaG stolz, nutze USB 2.0 oder neuer.
+CustomSongsMaxSeconds=Für öffentliche Maschinen solltest du es so einstellen, dass es dem 2-Runden-Cutoff unter Arcade-Optionen entspricht.\n\nWenn ein 1-Runden-Lied 2:30 sein kann, solltest du dies auf 2:30 einstellen.
 
 
 ##############################################


### PR DESCRIPTION
- Use "du" instead of the formal "Sie". It seems more appropriate for a
dancing game.
- Change some option menu translations to be more idiomatic. A lot of
menu options and descriptions that are part of SM and not Simply Love
are not translated yet at all, but this is a start.
- Fix a few typos.