### PR TITLE
SL-Histogram.lua no longer needs the SL table

### DIFF
--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/UpperNPSGraph.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/UpperNPSGraph.lua
@@ -44,8 +44,8 @@ return Def.ActorFrame{
 			self:zoomtoheight(1)
 
 			if #GAMESTATE:GetHumanPlayers()==2 and SL.P1.ActiveModifiers.NPSGraphAtTop and SL.P2.ActiveModifiers.NPSGraphAtTop then
-				local my_peak = SL[pn].NoteDensity.Peak
-				local their_peak = SL[ToEnumShortString(OtherPlayer[player])].NoteDensity.Peak
+				local my_peak = GAMESTATE:Env()[pn.."PeakNPS"]
+				local their_peak = GAMESTATE:Env()[ToEnumShortString(OtherPlayer[player]).."PeakNPS"]
 
 				if my_peak < their_peak then
 					self:zoomtoheight(my_peak/their_peak)

--- a/Scripts/SL-Histogram.lua
+++ b/Scripts/SL-Histogram.lua
@@ -15,13 +15,10 @@ local function gen_vertices(player, width, height)
 	-- broadcast this for any other actors on the current screen that rely on knowing the peak nps
 	MESSAGEMAN:Broadcast("PeakNPSUpdated", {PeakNPS=PeakNPS})
 
-	-- also, store the PeakNPS in SL[pn] in case both players are joined
+	-- also, store the PeakNPS in GAMESTATE:Env()[pn.."PeakNPS"] in case both players are joined
 	-- their charts may have different peak densities, and if they both want histograms,
 	-- we'll need to be able to compare densities and scale one of the graphs vertically
-	SL[ToEnumShortString(player)].NoteDensity.Peak = PeakNPS
-
-	-- FIXME: come up with a way to do this^ that doesn't rely on the SL table so other
-	-- themes can use this NPS_Histogram function more easily
+	GAMESTATE:Env()[ToEnumShortString(player).."PeakNPS"] = PeakNPS
 
 	local verts = {}
 	local x, y, t

--- a/Scripts/SL_Init.lua
+++ b/Scripts/SL_Init.lua
@@ -41,9 +41,6 @@ local PlayerDefaults = {
 				Difficulty = nil,
 				Measures = nil,
 			}
-			self.NoteDensity = {
-				Peak = nil
-			}
 			self.HighScores = {
 				EnteringName = false,
 				Name = ""


### PR DESCRIPTION
The PeakNPS values for each player are now stored in GAMESTATE:Env() so now it's easier to use the nps histogram in other themes