### PR TITLE
Fix BPM display in the player options screen for a single player

### DIFF
--- a/BGAnimations/ScreenPlayerOptions overlay/default.lua
+++ b/BGAnimations/ScreenPlayerOptions overlay/default.lua
@@ -147,7 +147,7 @@ local t = Def.ActorFrame{
 				table.insert(bpms, StringifyDisplayBPMs(player))
 			end
 
-			local text = ""
+			local text = StringifyDisplayBPMs()
 			if #bpms == 2 then
 				if bpms[1] == bpms[2] then
 					text = bpms[1]


### PR DESCRIPTION
0b39322d45be3f93d44b46832f8cd80fe6dd72a3 fixed the display for split BPM with two players but broke the single player case.

![Screenshot from 2020-03-28 16 06 20](https://user-images.githubusercontent.com/27127/77826180-25731000-710e-11ea-814c-ea62188d7d3c.png)
