### PR TITLE
autostyle when starting as p2 unjoins the only player

### DIFF
--- a/Scripts/SL-Branches.lua
+++ b/Scripts/SL-Branches.lua
@@ -46,7 +46,7 @@ Branch.AfterScreenSelectColor = function()
 		-- (for whatever reason), we're in a bit of a pickle, as there is
 		-- no way to read the player's mind and know which side they really
 		-- want to play on. Unjoin PLAYER_2 for lack of a better solution.
-		elseif preferred_style == "single" then
+		elseif preferred_style == "single" and GAMESTATE:GetNumSidesJoined() == 2 then
 			GAMESTATE:UnjoinPlayer(PLAYER_2)
 		end
 


### PR DESCRIPTION
Currently if you start the game as P2 (and P1 not joined) with autostyle set to single, the branch will unjoin you and then proceed to ScreenSelectPlayMode with no players so some errors are thrown. Looking at the comments, it looks like it's only supposed to unjoin if two people are playing so i just added that in to the if statement.