### PR TITLE
Fix handling of the Immediate fail type

### DIFF
--- a/Scripts/SL-Helpers.lua
+++ b/Scripts/SL-Helpers.lua
@@ -472,7 +472,7 @@ GetDefaultFailType = function()
 		end
 	end
 
-	return fail_strings[default_fail] or "FailType_ImmediateContinue"
+	return fail_strings[default_fail] or "FailType_Immediate"
 end
 
 -- -----------------------------------------------------------------------


### PR DESCRIPTION
Since 2154b72c6170175c9bcfe381318720daf8a4ec29 the fail type is forced to ImmediateContinue when Immediate is selected in the settings. The reason is that when you select Immediate in the settings no fail type modifier is added to DefaultModifiers. `GetDefaultFailType()` treats the absence of a fail type in DefaultModifiers as ImmediateContinue, but before that commit it was treated as Immediate.

Let's restore the previous behaviour.