### PR TITLE
 Validate the current theme's prefs, which depends on the folder name

### DIFF
--- a/Scripts/99 SL-ThemePrefs.lua
+++ b/Scripts/99 SL-ThemePrefs.lua
@@ -206,10 +206,11 @@ SL_CustomPrefs.Validate = function()
 	local file = IniFile.ReadFile("Save/ThemePrefs.ini")
 	local sl_prefs = SL_CustomPrefs.Get()
 
-	-- If a [Simply Love] section is found in ./Save/ThemePrefs.ini
-	if file["Simply Love"] then
+	-- If a section for this theme is found in ./Save/ThemePrefs.ini
+	local theme_name = THEME:GetCurThemeName()
+	if file[theme_name] then
 		-- loop through key/value pairs retrieved and do some basic validation
-		for k,v in pairs( file["Simply Love"] ) do
+		for k,v in pairs( file[theme_name] ) do
 			if sl_prefs[k] then
 				-- if we reach here, the setting exists in both the master definition as well as the user's ThemePrefs.ini
 				-- so perform some rudimentary validation; check for both type mismatch and presence in sl_prefs


### PR DESCRIPTION
The current code always validates the "Simply Love" section, while the actual section used by the theme depends on the folder in which it resides. This is indeed "Simply Love" when unzipping from the provided releases but can be different if the folder was renamed or if another method was used to get it. For example, the default folder name if you check out the theme from Git is "Simply-Love-SM5".