### PR TITLE
Add Menu Up+Down as valid option for closing folder

### DIFF
--- a/metrics.ini
+++ b/metrics.ini
@@ -1634,7 +1634,7 @@ NextSort1=""
 NextSort2=""
 NextSort3=""
 NextSort4=""
-CloseCurrentFolder="Up-Down"
+CloseCurrentFolder=PREFSMAN:GetPreference("OnlyDedicatedMenuButtons") and "MenuLeft-MenuRight" or "Up-Down"
 
 # This code can be used to navigate the player to whatever PrevScreen evaluates to
 # for the current screen. It's a bit too broad to be useful.  Backing out of SelectMusic

--- a/metrics.ini
+++ b/metrics.ini
@@ -1634,7 +1634,7 @@ NextSort1=""
 NextSort2=""
 NextSort3=""
 NextSort4=""
-CloseCurrentFolder=PREFSMAN:GetPreference("OnlyDedicatedMenuButtons") and "MenuLeft-MenuRight" or "Up-Down"
+CloseCurrentFolder="MenuUp-MenuDown" or "Up-Down"
 
 # This code can be used to navigate the player to whatever PrevScreen evaluates to
 # for the current screen. It's a bit too broad to be useful.  Backing out of SelectMusic


### PR DESCRIPTION
When using dedicated menu buttons, MenuUp-MenuDown doesn't close folder. Unsure if this was intended behavior

Can add gamemode/three-button/dedicated-menu-button checks if needed, but I'm not sure which combination of such should be considered valid