### PR TITLE
Show personal best if the song was failed and never passed before

### DIFF
--- a/BGAnimations/ScreenEvaluation common/Panes/Pane3/default.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane3/default.lua
@@ -29,15 +29,15 @@ local MachineHighScores = PROFILEMAN:GetMachineProfile():GetHighScoreList(SongOr
 local EarnedMachineHighScoreInEventMode = function()
 	-- if no DancePoints were earned, it's not a HighScore
 	if pss:GetPercentDancePoints() <= 0.01 then return false end
-	-- if DancePoints were earned, and no MachineHighScores exist, it's a HighScore
-	if #MachineHighScores < 1 then return true end
+	-- if DancePoints were earned, but no MachineHighScores exist at this point, it's a fail which was not considered a HighScore
+	if #MachineHighScores < 1 then return false end
 	-- otherwise, check if this score is better than the worst current HighScore retrieved from MachineProfile
 	return pss:GetHighScore():GetPercentDP() >= MachineHighScores[math.min(NumHighScores, #MachineHighScores)]:GetPercentDP()
 end
 
 -- -----------------------------------------------------------------------
 
-local EarnedMachineRecord = GAMESTATE:IsEventMode() and HighScoreIndex.Machine  >= 0 or EarnedMachineHighScoreInEventMode()
+local EarnedMachineRecord = GAMESTATE:IsEventMode() and EarnedMachineHighScoreInEventMode() or HighScoreIndex.Machine  >= 0
 local EarnedTop2Personal  = (HighScoreIndex.Personal >= 0 and HighScoreIndex.Personal < 2)
 
 -- -----------------------------------------------------------------------


### PR DESCRIPTION
The check for 0 machine high scores should evaluate to not having earned a high score. If the first high score was indeed earned, the value will be 1 at this point. If a player earned DP but the number of machine high scores is 0, the song was failed.

Also flip the condition that evaluated to using EarnedMachineHighScoreInEventMode() regardless of being in the EventMode or not.

Tested on Stepmania 5.0.12
See comments on eb1f6d65b558f50c61327857183f48dde765c7c2 for context.