### PR TITLE
TargetScore/Setup.lua - Bugfix TargetScoreGraph and ActionOnMissedTarget - Personal and Machine scores always fallback to 'S' target

### DIFF
--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/TargetScore/Setup.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/TargetScore/Setup.lua
@@ -107,11 +107,11 @@ local target_grade_score = 0
 
 if (target_grade_index == 17) then
 	-- player set TargetGrade as Machine best
-	target_grade_score = GetTopScore(player, "Machine")
+	target_grade_score = GetTopScore("Machine")
 
 elseif (target_grade_index == 18) then
 	-- player set TargetGrade as Personal best
-	target_grade_score = GetTopScore(player, "Personal")
+	target_grade_score = GetTopScore("Personal")
 else
 	-- player set TargetGrade as a particular letter grade
 	-- anything from C- to ☆☆☆☆


### PR DESCRIPTION
Removed passing the 'player' variable to function GetTopScore. The variable is already globally and used in the mentioned function.
On the contrary, this causes the non-retrive of the Machine or Personal score and this causes that target_grade_score is always 0 and fallback to 'S' as target, even if exist saved scores.
Tested on Stepmania 5.0.12, Simply Love (4.9.1) beta branch.