### PR TITLE
Fixing bug where PeakNPS lags behind by one song

### DIFF
--- a/Scripts/SL-Histogram.lua
+++ b/Scripts/SL-Histogram.lua
@@ -12,13 +12,14 @@ local function gen_vertices(player, width, height)
 	end
 
 	local PeakNPS, NPSperMeasure = GetNPSperMeasure(Song, Steps)
-	-- broadcast this for any other actors on the current screen that rely on knowing the peak nps
-	MESSAGEMAN:Broadcast("PeakNPSUpdated", {PeakNPS=PeakNPS})
 
-	-- also, store the PeakNPS in GAMESTATE:Env()[pn.."PeakNPS"] in case both players are joined
+	-- store the PeakNPS in GAMESTATE:Env()[pn.."PeakNPS"] in case both players are joined
 	-- their charts may have different peak densities, and if they both want histograms,
 	-- we'll need to be able to compare densities and scale one of the graphs vertically
 	GAMESTATE:Env()[ToEnumShortString(player).."PeakNPS"] = PeakNPS
+	
+	-- broadcast this for any other actors on the current screen that rely on knowing the peak nps
+	MESSAGEMAN:Broadcast("PeakNPSUpdated", {PeakNPS=PeakNPS})
 
 	local verts = {}
 	local x, y, t


### PR DESCRIPTION
This PR resolves a bug where the Peak NPS statistic lags behind by one song if the first song played did not have step statistics enabled (but the subsequent songs do). 

Steps to reproduce:
1) Start stepmania
2) Play any song (just use the default settings)
3) Start a new song (preferably one with a much higher nps count) and turn on step statistics
    - Observe that Peak NPS is absent
4) Start another new song (with a much lower nps count) and keep step statistics on
    - Observe that Peak NPS is very high
5) Repeat 3) and 4) and notice that the Peak NPS corresponds to the previous song each time

Here are some images demonstrating it: [album](https://photos.app.goo.gl/JgUsJ41AFGMc8LF48). The first image is after a song without step statistics was played. Note that Peak NPS is not shown. The next image is a level 1, yet has 10.87 Peak NPS, in line with the previous song. 

The bug is resolved by broadcasting Peak NPS after updating `GAMESTATE:Env()`.

Note: I am not a lua expert and this is my first PR to this project. Corrections are greatly appreciated. Thanks for the nice project.