### PR TITLE
Write score files for consumption by simply.training

### DIFF
--- a/BGAnimations/ScreenEvaluation common/default.lua
+++ b/BGAnimations/ScreenEvaluation common/default.lua
@@ -1,6 +1,10 @@
 local Players = GAMESTATE:GetHumanPlayers()
 local NumPanes = SL.Global.GameMode=="Casual" and 1 or 6
 
+if ThemePrefs.Get("WriteCustomScores") then
+	WriteScores()
+end
+
 local t = Def.ActorFrame{}
 
 if SL.Global.GameMode ~= "Casual" then

--- a/Languages/de.ini
+++ b/Languages/de.ini
@@ -574,6 +574,7 @@ nice=nice
 CasualMaxMeter=Max. Schwierigkeit\nim Casual Modus
 VisualStyle=Themen-Stil
 RainbowMode=Regenbogen-Modus
+WriteCustomScores=Ergebnisse speichern
 UseImageCache=ImageCache benutzen
 
 
@@ -754,6 +755,7 @@ ShowGradesInMusicWheel=Show or hide letter grades for each song you've played wi
 CasualMaxMeter=Charts harder than this will be filtered out of Casual Mode.
 VisualStyle=Choose the visual icon/emblem for this theme.\n\nEach visual style within Simply Love has unique graphics and background music.
 RainbowMode=Regenbogen-Modus ein oder ausschalten.\n\nRegenbogen-Modus deaktiviert standardmäßig ScreenSelectColor.
+WriteCustomScores=Diese Einstellung aktiviert die Speicherung von erweiterten Ergebnis-Dateien. Sie werden in deinem Profilordner abgelegt. Für Gastnutzer werden keine Ergebnisse gespeichert.\n\nDie Ergebnis-Dateien können auf der simply.training Webseite hochgeladen werden um deinen Fortschritt zu verfolgen.
 UseImageCache=Casual Mode will run more smoothly with the ImageCache system on, but StepMania will use a LOT more RAM as a consequence. It is recommended that you have at least 8GB of RAM to use the ImageCache system.\n\nYou will need to restart StepMania after turning this setting on for it to take effect.
 
 
@@ -860,6 +862,7 @@ AllowScreenSelectProfile=This should be 'No' for public machines.
 AllowDanceSolo=This should be 'No' unless you have a 6-panel dance pad.
 CasualMaxMeter=10 is about right for most public machines.
 nice=This is probably best left 'Off' for public machines.
+WriteCustomScores='Ja', wenn du die simply.training Webseite benutzen möchtest.
 UseImageCache=Du musst dies nicht aktivieren, wenn du den Casual-Modus nicht verwendest.
 
 

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -564,6 +564,7 @@ nice=nice
 CasualMaxMeter=Max Difficulty\nIn Casual Mode
 VisualStyle=Visual Style
 RainbowMode=Rainbow Mode
+WriteCustomScores=Write Custom Scores
 UseImageCache=Use ImageCache
 
 # MenuTimer Options
@@ -743,6 +744,7 @@ ShowGradesInMusicWheel=Show or hide letter grades for each song you've played wi
 CasualMaxMeter=Charts harder than this will be filtered out of Casual Mode.
 VisualStyle=Choose the visual icon/emblem for this theme.\n\nEach visual style within Simply Love has unique graphics and background music.
 RainbowMode=Turn Rainbow Mode on or off.\n\nRainbow Mode disables ScreenSelectColor by default.
+WriteCustomScores=This setting will enable the writing of custom scores files. They are stored in your profile directory. Scores are not stored for guest accounts.\n\nCustom score files can be uploaded to the simply.training website to track your personal progress.
 UseImageCache=Casual Mode will run more smoothly with the ImageCache system on, but StepMania will use a LOT more RAM as a consequence. It is recommended that you have at least 8GB of RAM to use the ImageCache system.\n\nYou will need to restart StepMania after turning this setting on for it to take effect.
 
 # USB MemoryCard Options
@@ -843,6 +845,7 @@ AllowScreenSelectProfile=This should be 'No' for public machines.
 AllowDanceSolo=This should be 'No' unless you have a 6-panel dance pad.
 CasualMaxMeter=10 is about right for most public machines.
 nice=This is probably best left 'Off' for public machines.
+WriteCustomScores=Set to 'Yes' if you intend to use the simply.training website.
 UseImageCache=There is no need to turn this on if you never use Casual Mode.
 
 # Appearance Options

--- a/Scripts/99 SL-ThemePrefs.lua
+++ b/Scripts/99 SL-ThemePrefs.lua
@@ -85,6 +85,11 @@ SL_CustomPrefs.Get = function()
 			},
 			Values = { true , false }
 		},
+		WriteCustomScores = {
+			Default = false,
+			Choices =  { THEME:GetString("ThemePrefs","Yes"), THEME:GetString("ThemePrefs", "No") },
+			Values	= { true, false }
+		},
 		-- - - - - - - - - - - - - - - - - - - -
 		-- SimplyLoveColor saves the theme color for the next time
 		-- the StepMania application is started.

--- a/Scripts/SL-CustomScores.lua
+++ b/Scripts/SL-CustomScores.lua
@@ -1,0 +1,178 @@
+function nilIfEmpty(s)
+	if s == "" then
+		return nil
+	end
+	return s
+end
+
+function WriteScores()
+	local template = {
+		Version = 1,
+		Theme = 'Simply Love',
+		ThemeVersion = GetThemeVersion(),
+		ProductID = ProductID(),
+		ProductVersion = ProductVersion(),
+		MachineGuid = PROFILEMAN:GetMachineProfile():GetGUID(),
+		GameMode = SL.Global.GameMode,
+	}
+
+	for player in ivalues(GAMESTATE:GetHumanPlayers()) do
+		local content = {}
+		for k, v in pairs(template) do
+			content[k] = v
+		end
+
+		local pss = STATSMAN:GetCurStageStats():GetPlayerStageStats(player)
+		local highscore = pss:GetHighScore()
+		local actualRadar = pss:GetRadarActual()
+		local possibleRadar = pss:GetRadarPossible()
+
+		content.Score = {
+			Guid = CRYPTMAN:GenerateRandomUUID(),
+			Grade = ToEnumShortString(highscore:GetGrade()),
+			Score = highscore:GetScore(),
+			PercentDP = highscore:GetPercentDP(),
+			SurviveSeconds = highscore:GetSurvivalSeconds(),
+			MaxCombo = highscore:GetMaxCombo(),
+			Modifiers = highscore:GetModifiers(),
+			DateTime = highscore:GetDate(),
+			PlayerGuid = PROFILEMAN:GetProfile(player):GetGUID(),
+			Disqualified = pss:IsDisqualified(),
+			TapNoteScores = {
+				W1 = highscore:GetTapNoteScore("TapNoteScore_W1"),
+				W2 = highscore:GetTapNoteScore("TapNoteScore_W2"),
+				W3 = highscore:GetTapNoteScore("TapNoteScore_W3"),
+				W4 = highscore:GetTapNoteScore("TapNoteScore_W4"),
+				W5 = highscore:GetTapNoteScore("TapNoteScore_W5"),
+				Miss = highscore:GetTapNoteScore("TapNoteScore_Miss"),
+				HitMine = highscore:GetTapNoteScore("TapNoteScore_HitMine"),
+				AvoidMine = highscore:GetTapNoteScore("TapNoteScore_AvoidMine"),
+				CheckpointMiss = highscore:GetTapNoteScore("TapNoteScore_CheckpointMiss"),
+				CheckpointHit = highscore:GetTapNoteScore("TapNoteScore_CheckpointHit"),
+			},
+			HoldNoteScores = {
+				LetGo = highscore:GetHoldNoteScore("HoldNoteScore_LetGo"),
+				Held = highscore:GetHoldNoteScore("HoldNoteScore_Held"),
+				MissedHold = highscore:GetHoldNoteScore("HoldNoteScore_MissedHold"),
+			},
+			Radar = {
+				Notes = actualRadar:GetValue("RadarCategory_Notes"),
+				TapsAndHolds = actualRadar:GetValue("RadarCategory_TapsAndHolds"),
+				Jumps = actualRadar:GetValue("RadarCategory_Jumps"),
+				Holds = actualRadar:GetValue("RadarCategory_Holds"),
+				Mines = actualRadar:GetValue("RadarCategory_Mines"),
+				Hands = actualRadar:GetValue("RadarCategory_Hands"),
+				Rolls = actualRadar:GetValue("RadarCategory_Rolls"),
+			},
+		}
+
+		local song = GAMESTATE:GetCurrentSong()
+		local course = GAMESTATE:GetCurrentCourse()
+
+		if course ~= nil then
+			local trail = GAMESTATE:GetCurrentTrail(player)
+
+			-- There is no GetFullTitle() method, so we have to
+			-- fake it by temporarily overwriting the
+			-- ShowNativeLanguage preference.
+			local showNativeLanguage = PREFSMAN:GetPreference("ShowNativeLanguage")
+			PREFSMAN:SetPreference('ShowNativeLanguage', true)
+			local fullTitle = course:GetDisplayFullTitle()
+			PREFSMAN:SetPreference('ShowNativeLanguage', showNativeLanguage)
+
+			local radarValues
+			if possibleRadar:GetValue("RadarCategory_Notes") == -1 then
+				radarValues = nil
+			else
+				radarValues = {
+					Notes = possibleRadar:GetValue("RadarCategory_Notes"),
+					TapsAndHolds = possibleRadar:GetValue("RadarCategory_TapsAndHolds"),
+					Jumps = possibleRadar:GetValue("RadarCategory_Jumps"),
+					Holds = possibleRadar:GetValue("RadarCategory_Holds"),
+					Mines = possibleRadar:GetValue("RadarCategory_Mines"),
+					Hands = possibleRadar:GetValue("RadarCategory_Hands"),
+					Rolls = possibleRadar:GetValue("RadarCategory_Rolls"),
+				}
+			end
+
+
+			content.Course = {
+				Path = nilIfEmpty(course:GetCourseDir()),
+				FullTitle = fullTitle,
+				TranslitFullTitle = course:GetTranslitFullTitle(),
+				Scripter = nilIfEmpty(course:GetScripter()),
+				Description = nilIfEmpty(course:GetDescription()),
+			}
+			content.Trail = {
+				Difficulty = ToEnumShortString(trail:GetDifficulty()),
+				Meter = trail:GetMeter(),
+				StepsType = ToEnumShortString(trail:GetStepsType()):lower():gsub('_', '-'),
+				LengthSeconds = trail:GetLengthSeconds(),
+				Radar = radarValues,
+			}
+		elseif song ~= nil then
+			local steps = GAMESTATE:GetCurrentSteps(player)
+
+			-- There are no GetArtist() and GetSubTitle() methods,
+			-- so we have to fake them by temporarily overwriting
+			-- the ShowNativeLanguage preference.
+			local showNativeLanguage = PREFSMAN:GetPreference("ShowNativeLanguage")
+			PREFSMAN:SetPreference('ShowNativeLanguage', true)
+			local artist = song:GetDisplayArtist()
+			local subtitle = song:GetDisplaySubTitle()
+			PREFSMAN:SetPreference('ShowNativeLanguage', showNativeLanguage)
+
+			content.Song = {
+				Dir = song:GetSongDir(),
+				Group = song:GetGroupName(),
+				Title = song:GetMainTitle(),
+				SubTitle = nilIfEmpty(subtitle),
+				Artist = nilIfEmpty(artist),
+				TranslitTitle = song:GetTranslitMainTitle(),
+				TranslitSubTitle = nilIfEmpty(song:GetTranslitSubTitle()),
+				TranslitArtist = nilIfEmpty(song:GetTranslitArtist()),
+				Genre = nilIfEmpty(song:GetGenre()),
+				BPM = song:GetDisplayBpms(),
+				RandomBPM = song:IsDisplayBpmRandom(),
+				MusicLengthSeconds = song:MusicLengthSeconds(),
+			}
+			content.Steps = {
+				Difficulty = ToEnumShortString(steps:GetDifficulty()),
+				Meter = steps:GetMeter(),
+				StepsType = ToEnumShortString(steps:GetStepsType()):lower():gsub('_', '-'),
+				AuthorCredit = steps:GetAuthorCredit(),
+				Description = steps:GetDescription(),
+				Radar = {
+					Notes = possibleRadar:GetValue("RadarCategory_Notes"),
+					TapsAndHolds = possibleRadar:GetValue("RadarCategory_TapsAndHolds"),
+					Jumps = possibleRadar:GetValue("RadarCategory_Jumps"),
+					Holds = possibleRadar:GetValue("RadarCategory_Holds"),
+					Mines = possibleRadar:GetValue("RadarCategory_Mines"),
+					Hands = possibleRadar:GetValue("RadarCategory_Hands"),
+					Rolls = possibleRadar:GetValue("RadarCategory_Rolls"),
+				},
+			}
+		end
+
+		-- Don't store scores for guest profiles
+		if PROFILEMAN:IsPersistentProfile(player) then
+			local profileSlot = {
+				[PLAYER_1] = "ProfileSlot_Player1",
+				[PLAYER_2] = "ProfileSlot_Player2"
+			}
+			local profileDir  = PROFILEMAN:GetProfileDir(profileSlot[player])
+			local date = highscore:GetDate()
+
+			-- Remove colons from date, because they are not
+			-- allowed on FAT file systems (especially important
+			-- for USB profiles)
+			local filename = date:gsub(':', '') .. ".json"
+
+			local f = RageFileUtil.CreateRageFile()
+			if f:Open(profileDir .. "SL-Scores/" .. filename, 2) then
+				f:Write(json.encode(content))
+			end
+			f:destroy()
+		end
+	end
+end

--- a/Scripts/json.lua
+++ b/Scripts/json.lua
@@ -1,0 +1,400 @@
+--
+-- json.lua
+--
+-- Copyright (c) 2019 rxi
+--
+-- Permission is hereby granted, free of charge, to any person obtaining a copy of
+-- this software and associated documentation files (the "Software"), to deal in
+-- the Software without restriction, including without limitation the rights to
+-- use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+-- of the Software, and to permit persons to whom the Software is furnished to do
+-- so, subject to the following conditions:
+--
+-- The above copyright notice and this permission notice shall be included in all
+-- copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+-- SOFTWARE.
+--
+
+json = { _version = "0.1.2" }
+
+-------------------------------------------------------------------------------
+-- Encode
+-------------------------------------------------------------------------------
+
+local encode
+
+local escape_char_map = {
+  [ "\\" ] = "\\\\",
+  [ "\"" ] = "\\\"",
+  [ "\b" ] = "\\b",
+  [ "\f" ] = "\\f",
+  [ "\n" ] = "\\n",
+  [ "\r" ] = "\\r",
+  [ "\t" ] = "\\t",
+}
+
+local escape_char_map_inv = { [ "\\/" ] = "/" }
+for k, v in pairs(escape_char_map) do
+  escape_char_map_inv[v] = k
+end
+
+
+local function escape_char(c)
+  return escape_char_map[c] or string.format("\\u%04x", c:byte())
+end
+
+
+local function encode_nil(val)
+  return "null"
+end
+
+
+local function encode_table(val, stack)
+  local res = {}
+  stack = stack or {}
+
+  -- Circular reference?
+  if stack[val] then error("circular reference") end
+
+  stack[val] = true
+
+  if rawget(val, 1) ~= nil or next(val) == nil then
+    -- Treat as array -- check keys are valid and it is not sparse
+    local n = 0
+    for k in pairs(val) do
+      if type(k) ~= "number" then
+        error("invalid table: mixed or invalid key types")
+      end
+      n = n + 1
+    end
+    if n ~= #val then
+      error("invalid table: sparse array")
+    end
+    -- Encode
+    for i, v in ipairs(val) do
+      table.insert(res, encode(v, stack))
+    end
+    stack[val] = nil
+    return "[" .. table.concat(res, ",") .. "]"
+
+  else
+    -- Treat as an object
+    for k, v in pairs(val) do
+      if type(k) ~= "string" then
+        error("invalid table: mixed or invalid key types")
+      end
+      table.insert(res, encode(k, stack) .. ":" .. encode(v, stack))
+    end
+    stack[val] = nil
+    return "{" .. table.concat(res, ",") .. "}"
+  end
+end
+
+
+local function encode_string(val)
+  return '"' .. val:gsub('[%z\1-\31\\"]', escape_char) .. '"'
+end
+
+
+local function encode_number(val)
+  -- Check for NaN, -inf and inf
+  if val ~= val or val <= -math.huge or val >= math.huge then
+    error("unexpected number value '" .. tostring(val) .. "'")
+  end
+  return string.format("%.14g", val)
+end
+
+
+local type_func_map = {
+  [ "nil"     ] = encode_nil,
+  [ "table"   ] = encode_table,
+  [ "string"  ] = encode_string,
+  [ "number"  ] = encode_number,
+  [ "boolean" ] = tostring,
+}
+
+
+encode = function(val, stack)
+  local t = type(val)
+  local f = type_func_map[t]
+  if f then
+    return f(val, stack)
+  end
+  error("unexpected type '" .. t .. "'")
+end
+
+
+function json.encode(val)
+  return ( encode(val) )
+end
+
+
+-------------------------------------------------------------------------------
+-- Decode
+-------------------------------------------------------------------------------
+
+local parse
+
+local function create_set(...)
+  local res = {}
+  for i = 1, select("#", ...) do
+    res[ select(i, ...) ] = true
+  end
+  return res
+end
+
+local space_chars   = create_set(" ", "\t", "\r", "\n")
+local delim_chars   = create_set(" ", "\t", "\r", "\n", "]", "}", ",")
+local escape_chars  = create_set("\\", "/", '"', "b", "f", "n", "r", "t", "u")
+local literals      = create_set("true", "false", "null")
+
+local literal_map = {
+  [ "true"  ] = true,
+  [ "false" ] = false,
+  [ "null"  ] = nil,
+}
+
+
+local function next_char(str, idx, set, negate)
+  for i = idx, #str do
+    if set[str:sub(i, i)] ~= negate then
+      return i
+    end
+  end
+  return #str + 1
+end
+
+
+local function decode_error(str, idx, msg)
+  local line_count = 1
+  local col_count = 1
+  for i = 1, idx - 1 do
+    col_count = col_count + 1
+    if str:sub(i, i) == "\n" then
+      line_count = line_count + 1
+      col_count = 1
+    end
+  end
+  error( string.format("%s at line %d col %d", msg, line_count, col_count) )
+end
+
+
+local function codepoint_to_utf8(n)
+  -- http://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&id=iws-appendixa
+  local f = math.floor
+  if n <= 0x7f then
+    return string.char(n)
+  elseif n <= 0x7ff then
+    return string.char(f(n / 64) + 192, n % 64 + 128)
+  elseif n <= 0xffff then
+    return string.char(f(n / 4096) + 224, f(n % 4096 / 64) + 128, n % 64 + 128)
+  elseif n <= 0x10ffff then
+    return string.char(f(n / 262144) + 240, f(n % 262144 / 4096) + 128,
+                       f(n % 4096 / 64) + 128, n % 64 + 128)
+  end
+  error( string.format("invalid unicode codepoint '%x'", n) )
+end
+
+
+local function parse_unicode_escape(s)
+  local n1 = tonumber( s:sub(3, 6),  16 )
+  local n2 = tonumber( s:sub(9, 12), 16 )
+  -- Surrogate pair?
+  if n2 then
+    return codepoint_to_utf8((n1 - 0xd800) * 0x400 + (n2 - 0xdc00) + 0x10000)
+  else
+    return codepoint_to_utf8(n1)
+  end
+end
+
+
+local function parse_string(str, i)
+  local has_unicode_escape = false
+  local has_surrogate_escape = false
+  local has_escape = false
+  local last
+  for j = i + 1, #str do
+    local x = str:byte(j)
+
+    if x < 32 then
+      decode_error(str, j, "control character in string")
+    end
+
+    if last == 92 then -- "\\" (escape char)
+      if x == 117 then -- "u" (unicode escape sequence)
+        local hex = str:sub(j + 1, j + 5)
+        if not hex:find("%x%x%x%x") then
+          decode_error(str, j, "invalid unicode escape in string")
+        end
+        if hex:find("^[dD][89aAbB]") then
+          has_surrogate_escape = true
+        else
+          has_unicode_escape = true
+        end
+      else
+        local c = string.char(x)
+        if not escape_chars[c] then
+          decode_error(str, j, "invalid escape char '" .. c .. "' in string")
+        end
+        has_escape = true
+      end
+      last = nil
+
+    elseif x == 34 then -- '"' (end of string)
+      local s = str:sub(i + 1, j - 1)
+      if has_surrogate_escape then
+        s = s:gsub("\\u[dD][89aAbB]..\\u....", parse_unicode_escape)
+      end
+      if has_unicode_escape then
+        s = s:gsub("\\u....", parse_unicode_escape)
+      end
+      if has_escape then
+        s = s:gsub("\\.", escape_char_map_inv)
+      end
+      return s, j + 1
+
+    else
+      last = x
+    end
+  end
+  decode_error(str, i, "expected closing quote for string")
+end
+
+
+local function parse_number(str, i)
+  local x = next_char(str, i, delim_chars)
+  local s = str:sub(i, x - 1)
+  local n = tonumber(s)
+  if not n then
+    decode_error(str, i, "invalid number '" .. s .. "'")
+  end
+  return n, x
+end
+
+
+local function parse_literal(str, i)
+  local x = next_char(str, i, delim_chars)
+  local word = str:sub(i, x - 1)
+  if not literals[word] then
+    decode_error(str, i, "invalid literal '" .. word .. "'")
+  end
+  return literal_map[word], x
+end
+
+
+local function parse_array(str, i)
+  local res = {}
+  local n = 1
+  i = i + 1
+  while 1 do
+    local x
+    i = next_char(str, i, space_chars, true)
+    -- Empty / end of array?
+    if str:sub(i, i) == "]" then
+      i = i + 1
+      break
+    end
+    -- Read token
+    x, i = parse(str, i)
+    res[n] = x
+    n = n + 1
+    -- Next token
+    i = next_char(str, i, space_chars, true)
+    local chr = str:sub(i, i)
+    i = i + 1
+    if chr == "]" then break end
+    if chr ~= "," then decode_error(str, i, "expected ']' or ','") end
+  end
+  return res, i
+end
+
+
+local function parse_object(str, i)
+  local res = {}
+  i = i + 1
+  while 1 do
+    local key, val
+    i = next_char(str, i, space_chars, true)
+    -- Empty / end of object?
+    if str:sub(i, i) == "}" then
+      i = i + 1
+      break
+    end
+    -- Read key
+    if str:sub(i, i) ~= '"' then
+      decode_error(str, i, "expected string for key")
+    end
+    key, i = parse(str, i)
+    -- Read ':' delimiter
+    i = next_char(str, i, space_chars, true)
+    if str:sub(i, i) ~= ":" then
+      decode_error(str, i, "expected ':' after key")
+    end
+    i = next_char(str, i + 1, space_chars, true)
+    -- Read value
+    val, i = parse(str, i)
+    -- Set
+    res[key] = val
+    -- Next token
+    i = next_char(str, i, space_chars, true)
+    local chr = str:sub(i, i)
+    i = i + 1
+    if chr == "}" then break end
+    if chr ~= "," then decode_error(str, i, "expected '}' or ','") end
+  end
+  return res, i
+end
+
+
+local char_func_map = {
+  [ '"' ] = parse_string,
+  [ "0" ] = parse_number,
+  [ "1" ] = parse_number,
+  [ "2" ] = parse_number,
+  [ "3" ] = parse_number,
+  [ "4" ] = parse_number,
+  [ "5" ] = parse_number,
+  [ "6" ] = parse_number,
+  [ "7" ] = parse_number,
+  [ "8" ] = parse_number,
+  [ "9" ] = parse_number,
+  [ "-" ] = parse_number,
+  [ "t" ] = parse_literal,
+  [ "f" ] = parse_literal,
+  [ "n" ] = parse_literal,
+  [ "[" ] = parse_array,
+  [ "{" ] = parse_object,
+}
+
+
+parse = function(str, idx)
+  local chr = str:sub(idx, idx)
+  local f = char_func_map[chr]
+  if f then
+    return f(str, idx)
+  end
+  decode_error(str, idx, "unexpected character '" .. chr .. "'")
+end
+
+
+function json.decode(str)
+  if type(str) ~= "string" then
+    error("expected argument of type string, got " .. type(str))
+  end
+  local res, idx = parse(str, next_char(str, 1, space_chars, true))
+  idx = next_char(str, idx, space_chars, true)
+  if idx <= #str then
+    decode_error(str, idx, "trailing garbage")
+  end
+  return res
+end
+
+
+-- return json

--- a/metrics.ini
+++ b/metrics.ini
@@ -1128,7 +1128,7 @@ Fallback="ScreenOptionsServiceChild"
 OptionRowNormalMetricsGroup="OptionRowSimplyLoveOptions"
 
 LineNames=(function() \
-   	local lines = "VisualStyle,RainbowMode,,MusicWheelSpeed,,MusicWheelStyle,AutoStyle,DefaultGameMode,AllowFailingOutOfSet,NumberOfContinuesAllowed,CasualMaxMeter,SelectProfile,SelectColor,EvalSummary,NameEntry,GameOver,HideStockNoteSksins,DanceSolo,Nice" \
+   	local lines = "VisualStyle,RainbowMode,,MusicWheelSpeed,,MusicWheelStyle,AutoStyle,DefaultGameMode,AllowFailingOutOfSet,NumberOfContinuesAllowed,CasualMaxMeter,SelectProfile,SelectColor,EvalSummary,NameEntry,GameOver,HideStockNoteSksins,DanceSolo,Nice,WriteCustomScores" \
    	if Sprite.LoadFromCached ~= nil then lines = lines .. ",UseImageCache" end \
       return lines \
 end)()
@@ -1156,6 +1156,7 @@ LineVisualStyle="lua,ThemePrefsRows.GetRow('VisualStyle')"
 LineRainbowMode="lua,ThemePrefsRows.GetRow('RainbowMode')"
 
 LineUseImageCache="lua,ThemePrefsRows.GetRow('UseImageCache')"
+LineWriteCustomScores="lua,ThemePrefsRows.GetRow('WriteCustomScores')"
 
 
 [ScreenMenuTimerOptions]


### PR DESCRIPTION
## What is Simply Training?

Simply Training is a web application that helps you track your personal progress in ITG. Think fitness tracker, but for ITG. It keeps a diary, including the full list of songs and charts played with their respective scores, the number of steps taken and other aggregated statistics. There are also graphs and a filterable score list available.

I created this website to keep myself motivated, by having my progress visible in a chart. I hope it is useful for other people too. The website will be officially announced soon.

### How to use it

To use the website you will have to use StepMania 5.0 or 5.1 beta with the Simply Love theme (+ the code from this PR). The website relies on custom score files written by the Simply Love theme, which have to be enabled in the options (`Options` → `Simply Love Options` → `Write Custom Scores`). Score files are stored in the user profile directory, so if you use USB profiles, the scores are stored on the USB stick. Handy!

Currently the Simply Love theme is required. Ideally other themes will be supported in the future too.

### The PR

The code in this pull requests adds the menu option for enabling custom scores and the actual score serialization and writing functionality.

One thing I'm not sure about is the wording of the menu option. "Custom scores" sounds a bit cheesy.
Suggestions welcome!

I intend to keep updating the score writing as new features are added to the website. E.g. displaying full timing information (the graph) comes to mind. The score writing code is mostly independent from all the other code in the theme, so it shouldn't need much maintenance unless major changes happen. If necessary I will fix issues with it.

---
This PR is not a hacktoberfest contribution ;)
