### PR TITLE
Replace / in song names when saving screenshots

### DIFF
--- a/BGAnimations/ScreenEvaluation common/Shared/ScreenshotHandler.lua
+++ b/BGAnimations/ScreenEvaluation common/Shared/ScreenshotHandler.lua
@@ -27,6 +27,10 @@ spr.CodeMessageCommand=function(self, params)
 		-- so, let's use only the first 10 characters of the title in the screenshot filename
 		title = title:sub(1,10)
 
+		-- some song titles have slashes in them, which is interpreted as a folder in the path as
+		-- screenshot is saved. we'll substitute those slashes with underscores to prevent this.
+		title = title:gsub("/", "_")
+
 		-- organize screenshots Love into directories, like...
 		--      ./Screenshots/Simply_Love/2020/04-April/DVNO-2020-04-22_175951.png
 		-- note that the engine's SaveScreenshot() function will convert whitespace


### PR DESCRIPTION
This prevents the game from interpreting the / as a folder when you save a screenshot for songs like K/DA's "Pop/Stars".

**Current behavior as of 4.9.1:**
A screenshot for "Pop/Stars" will be saved as "Stars_2020-10-11_115540.png" in a folder called "Pop".

**Behavior with the suggested fix:**
A screenshot for "Pop/Stars" will be saved as "Pop_Stars_2020-10-11_115540.png", in the main screenshot folder.

Here's a picture to illustrate the difference:
![image](https://user-images.githubusercontent.com/706916/97504564-7f121600-194d-11eb-9f5e-cb105f88c9f0.png)

Looks like I missed the 4.9.1 release due to my procrastination, oops. 😅

Thanks for the continued work! 🥇 