### PR TITLE
Refactor StepManiaVersionIsSupported

### DIFF
--- a/Scripts/SL-SupportHelpers.lua
+++ b/Scripts/SL-SupportHelpers.lua
@@ -59,7 +59,8 @@ StepManiaVersionIsSupported = function()
 	if type(version) ~= "string" then return false end
 
 	-- remove the git hash if one is present in the version string
-	version = version:gsub("-git-.+", "")
+	-- if Stepmania has been built without git, git hash will be UNKNOWN
+	version = version:gsub("-git-.+", ""):gsub("-UNKNOWN", "")
 
 	-- split the remaining version string on periods; store each segment in a temp table
 	local t = {}


### PR DESCRIPTION
This makes it, so that supported versions are looked up in a table, which should make it easier for both this repository and forks to enable support for future versions (or backports to earlier versions) without completely disabling version checks.

This patch also enables support for UNKNOWN builds as requested in #186, treating them as if they were git builds.  If git is not present in the build environment (as is the case in GNU Guix, apparently also Flatpak, and likely some others as well), the stepmania build system fails to detect the version correctly, thus returning `$MAJOR.$MINOR-UNKNOWN`.  This is the case even for `-DWITH_FULL_RELEASE=ON`, so in order to have anything different, one would first need to patch the build system (so much for discouraging unmodified builds).  

If it ever becomes necessary, one could capture the git hash part and only allow "good" hashes (e.g. the one for 5.1.0-b2), but I'm personally not too big a fan of this idea. 