### PR TITLE
Minor improvements for custom score writing

### DIFF
--- a/Scripts/SL-CustomScores.lua
+++ b/Scripts/SL-CustomScores.lua
@@ -8,8 +8,8 @@ end
 function WriteScores()
 	local template = {
 		Version = 1,
-		Theme = 'Simply Love',
-		ThemeVersion = GetThemeVersion(),
+		Theme = THEME:GetThemeDisplayName(),
+		ThemeVersion = tostring(GetThemeVersion()),
 		ProductID = ProductID(),
 		ProductVersion = ProductVersion(),
 		MachineGuid = PROFILEMAN:GetMachineProfile():GetGUID(),


### PR DESCRIPTION
This commit introduces two changes to score writing:
- Always convert the theme version to string, which is what the Simply Training uploader expects. GetThemeVersion() returns a string in case the version number is something like `4.9.1`, but it returns a number in case the version is something like `4.9`. The data type is accidentally correct now (`4.9.1` -> string), but score writing would break on the next major version upgrade, whoops! This issue was found by @Roujo  when porting the score writing to SL-vertical.
- Programmatically get the theme name instead of hardcoding it. It doesn't add any advantages for SL, but it allows other themes to pick the score writing and it will already use the correct name without changes. (Also from @Roujo .)