### PR TITLE
Fix measure counter in course mode

### DIFF
--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/MeasureCounter.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/MeasureCounter.lua
@@ -29,6 +29,10 @@ local InitializeMeasureCounter = function()
 	streams = SL[pn].Streams
 	streamIndex = 1
 	prevMeasure = -1
+
+	for actor in ivalues(bmt) do
+		actor:visible(true)
+	end
 end
 
 -- Returns whether or not we've reached the end of this stream segment.


### PR DESCRIPTION
The measure counter is hidden at the end of the song when there are no more streams, but never made visible again when the next song starts. This effectively disables the measure counter after the first song in a course.

Let's change that by resetting the visibility when the song changes.

Fixes https://github.com/Simply-Love/Simply-Love-SM5/issues/217