### PR TITLE
Add Trace() call to the SM() function

### DIFF
--- a/Scripts/06 SL-Utilities.lua
+++ b/Scripts/06 SL-Utilities.lua
@@ -85,6 +85,7 @@ SM = function( arg, duration )
 	-- let's broadcast directly using MESSAGEMAN so that we can also pack in a duration
 	-- value (how long to display the SystemMessage for) if so desired
 	MESSAGEMAN:Broadcast("SystemMessage", {Message=msg, Duration=duration})
+	Trace(msg)
 end
 
 


### PR DESCRIPTION
Since 8b06a811cc948688d80cd87e5a7caba8e5087bec the SM() function doesn't write the message to log.txt anymore. I think this was an unintended side-effect of adding the duration parameter.

Fixes https://github.com/Simply-Love/Simply-Love-SM5/issues/219