### PR TITLE
ShowDateTimeOnHeader - Add option for show current datetime on Event Mode

### DIFF
--- a/Graphics/ScreenSelectMusic header.lua
+++ b/Graphics/ScreenSelectMusic header.lua
@@ -16,20 +16,25 @@ local SecondsToHMMSS = SecondsToHMMSS or function(s)
 end
 
 local UpdateTimer = function(af, dt)
-	local seconds = GetTimeSinceStart() - SL.Global.TimeAtSessionStart
+	if ThemePrefs.Get("ShowDateTimeOnHeader") then
+		local DateFormat = "%02d.%02d.%02d     %02d:%02d:%02d"
+		bmt_actor:settext(DateFormat:format(DayOfMonth(), MonthOfYear()+1, Year(), Hour(), Minute(), Second()))
+	else 
+		local seconds = GetTimeSinceStart() - SL.Global.TimeAtSessionStart
 
-	-- if this game session is less than 1 hour in duration so far
-	if seconds < 3600 then
-		bmt_actor:settext( SecondsToMMSS(seconds) )
+		-- if this game session is less than 1 hour in duration so far
+		if seconds < 3600 then
+			bmt_actor:settext( SecondsToMMSS(seconds) )
 
-	-- somewhere between 1 and 10 hours
-	elseif seconds >= 3600 and seconds < 36000 then
-		bmt_actor:settext( SecondsToHMMSS(seconds) )
+		-- somewhere between 1 and 10 hours
+		elseif seconds >= 3600 and seconds < 36000 then
+			bmt_actor:settext( SecondsToHMMSS(seconds) )
 
-	-- in it for the long haul
-	else
-		bmt_actor:settext( SecondsToHHMMSS(seconds) )
-	end
+		-- in it for the long haul
+		else
+			--bmt_actor:settext( SecondsToHHMMSS(seconds) )
+		end
+	end 
 end
 
 -- -----------------------------------------------------------------------

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -225,7 +225,7 @@ Heart Rate=Heart Rate
 
 ##############################################
 [ScreenEvaluation]
-HeaderText=FuriaBuia Cabinet
+HeaderText=Evaluation
 
 Holds=holds
 Mines=mines

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -225,7 +225,7 @@ Heart Rate=Heart Rate
 
 ##############################################
 [ScreenEvaluation]
-HeaderText=Evaluation
+HeaderText=FuriaBuia Cabinet
 
 Holds=holds
 Mines=mines
@@ -559,6 +559,7 @@ CasualMaxMeter=Max Difficulty\nIn Casual Mode
 VisualStyle=Visual Style
 RainbowMode=Rainbow Mode
 WriteCustomScores=Write Custom Scores
+ShowDateTimeOnHeader=Show Date Time\nOn Header
 UseImageCache=Use ImageCache
 
 # MenuTimer Options
@@ -738,6 +739,7 @@ VisualStyle=Choose the visual icon/emblem for this theme.\n\nEach visual style w
 RainbowMode=Turn Rainbow Mode on or off.\n\nRainbow Mode disables ScreenSelectColor by default.
 WriteCustomScores=This setting will enable the writing of custom scores files. They are stored in your profile directory. Scores are not stored for guest accounts.\n\nCustom score files can be uploaded to the simply.training website to track your personal progress.
 UseImageCache=Casual Mode will run more smoothly with the ImageCache system on, but StepMania will use a LOT more RAM as a consequence. It is recommended that you have at least 8GB of RAM to use the ImageCache system.\n\nYou will need to restart StepMania after turning this setting on for it to take effect.
+ShowDateTimeOnHeader=This setting replace the gameplay timer with the current Date and Time on the screen's headers.\n\nThis works only when Event Mode is ON.
 
 # USB MemoryCard Options
 MemoryCards=Allow players to save preferences and personal high scores to USB drives.\n\nNote that you must configure your computer's OS (outside of StepMania) to mount USB drives a specific way first for this to work.\n\nConsult the Wiki on StepMania's GitHub for detailed instructions about this.\n\ngithub.com/stepmania/stepmania/wiki
@@ -838,6 +840,7 @@ CasualMaxMeter=10 is about right for most public machines.
 nice=This is probably best left 'Off' for public machines.
 WriteCustomScores=Set to 'Yes' if you intend to use the simply.training website.
 UseImageCache=There is no need to turn this on if you never use Casual Mode.
+ShowDateTimeOnHeader=Set to 'Yes' if you want do screenshots with current Date and Time :)
 
 # Appearance Options
 ShowLyrics=Hide

--- a/Languages/it.ini
+++ b/Languages/it.ini
@@ -1168,6 +1168,7 @@ ShowGradesInMusicWheel=Mostra Record\nNella selezione musica
 VisualStyle=Stile Visivo
 RainbowMode=Modalità Arcobaleno
 UseImageCache=Usa la cache immagini
+ShowDateTimeOnHeader=Mostra la data e ora\nIn Testata
 
 # MenuTimer Options
 ScreenSelectMusicMenuTimer=Selezione musica
@@ -1464,6 +1465,7 @@ VisualStyle=Scegli l'icona che verrà utilizzata come base per il tema. Ognuna d
 RainbowMode=Attiva o disattiva la modalità arcobaleno, che renderà l'animazione di sfondo di colore cangiante.\n\nSe attiva, disabiliterà la schermata di selezione del colore.
 
 UseImageCache=La Modalità casual funzionerà molto meglio con il sistema ImageCache attivato, ma StepMania utilizzerà MOLTA più RAM. Si consiglia di disporre di almeno 8 GB totali di RAM per utilizzare il sistema ImageCache.\n\nÈ necessario riavviare StepMania dopo aver modificato questa opzione per renderla effettiva.
+ShowDateTimeOnHeader=Questa opzione sostituisce il timer di gioco con la data e ora corrente sulla testata dello schermo.\n\nQuesta opzione è valida solo se è attiva la modalità Evento.
 
 # USB Profile CustomSongs Options
 CustomSongsEnable=Consente di caricare musica aggiuntiva da card USB.\n\nAttenzione: è necessario prima configurare il sistema operativo per montare e riconoscere le chiavette USB affinché il sistema funzioni.\n\nConsulta la Wiki di StepMania per istruzioni su Linux o hackmycab.com per istruzioni su Windows.
@@ -1566,6 +1568,7 @@ CasualMaxMeter=10 è sufficiente per le macchine pubbliche.
 nice=Disattivato.
 
 UseImageCache=Non è necessario attivarlo se non si utilizza mai la modalità Casual.
+ShowDateTimeOnHeader=Attivalo se vuoi fare gli screenshot con la data e ora :)
 
 # Appearance Options
 ShowLyrics=Nascondi

--- a/Scripts/99 SL-ThemePrefs.lua
+++ b/Scripts/99 SL-ThemePrefs.lua
@@ -195,7 +195,14 @@ SL_CustomPrefs.Get = function()
 			Default = 0,
 			Choices = { THEME:GetString("ThemePrefs","Off"), THEME:GetString("ThemePrefs","On"), THEME:GetString("ThemePrefs","OnWithSound") },
 			Values  = { 0, 1, 2 }
-		}
+		},
+
+		-- Replace the game duration with the current date and time
+		ShowDateTimeOnHeader = {
+			Default = false,
+			Choices =  { THEME:GetString("ThemePrefs","Yes"), THEME:GetString("ThemePrefs", "No") },
+			Values	= { true, false }
+		},
 	}
 end
 

--- a/metrics.ini
+++ b/metrics.ini
@@ -1083,7 +1083,7 @@ Fallback="ScreenOptionsServiceChild"
 OptionRowNormalMetricsGroup="OptionRowSimplyLoveOptions"
 
 LineNames=(function() \
-   	local lines = "VisualStyle,RainbowMode,,MusicWheelSpeed,,MusicWheelStyle,AutoStyle,DefaultGameMode,AllowFailingOutOfSet,NumberOfContinuesAllowed,CasualMaxMeter,SelectProfile,SelectColor,EvalSummary,NameEntry,GameOver,HideStockNoteSksins,DanceSolo,Nice,WriteCustomScores" \
+   	local lines = "VisualStyle,RainbowMode,,MusicWheelSpeed,,MusicWheelStyle,AutoStyle,DefaultGameMode,AllowFailingOutOfSet,NumberOfContinuesAllowed,CasualMaxMeter,SelectProfile,SelectColor,EvalSummary,NameEntry,GameOver,HideStockNoteSksins,DanceSolo,Nice,WriteCustomScores,ShowDateTimeOnHeader" \
    	if Sprite.LoadFromCached ~= nil then lines = lines .. ",UseImageCache" end \
       return lines \
 end)()
@@ -1112,6 +1112,7 @@ LineRainbowMode="lua,ThemePrefsRows.GetRow('RainbowMode')"
 
 LineUseImageCache="lua,ThemePrefsRows.GetRow('UseImageCache')"
 LineWriteCustomScores="lua,ThemePrefsRows.GetRow('WriteCustomScores')"
+LineShowDateTimeOnHeader="lua,ThemePrefsRows.GetRow('ShowDateTimeOnHeader')"
 
 
 [ScreenMenuTimerOptions]


### PR DESCRIPTION
As a new cab owner, I still have feelings about days on arcades, which include do screenshots of the scores with the date and time on top of the screen, at least here, in Italy.
Sooooo.... I have made this!
On SimplyLove Options menu you will see "Show Date Time On Header" option (default is false) that will replace the gameplay timer on header with the current date and time (format: DD.MM.YYYY HH:mm:ss)
That option set to true will be consider only if the Event Mode is ON; I've made this decision because I think for the arcade machines it's much more important showing the current round instead of the Date/Time.

Tested using Stepmania 5.0.12, SimplyLove 4.9.2 (beta)
Viper

Here a screenshot for explain what this option shown (look at header):
![photo5920114639872570167](https://user-images.githubusercontent.com/10159143/100627188-fd841e00-3326-11eb-9794-5b9c04aca7b9.jpg)
![photo5920114639872570168](https://user-images.githubusercontent.com/10159143/100627202-0117a500-3327-11eb-8bd2-5d27dd25c497.jpg)