### PR TITLE
Add GlobbalOffsetSeconds to Graphics/Sound options

### DIFF
--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -532,6 +532,7 @@ EditorNoteSkin=Editor Noteskin
 
 # Graphics/Sound Options
 VideoRenderer=Video Renderer
+GlobalOffsetSeconds=Global Offset
 
 # Arcade Options
 AllowMultipleHighScoreWithSameName=Multiple High Scores\nWith Same Name
@@ -679,6 +680,7 @@ TextureColorDepth=Choose the color depth of textures.\n\n32-bit textures support
 SmoothLines=Toggle whether certain theme components are rendered with antialiased lines.
 FastNoteRendering=If enabled, the z buffer is not cleared after every note.  This causes 3D noteskins to collide, but substantially improves performance in gameplay.
 ShowStats=Display performance statistics in the upper right corner of the screen and show frame skips in the lower right.\n\nFPS = frames per second\nVPF = vertices per frame\n\nA high VPF count indicates that the theme is drawing complex things and requires better hardware (or better programming) to maintain a steady FPS.\n\nThis feature can be toggled at any time by pressing F3+6.
+GlobalOffsetSeconds=Set the audio offset in milliseconds.\n\nNegative values cause the audio to be played earlier (late arrows), positive values cause audio playback to be late (early arrows).
 VisualDelaySeconds=Subtract or add this many milliseconds of visual delay to gameplay.\n\nNegative values can be used to compensate for an LCD TV with a lot of "lag" or latency.
 AttractSoundFrequency=Set to 'Always' to play sounds every time during StepMania's attract sequence.\n\nSet to '2 Times' to play sounds every other attract sequence.\n\nSet to 'Never' if you are an arcade attendent slowly losing your sanity to the unending noise engulfing you.\n\nSimply Love does not have any attract sequence sounds, but this setting may impact other themes.
 
@@ -851,6 +853,7 @@ HighResolutionTextures=Auto
 TextureColorDepth=32bit
 DelayedTextureDelete=On
 FastNoteRendering=If you are experiencing low fps in gameplay, try turning this on.\n\nNote that specifying a SoundDevice in your Preferences.ini file can also substantially improve fps in gameplay.
+GlobalOffsetSeconds=Start at -9ms to compensate for ITG offset and tweak from there.
 # Arcade Options
 AllowMultipleHighScoreWithSameName=Off
 ComboContinuesBetweenSongs=Off

--- a/Scripts/SL-OperatorMenuOptions.lua
+++ b/Scripts/SL-OperatorMenuOptions.lua
@@ -222,46 +222,50 @@ OperatorMenuOptionRows.VideoRenderer = function()
 	}
 end
 
-OperatorMenuOptionRows.VisualDelaySeconds = function()
+function offsetMS(pref, low, high)
+	local val = PREFSMAN:GetPreference(pref)
+	local ms = round(val * 1000)	-- convert seconds to milliseconds
 
-	-- visual delay seconds
-	local vds = PREFSMAN:GetPreference("VisualDelaySeconds")
-	-- visual delay milliseconds, rounded to nearest int
-	local vdms = round(vds * 1000)
-
-	-- it's hopefully safe to assume that the player does not have a VisualDelaySeconds value
-	-- smaller than -1 or larger than 1, but accommodate if they do by using their value as
-	-- the largest or smallest available choice in this OptionRow
-	local low  = round(math.min(-1000, vdms))
-	local high = round(math.max( 1000, vdms))
+	-- If the player has a value set outside of the specified range
+	-- accommodate by extending the range.
+	low = math.min(low, ms)
+	high = math.max(high, ms)
 
 	-- _values as a temp table of values * 1000 as an intermediate step, not presented to players
-	-- _choices as millisecond integers, used for comparison, not presented to players
 	--  choices as millisecond integers with "ms" appended, presented to players
 	local _values  = range(low, high)
-	local _choices = stringify(_values, "%i")
 	local choices  = stringify(_values, "%ims")
 
 	return {
-		Name="VisualDelaySeconds",
+		Name=pref,
 		Choices=choices,
 		LayoutType = "ShowOneInRow",
 		SelectType = "SelectOne",
 		OneChoiceForAllPlayers = true,
 		ExportOnChange = false,
 		LoadSelections = function(self, list, pn)
-			local i = FindInTable(("%i"):format(vdms), _choices) or math.ceil(#choices/2)
+			local i = ms - low + 1
 			list[i] = true
 		end,
 		SaveSelections = function(self, list, pn)
 			for i=1, #choices do
 				if list[i] then
-					PREFSMAN:SetPreference("VisualDelaySeconds", tonumber(_choices[i])/1000)
+					PREFSMAN:SetPreference(pref, (low + i - 1) / 1000)
 					break
 				end
 			end
 		end
 	}
+end
+
+OperatorMenuOptionRows.GlobalOffsetSeconds = function()
+	-- 100ms should be sufficient to accomodate for audio delay
+	return offsetMS("GlobalOffsetSeconds", -100, 100)
+end
+
+OperatorMenuOptionRows.VisualDelaySeconds = function()
+	-- up to 1s of visual delay, because some TVs are really slow
+	return offsetMS("VisualDelaySeconds", -1000, 1000)
 end
 
 -- -----------------------------------------------------------------------

--- a/metrics.ini
+++ b/metrics.ini
@@ -972,7 +972,7 @@ Fallback="ScreenOptionsServiceChild"
 # functions aren't available; they were both added in 5.1 but SL also supports 5.0.12 for now
 # Remove DisplayMode from macOS for now; this is still broken in 5.1-beta and can cause players to get stuck.
 LineNames=(function() \
-   local lines = "VideoRenderer,DisplayMode,DisplayAspectRatio,DisplayResolution,RefreshRate,FullscreenType,DisplayColorDepth,HighResolutionTextures,MaxTextureResolution,TextureColorDepth,MovieColorDepth,SmoothLines,CelShadeModels,DelayedTextureDelete,Vsync,FastNoteRendering,ShowStats,AttractSoundFrequency,SoundVolume,EnableAttackSounds,EnableMineHitSound,VisualDelaySeconds" \
+   local lines = "VideoRenderer,DisplayMode,DisplayAspectRatio,DisplayResolution,RefreshRate,FullscreenType,DisplayColorDepth,HighResolutionTextures,MaxTextureResolution,TextureColorDepth,MovieColorDepth,SmoothLines,CelShadeModels,DelayedTextureDelete,Vsync,FastNoteRendering,ShowStats,AttractSoundFrequency,SoundVolume,EnableAttackSounds,EnableMineHitSound,GlobalOffsetSeconds,VisualDelaySeconds" \
 	if type(ConfAspectRatio) ~= "function" then lines = lines:gsub("DisplayAspectRatio","DisplayAspectRatioConf") end \
 	if type(ConfDisplayResolution) ~= "function" then lines = lines:gsub("DisplayResolution", "DisplayResolutionConf") end \
 	if type(ConfDisplayMode) ~= "function" then lines = lines:gsub("DisplayMode,", "") end \
@@ -1010,6 +1010,7 @@ LineAttractSoundFrequency="conf,AttractSoundFrequency"
 LineSoundVolume="conf,SoundVolume"
 LineEnableAttackSounds="conf,EnableAttackSounds"
 LineEnableMineHitSound="conf,EnableMineHitSound"
+LineGlobalOffsetSeconds="lua,OperatorMenuOptionRows.GlobalOffsetSeconds()"
 LineVisualDelaySeconds="lua,OperatorMenuOptionRows.VisualDelaySeconds()"
 
 


### PR DESCRIPTION
I believe that adding this to to the options menu and providing a description and recommendation can help new players to correctly sync their setup. I forget every time whether negative or positive values are required to make the arrows later, so this helps me to remember too.

I called the option "Global Offset", because that's what it's called in Preferences.ini and that's the term experienced players are familiar with. "Audio Offset" or "Audio Delay" might have been more descriptive, but oh well...

Is there a reason why this was not available in the options menu before?