### PR TITLE
Use correct translation strings for casual mode song description

### DIFF
--- a/BGAnimations/ScreenSelectMusic overlay/SongDescription/SongDescription.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SongDescription/SongDescription.lua
@@ -34,7 +34,7 @@ af[#af+1] = Def.ActorFrame{
 	-- ----------------------------------------
 	-- Artist Label
 	LoadFont("Common Normal")..{
-		Text=THEME:GetString("SongDescription", GAMESTATE:IsCourseMode() and "NumSongs" or "Artist"),
+		Text=THEME:GetString("SongDescription", GAMESTATE:IsCourseMode() and "NumSongs" or "Artist"):upper(),
 		InitCommand=function(self) self:align(1,0):y(-11):maxwidth(44):diffuse(0.5,0.5,0.5,1) end,
 	},
 
@@ -55,7 +55,7 @@ af[#af+1] = Def.ActorFrame{
 	-- ----------------------------------------
 	-- BPM Label
 	LoadFont("Common Normal")..{
-		Text=THEME:GetString("SongDescription", "BPM"),
+		Text=THEME:GetString("SongDescription", "BPM"):upper(),
 		InitCommand=function(self)
 			self:align(1,0):y(10):diffuse(0.5,0.5,0.5,1)
 		end
@@ -125,7 +125,7 @@ af[#af+1] = Def.ActorFrame{
 	-- ----------------------------------------
 	-- Song Duration Label
 	LoadFont("Common Normal")..{
-		Text=THEME:GetString("SongDescription", "Length"),
+		Text=THEME:GetString("SongDescription", "Length"):upper(),
 		InitCommand=function(self)
 			self:align(1,0):diffuse(0.5,0.5,0.5,1)
 			self:x(_w-130):y(10)

--- a/BGAnimations/ScreenSelectMusicCasual overlay/SongWheelShared.lua
+++ b/BGAnimations/ScreenSelectMusicCasual overlay/SongWheelShared.lua
@@ -129,7 +129,7 @@ af[#af+1] = Def.ActorFrame{
 		InitCommand=function(self) self:zoom(0.85):diffuse(Color.White):y(-20):horizalign(left) end,
 		CurrentSongChangedMessageCommand=function(self, params)
 			if params.song then
-				self:settext( THEME:GetString("ScreenSelectMusic", "Artist") .. ": " .. params.song:GetDisplayArtist() )
+				self:settext( THEME:GetString("SongDescription", "Artist") .. ": " .. params.song:GetDisplayArtist() )
 			end
 		end,
 	},
@@ -144,7 +144,7 @@ af[#af+1] = Def.ActorFrame{
 			InitCommand=function(self) self:zoom(0.65):diffuse(Color.White):y(0):horizalign(left) end,
 			CurrentSongChangedMessageCommand=function(self, params)
 				if params.song then
-					self:settext( ("%s: %s"):format(THEME:GetString("ScreenSelectMusic", "BPM"), StringifyDisplayBPMs() or "") )
+					self:settext( ("%s: %s"):format(THEME:GetString("SongDescription", "BPM"), StringifyDisplayBPMs() or "") )
 				end
 			end,
 		},
@@ -155,7 +155,7 @@ af[#af+1] = Def.ActorFrame{
 			InitCommand=function(self) self:zoom(0.65):diffuse(Color.White):y(14):horizalign(left) end,
 	 		CurrentSongChangedMessageCommand=function(self, params)
 				if params.song then
-		 			self:settext( THEME:GetString("ScreenSelectMusic", "Length") .. ": " .. SecondsToMMSS(params.song:MusicLengthSeconds()):gsub("^0*","") )
+		 			self:settext( THEME:GetString("SongDescription", "Length") .. ": " .. SecondsToMMSS(params.song:MusicLengthSeconds()):gsub("^0*","") )
 				end
 	 		end,
 		},
@@ -168,7 +168,7 @@ af[#af+1] = Def.ActorFrame{
 			end,
 			CurrentSongChangedMessageCommand=function(self, params)
 				if params.song then
-					self:settext( THEME:GetString("ScreenSelectMusic", "Genre") .. ": " .. params.song:GetGenre() )
+					self:settext( THEME:GetString("SongDescription", "Genre") .. ": " .. params.song:GetGenre() )
 				end
 			end,
 		},

--- a/Languages/de.ini
+++ b/Languages/de.ini
@@ -137,13 +137,13 @@ STEPS=STEPS
 # SortMenu
 Group=Gruppe
 Title=Titel
-Artist=Kunstler
+Artist=Künstler
 Genre=Genre
 BPM=BPM
-Length=Lange
+Length=Länge
 Recent=Kürzlich Gespielt
 Popularity=Meist Gespielt
-BeginnerMeter=Anfanger
+BeginnerMeter=Anfänger
 EasyMeter=Einfach
 MediumMeter=Mittel
 HardMeter=Schwierig
@@ -179,13 +179,14 @@ NoInfo=Weiterspielen.
 
 
 [SongDescription]
-Artist=KÜNSTLER
+Artist=Künstler
 BPM=BPM
-Length=LÄNGE
+Length=Länge
 r21=nicht 1:45
 IsLong=ZÄHLT ALS 2 SPIELE
 IsMarathon=ZÄHLT ALS 3 SPIELE
-NumSongs=LIEDER
+NumSongs=Lieder
+Genre=Genre
 
 
 # Parent of ScreenPlayerOptions and ScreenPlayerOptions2

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -178,13 +178,14 @@ NPS=NPS
 
 
 [SongDescription]
-Artist=ARTIST
+Artist=Artist
 BPM=BPM
-Length=LENGTH
+Length=Length
 r21=not 1:45
 IsLong=COUNTS AS 2 ROUNDS
 IsMarathon=COUNTS AS 3 ROUNDS
-NumSongs=SONGS
+NumSongs=Songs
+Genre=Genre
 
 # basically ScreenSelectMusic, but for CourseMode
 [ScreenSelectCourse]

--- a/Languages/es.ini
+++ b/Languages/es.ini
@@ -159,13 +159,14 @@ NoInfo=Seguir jugando.
 
 
 [SongDescription]
-Artist=ARTIS.
+Artist=Artista
 BPM=BPM
-Length=DURACIÓN
+Length=Duración
 r21=no 1:45
 IsLong=CUENTA 2 RONDAS
 IsMarathon=CUENTA 3 RONDAS
-NumSongs=PISTAS
+NumSongs=Pistas
+Genre=Genero
 
 # Parent of ScreenPlayerOptions and ScreenPlayerOptions2
 [ScreenOptions]

--- a/Languages/fr.ini
+++ b/Languages/fr.ini
@@ -131,13 +131,14 @@ Single=Simple
 Versus=Versus
 
 [SongDescription]
-Artist=ARTISTE
+Artist=Artiste
 BPM=BPM
-Length=DURÉE
+Length=Durée
 r21=pas 1:45
 IsLong=2 MANCHES
 IsMarathon=3 MANCHES
-NumSongs=CHANSONS
+NumSongs=Chansons
+Genre=Genre
 
 # Parent of ScreenPlayerOptions and ScreenPlayerOptions2
 [ScreenOptions]

--- a/Languages/it.ini
+++ b/Languages/it.ini
@@ -201,7 +201,8 @@ Length=Durata
 r21=not 1:45
 IsLong=Vale come 2 round
 IsMarathon=Vale come 3 round
-NumSongs=SONGS
+NumSongs=Songs
+Genre=Genere
 
 # Parent of ScreenPlayerOptions and ScreenPlayerOptions2
 [ScreenOptions]

--- a/Languages/ja.ini
+++ b/Languages/ja.ini
@@ -123,13 +123,14 @@ Single=Single
 Versus=Versus
 
 [SongDescription]
-Artist=ARTIST
+Artist=Artist
 BPM=BPM
-Length=LENGTH
+Length=Length
 r21=not 1:45
 IsLong=COUNTS AS 2 ROUNDS
 IsMarathon=COUNTS AS 3 ROUNDS
-NumSongs=SONGS
+NumSongs=Songs
+Genre=Genre
 
 # Parent of ScreenPlayerOptions and ScreenPlayerOptions2
 [ScreenOptions]

--- a/Languages/pt-br.ini
+++ b/Languages/pt-br.ini
@@ -200,13 +200,14 @@ Routine=Rotina
 Group=Grupo
 
 [SongDescription]
-Artist=ARTIS.
+Artist=Artista
 BPM=BPM
-Length=DURAÇÃO
+Length=Duração
 r21=não 1:45
 IsLong=Conta como 2 Rounds
 IsMarathon=Conta como 3 Rounds
-NumSongs=SONS
+NumSongs=Sons
+Genre=Genero
 
 # Parent of ScreenPlayerOptions and ScreenPlayerOptions2
 [ScreenOptions]


### PR DESCRIPTION
Until now the strings for sorting in the music wheel were used. This
could result in some words showing up in the incorrect grammatical case
for some languages. With this change ITG and casual mode now use the
same translation strings for the song description.

Issue reported by @JustMoneko.