### PR TITLE
fix layout for Holds, Mines, and Rolls BMTs in StepStats pane

### DIFF
--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/StepStatistics/HoldsMinesRolls.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/StepStatistics/HoldsMinesRolls.lua
@@ -34,8 +34,8 @@ for index, RCType in ipairs(RadarCategories) do
 		Text="000",
 		InitCommand=function(self)
 			self:zoom(0.4)
-			self:halign(PlayerNumber:Reverse()[OtherPlayer[player]])
-			self:x( 0 )
+			self:horizalign(left)
+			self:x( player==PLAYER_1 and -100 or 0 )
 			self:y((index-1)*row_height - 22)
 		end,
 		BeginCommand=function(self)
@@ -79,8 +79,8 @@ for index, RCType in ipairs(RadarCategories) do
 	af[#af+1] = LoadFont("Wendy/_ScreenEvaluation numbers")..{
 		InitCommand=function(self)
 			self:zoom(0.4)
-			self:halign(PlayerNumber:Reverse()[player])
-			self:x( 100 * (player==PLAYER_1 and -1 or 1) )
+			self:horizalign(right)
+			self:x( player==PLAYER_1 and 0 or 100 )
 			self:y((index-1)*row_height - 22)
 		end,
 		BeginCommand=function(self)


### PR DESCRIPTION
This addresses a small bug introduced in 5de3718984da287b16970e65cd1ae3974f208557 with the way BitmapText actors for Holds, Mines, and Rolls values were laid out.

Following 5de3718984da287b16970e65cd1ae3974f208557,  the "current performance" values and the "potential" values for PLAYER_1 were accidentally switched.  SL v4.9.1 looks like this:
<img width="809" alt="CleanShot 2020-12-22 at 15 36 30@2x" src="https://user-images.githubusercontent.com/1253483/102931625-b6440580-446c-11eb-8652-f313e8351977.png">

This addresses that bug so that the layouts match and are correct for both players, like this:
<img width="811" alt="CleanShot 2020-12-22 at 15 34 19@2x" src="https://user-images.githubusercontent.com/1253483/102931792-058a3600-446d-11eb-89c1-23ba4d32b88a.png">
