### PR TITLE
bug fix: OptionRows being hidden in ScreenManageProfiles MiniMenu (#230)

### DIFF
--- a/metrics.ini
+++ b/metrics.ini
@@ -1347,15 +1347,14 @@ TimerSeconds=-1
 ShowHelp=false
 OptionRowNormalMetricsGroup="OptionRowMiniMenuContext"
 
-ContainerOnCommand=
-LineHighlightOnCommand=visible,false
-HeaderOnCommand=visible,false
-FooterOnCommand=visible,false
-CursorOnCommand=visible,false
-PageOnCommand=visible,false
+ContainerOnCommand=diffusealpha,1
 ShowExplanations=false
+# ShowExitRow must be false for this use of OptionRows in ScreenOptionsManageProfiles
+# having a dedicated OptionRow for Exit here can break input handling — pressing START
+# will move the player to the end of the list of OptionRows (the Exit row) instead of
+# choosing that OptionRow and having it *do* something (like bring up an overlay to
+# rename the profile)
 ShowExitRow=false
-AllowRepeatingChangeValueInput=true
 
 [OptionRowMiniMenuContext]
 TitleX=_screen.cx - 345


### PR DESCRIPTION
# Bug

Issue #230 on GitHub noted that the MiniMenu for ScreenOptionsManageProfiles would appear all white upon exiting and then re-entering it.

~~The bug seems to be that the OptionRows within the MiniMenu were being hidden.~~

~~This addresses the issue by explicitly setting `Fallback="OptionRowMiniMenu"` which (I think?) means it will inherit SL's `OptionRowMiniMenu` definitions first, rather than inheriting directly from the definitions in the _fallback theme.~~

~~I tested the _fallback theme directly and there's no analogous issue with MiniMenu OptionRows being hidden on subsequent viewings, so I have to conclude the issue is introduced somewhere in SL's metrics.~~

~~Thus, to be fully honest, I haven't fully reasoned through *why* this particular change fixes the issue.~~

## EDIT:

The bug stems from `ScreenMiniMenuContext` having its `ContainerOnCommand` explicitly set to an empty string and not having a `ContainerOffCommand`, leaving that to be inherited from somewhere up the tree.

`ContainerOffCommand` was coming from `[ScreenOptions]`, which applied `accelerate,0.3; diffusealpha,0` for style.  In `ScreenMiniMenuContext`, the container would be shown correctly the first time (empty OnCommand) then hidden (inherited OffCommand applies `diffusealpha,0`) and then never unhidden.

The fix I went with was to specify `ContainerOnCommand=diffusealpha,1`.

**Aside:** While poking at these metrics, I experimented with setting `ShowExitRow=true` since the only way out of the MiniMenu right now is with <kbd>Escape</kbd> on a keyboard.  I bumped into issues with that quickly and added inline comments to metrics.ini documenting what I found.