### PR TITLE
bug fix: don't diffuse emoji in OptionRow Titles

### DIFF
--- a/metrics.ini
+++ b/metrics.ini
@@ -403,8 +403,9 @@ ShowBpmInSpeedTitle=false
 TitleX=WideScale(26,40)
 TitleOnCommand=zoom,0.8;vertspacing,-8;horizalign,left;maxwidth,WideScale(128,120)
 TitleGainFocusCommand=%function(self)\
-	self:diffuse(PlayerColor(PLAYER_1)); \
-	MESSAGEMAN:Broadcast("OptionRowChanged", {Title=self}); \
+	self:diffuse(PlayerColor(PLAYER_1)) \
+	DiffuseEmojis(self) \
+	MESSAGEMAN:Broadcast("OptionRowChanged", {Title=self}) \
 end
 TitleLoseFocusCommand=diffuse,color("#FFFFFF")
 


### PR DESCRIPTION
# The Bug

If the player has emojis in their DisplayName, those emojis would be inappropriately diffused in ScreenOptionsManageProfiles, like this:

![Screen Shot 2021-01-15 at 10 55 19 PM](https://user-images.githubusercontent.com/1253483/104796818-91029880-5787-11eb-9890-db74ad6e9771.png)


## The Fix 

I used `DiffuseEmojis(self)` in metrics.ini, under the definition for `[OptionRow]`.  The result:

![Screen Shot 2021-01-15 at 10 55 40 PM](https://user-images.githubusercontent.com/1253483/104796848-d0c98000-5787-11eb-9f56-b247e3729ced.png)

## Considerations

Emojis in the the "modal" used to manage a single local profile (ScreenMiniMenuContext underlay.lua) were already handled correctly (debb9681260eca6bebfdd86494f00d7d0fee14ef) .

![Screen Shot 2021-01-15 at 11 07 31 PM](https://user-images.githubusercontent.com/1253483/104796853-d921bb00-5787-11eb-84e5-f24e93f17a4b.png)

Finally, it's arguably overkill to apply this diffuse correction to *all* OptionRow Titles rather than just places emoji could appear (anywhere user-input text can appear), but this shouldn't break anything.

A better fix (outside the scope of this pull request/for the future) would be engine-side; perhaps StepMania's BitmapText specification could be enhanced to allow designated font sheets to ignore diffuse commands.