### PR TITLE
bug fix: _wendy small's import

### DIFF
--- a/Fonts/Wendy/_wendy small.ini
+++ b/Fonts/Wendy/_wendy small.ini
@@ -64,6 +64,9 @@ AddToAllWidths=-16
 89=38
 90=28
 
+import=Wendy/_game chars 36px
+
+
 [alt]
 Line 0= Ą˘Ł¤ĽŚ§¨Š
 Line 1=ŞŤŹ­ŽŻ°ą˛ł
@@ -84,7 +87,7 @@ AddToAllWidths=-16
 4=60
 
 45=30
-46=30								
+46=30
 
 48=45
 
@@ -94,5 +97,3 @@ AddToAllWidths=-16
 78=30
 
 80=45
-
-import=Wendy/_game chars 36px


### PR DESCRIPTION
# Background

f539e765ed66e5006a7ce245bbc25feb59c2ab8b added support for the `[alt]` glyph block to _wendy small.  

It accidentally moved the `import` line to be under the `[alt]` section, causing the import to not occur.  The SM5 engine currently expects `import` to be under `[main]` (see [Font.cpp](https://github.com/stepmania/stepmania/blob/aab36dae8d1236b90383838b776a95c3218e7f3e/src/Font.cpp#L807)).  

# Bug

This resulted the engine falling back on the smaller version of the *_game chars* font, imported in `./Fonts/16px fonts/_16px fonts.ini`:

![Screen Shot 2021-01-16 at 3 00 00 AM](https://user-images.githubusercontent.com/1253483/104807049-b6080300-57a9-11eb-869c-3d4e2aec828f.png)

![Screen Shot 2021-01-16 at 3 00 11 AM](https://user-images.githubusercontent.com/1253483/104807052-bd2f1100-57a9-11eb-8982-08285ca126f5.png)

# Fix

This commit moves the import line back under the `[main]` section again, allowing the SM5 engine to correctly handle the import.