### PR TITLE
add NoRolls mod to Uncommon Modifiers as "Rolls to Holds"

### DIFF
--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -505,6 +505,8 @@ Five Key Menu=Off
 # in ITG, this was localized as "Hide Background" so we retain that here
 Cover=Hide BG
 
+# NoRolls is a modifier defined in the SM5 engine that transforms Rolls into Holds
+NoRolls=Rolls to Holds
 
 [OptionTitles]
 # Top-level Service menu items

--- a/metrics.ini
+++ b/metrics.ini
@@ -615,12 +615,13 @@ Scroll,3="mod,alternate;name,Alternate"
 Scroll,4="mod,cross;name,Cross"
 Scroll,5="mod,centered;name,Centered"
 
-Holds="4;selectmultiple"
+Holds="5;selectmultiple"
 HoldsDefault="mod,no planted,no floored,no twister,no holdrolls"
 Holds,1="mod,planted;name,Planted"
 Holds,2="mod,floored;name,Floored"
 Holds,3="mod,twister;name,Twister"
-Holds,4="mod,holdrolls;name,HoldsToRolls"
+Holds,4="mod,norolls;name,NoRolls"
+Holds,5="mod,holdrolls;name,HoldsToRolls"
 
 
 


### PR DESCRIPTION
Someone asked where the modifier to change rolls into holds was in SL:
https://www.reddit.com/r/Stepmania/comments/kriov0/simply_love_settings/

It turns out Simply Love didn't have it.  It's the `NoRolls` modifier (see [NoteDataUtil.cpp](https://github.com/stepmania/stepmania/blob/aab36dae8d1236b90383838b776a95c3218e7f3e/src/NoteDataUtil.cpp#L2754)).  

This commit adds it via metrics to appear in the `Notes → Holds` row.  The English text for this row still comfortably fits in its horizontal bounds in 4:3 aspect ratio.

![Screen Shot 2021-01-16 at 3 26 51 AM](https://user-images.githubusercontent.com/1253483/104807184-e7350300-57aa-11eb-866e-617614a1583c.png)