### PR TITLE
bug fix: BitmapText positioning in ScreenPlayerOptions

### DIFF
--- a/BGAnimations/ScreenPlayerOptions overlay/default.lua
+++ b/BGAnimations/ScreenPlayerOptions overlay/default.lua
@@ -263,7 +263,7 @@ for player in ivalues(GAMESTATE:GetHumanPlayers()) do
 		InitCommand=function(self)
 			self:diffuse(PlayerColor(player)):diffusealpha(0)
 			self:zoom(0.5):y(48)
-			self:x(player==PLAYER_1 and -100 or 150)
+			self:x(player==PLAYER_1 and WideScale(-77, -100) or WideScale(140,154))
 			self:shadowlength(0.55)
 		end,
 		OnCommand=function(self) self:linear(0.4):diffusealpha(1) end,

--- a/metrics.ini
+++ b/metrics.ini
@@ -839,13 +839,13 @@ ColorSelected=color("1,1,1,1")
 ColorNotSelected=color("0.85,0.85,0.85,1")
 CursorOnCommand=zoomx,1.33
 
-DisqualifyP1X=_screen.cx + WideScale(-200,-234)
+DisqualifyP1X=_screen.cx - WideScale(0,15) - WideScale(177,200)
 DisqualifyP1Y=SCREEN_TOP+48
-DisqualifyP1OnCommand=zoom,0.25;diffuse,PlayerColor(PLAYER_1)
+DisqualifyP1OnCommand=zoom,0.25;horizalign,right;diffuse,PlayerColor(PLAYER_1)
 
-DisqualifyP2X=_screen.cx + WideScale(200,234)
+DisqualifyP2X=_screen.cx - WideScale(0,15) + WideScale(177,200)
 DisqualifyP2Y=SCREEN_TOP+48
-DisqualifyP2OnCommand=zoom,0.25;diffuse,PlayerColor(PLAYER_2)
+DisqualifyP2OnCommand=zoom,0.25;horizalign,left;diffuse,PlayerColor(PLAYER_2)
 
 
 


### PR DESCRIPTION
# Bug

The BitmapText actors for SpeedModHelper were not cleanly centered above the OptionRow choices immediately below. It looked fine in 16:9 and acceptable in 4:3, but was visibly awry in 21:9.

Additionally, the "Disqualified" BitmapText actors overlapped with the SpeedModHelpers in 4:3.

![21-9-broken](https://user-images.githubusercontent.com/1253483/104867969-17e27d00-5910-11eb-85b2-aa7e3ffba929.png)
SpeedModHelper text off-center in 21:9.

![4-3_broken](https://user-images.githubusercontent.com/1253483/104867955-0e591500-5910-11eb-9050-f9cc45c522c4.png)
Text overlap in 4:3.


# Fix 
This addresses both those issues by calculating positions using `WideScale()`.

Tested in 4:3, 16:10, 16:9, and 21:9.

---

**EDIT:** Removed screenshots from the old code since they no longer reflect how the new code looks.