### PR TITLE
new feature: track last selected song in Edit Mode

### DIFF
--- a/BGAnimations/ScreenEditMenu underlay.lua
+++ b/BGAnimations/ScreenEditMenu underlay.lua
@@ -104,6 +104,32 @@ local t = Def.ActorFrame{
 	end
 }
 
+t[#t+1] = Def.Actor{
+	InitCommand=function()
+		local str = ThemePrefs.Get("EditModeLastSeenSong")
+
+		if str ~= "" then
+			local song = SONGMAN:FindSong( str )
+			if song then
+				-- If a song was saved in ThemePrefs, set GAMESTATE's CurrentSong now
+				-- during Init.  In the engine's code, EditMenu::RefreshAll() is called
+				-- once at the end of EditMode::Load(), and uses GAMESTATE's current song.
+				GAMESTATE:SetCurrentSong( song )
+			end
+		end
+	end,
+	OffCommand=function()
+		local song = GAMESTATE:GetCurrentSong()
+
+		if song then
+			-- the string returned by song:GetSongDir() isn't usable by SONGMAN:FindSong()
+			local path = ("/%s/%s"):format(song:GetGroupName(), Basename(song:GetSongDir()))
+			ThemePrefs.Set("EditModeLastSeenSong", path)
+			ThemePrefs.Save()
+		end
+	end
+}
+
 
 -- the overall BG
 t[#t+1] = Def.Quad {

--- a/Scripts/99 SL-ThemePrefs.lua
+++ b/Scripts/99 SL-ThemePrefs.lua
@@ -102,6 +102,19 @@ SL_CustomPrefs.Get = function()
 		},
 
 		-- - - - - - - - - - - - - - - - - - - -
+		-- Save the last seen song in Edit Mode to disk so that ScreenEditMenu
+		-- can load with it already selected, instead of the first song in the
+		-- first pack.  See: ./BGAnimations/ScreenEditMenu underlay.lua
+		EditModeLastSeenSong =
+		{
+			Default = "",
+			Validation = function(val)
+				if SONGMAN:FindSong(val) then return true end
+				return false
+			end
+		},
+
+		-- - - - - - - - - - - - - - - - - - - -
 		-- MenuTimer values for various screens
 		ScreenSelectMusicMenuTimer =
 		{
@@ -210,8 +223,10 @@ SL_CustomPrefs.Validate = function()
 		for k,v in pairs( file[theme_name] ) do
 			if sl_prefs[k] then
 				-- if we reach here, the setting exists in both the master definition as well as the user's ThemePrefs.ini
-				-- so perform some rudimentary validation; check for both type mismatch and presence in sl_prefs
-				if type( v ) ~= type( sl_prefs[k].Default )
+				-- if the ThemePref has its own validation function, use that
+				-- otherwise check for type mismatch and presence in sl_prefs
+				if (type(sl_prefs[k].Validation)=="function" and sl_prefs[k].Validation(v) ~= true)
+				or type( v ) ~= type( sl_prefs[k].Default )
 				or not FindInTable(v, (sl_prefs[k].Values or sl_prefs[k].Choices))
 				then
 					-- overwrite the user's erroneous setting with the default value


### PR DESCRIPTION
# Request

GitHub issue #249 requested a way to initialize ScreenEditMenu with the song that was most recently being worked on in EditMode, rather than always initializing to the first song in the first pack.

This implements that request.

# Implementation

I've created a new ThemePref under the key `EditModeLastSeenSong`.

A string in the format of `/group_name/song_name` is saved to it during ScreenEditMenu's OffCommand.  That value is likewise used to set `GAMESTATE`'s CurrentSong during ScreenEditMenu's InitCommand.

Conveniently, the `RefreshAll()` method in EditMenu.cpp [uses GAMESTATE's CurrentSong](https://github.com/stepmania/stepmania/blob/aab36dae8d1236b90383838b776a95c3218e7f3e/src/EditMenu.cpp#L203-L204), and `RefreshAll()` is called [once](https://github.com/stepmania/stepmania/blob/aab36dae8d1236b90383838b776a95c3218e7f3e/src/EditMenu.cpp#L193) after the EditMenu finishes loading.

## ThemePrefs Validation Extended

Storing a custom string like this in ThemePrefs required me to extend ThemePrefs validation.

As noted [in the discussion](https://github.com/Simply-Love/Simply-Love-SM5/issues/249#issuecomment-767319643), ThemePrefs was previously validating everything read from disk and only allowing values within a hard-coded range, specified in `./Scripts/99 SL-ThemePrefs.lua`.  This approach didn't work well here, where the range of acceptable values would be a unique string for every installed song.

It's now possible for Simply Love's ThemePrefs to specify their own custom Validation functions, instead of just validating on variable type and presence in a hard-coded table.

# Considerations

1. I considered storing this in the `Simply Love UserPrefs.ini` associated with profiles, but I don't think ScreenEditMenu has profiles loaded.

2. There will be an initial frame or two where the first group banner and first song banner are shown before updating to display what we've set here.  I didn't dig into addressing this as it is brief and does not impact usability, but I am noting it here.