### PR TITLE
enhancement: add "peak bpm" to StepStats side pane

### DIFF
--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/StepStatistics/DensityGraph.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/StepStatistics/DensityGraph.lua
@@ -79,51 +79,6 @@ local histogram_amv = Scrolling_NPS_Histogram(player, width, height)..{
 	end
 }
 
--- PeakNPS text
-local text = LoadFont("Common Normal")..{
-	InitCommand=function(self)
-		self:zoom(0.9)
-		self:halign( PlayerNumber:Reverse()[OtherPlayer[player]] )
-		self:vertalign(bottom)
-
-		-- flip alignment if ultrawide and both players joined because the pane
-		-- will now appear on the player's side of the screen rather than opposite
-		if IsUltraWide and #GAMESTATE:GetHumanPlayers() > 1 then
-			self:halign( PlayerNumber:Reverse()[player] )
-		end
-	end,
-	PeakNPSUpdatedMessageCommand=function(self)
-		local my_peak = GAMESTATE:Env()[pn.."PeakNPS"]
-
-		if my_peak == nil then
-			self:settext("")
-			return
-		end
-
-		if player == PLAYER_1 then
-			self:x(_screen.w*0.5 - SL_WideScale(6,59))
-
-			if NoteFieldIsCentered then
-				self:x(_screen.w*0.5 - 134)
-			end
-			if IsUltraWide and #GAMESTATE:GetHumanPlayers() > 1 then
-				self:x(52)
-			end
-		else
-			self:x(SL_WideScale(6,130))
-			if NoteFieldIsCentered then
-				self:x(69)
-			end
-			if IsUltraWide and #GAMESTATE:GetHumanPlayers() > 1 then
-				self:x(180)
-			end
-		end
-
-		self:y( -self:GetHeight()/2 - 2 )
-		self:settext( ("%s: %g"):format(THEME:GetString("ScreenGameplay", "PeakNPS"), round(my_peak * SL.Global.ActiveModifiers.MusicRate,2)) )
-	end,
-}
-
 local graph_and_lifeline = Def.ActorFrame{
 
 	CurrentSongChangedMessageCommand=function(self)
@@ -239,7 +194,6 @@ local graph_and_lifeline = Def.ActorFrame{
 	},
 }
 
-af[#af+1] = text
 af[#af+1] = bg
 af[#af+1] = graph_and_lifeline
 

--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/StepStatistics/PeakBPMAndNPS.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/StepStatistics/PeakBPMAndNPS.lua
@@ -1,0 +1,71 @@
+local player = ...
+local pn = ToEnumShortString(player)
+
+local NoteFieldIsCentered = (GetNotefieldX(player) == _screen.cx)
+local IsUltraWide = (GetScreenAspectRatio() > 21/9)
+
+
+-- Peak BPM and Peak NPS values
+local values = LoadFont("Common Normal")..{
+	InitCommand=function(self)
+		self:horizalign(left)
+		self:vertalign(bottom)
+		self:vertspacing(-3)
+	end,
+	PeakNPSUpdatedMessageCommand=function(self)
+		-- don't use the GetDisplayBPMs(player) helper function here because in CourseMode
+		-- that would give us the min/max BPM for the overall Course; in this case
+		-- we want the peak bpm value to update with each new TrailEntry in the Course
+		local steps
+		if GAMESTATE:IsCourseMode() then
+			local trail_entry = GAMESTATE:GetCurrentTrail(player):GetTrailEntry(GAMESTATE:GetCourseSongIndex())
+			if trail_entry then steps = trail_entry:GetSteps() end
+		else
+			steps = GAMESTATE:GetCurrentSteps(player)
+		end
+
+		local bpms =  steps:GetTimingData():GetActualBPM()
+		local peak_bpm = type(bpms)=="table" and tostring(round(bpms[2] * SL.Global.ActiveModifiers.MusicRate,2)) or ""
+
+		local peak_nps = GAMESTATE:Env()[pn.."PeakNPS"]
+		if peak_nps then
+			peak_nps = tostring(round(peak_nps * SL.Global.ActiveModifiers.MusicRate,2))
+		else
+			peak_nps = ""
+		end
+
+		self:settext( ("%s\n%s"):format(peak_bpm, peak_nps) )
+	end,
+}
+
+-- Peak BPM and Peak NPS labels
+local labels = LoadFont("Common Normal")..{
+	Text=("%s    \n%s    "):format(THEME:GetString("ScreenGameplay", "PeakBPM"), THEME:GetString("ScreenGameplay", "PeakNPS")),
+	InitCommand=function(self)
+		self:zoom(0.833)
+		self:vertspacing(1)
+		self:horizalign(right)
+		self:vertalign(bottom)
+	end
+}
+
+local af = Def.ActorFrame{}
+af.InitCommand=function(self)
+	self:x( player==PLAYER_1 and 58 or -82 )
+
+	-- adjust for smaller panes when notefield is centered
+	if NoteFieldIsCentered and IsUsingWideScreen() then
+		self:x( player==PLAYER_1 and 58 or -86 )
+
+	-- adjust for smaller panes when ultrawide and both players joined
+	elseif IsUltraWide and #GAMESTATE:GetHumanPlayers() > 1 then
+		self:x( player==PLAYER_1 and -83 or 54 )
+	end
+
+	self:y( 50 )
+end
+
+af[#af+1] = values
+af[#af+1] = labels
+
+return af

--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/StepStatistics/default.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/StepStatistics/default.lua
@@ -89,6 +89,7 @@ af[#af+1] = Def.ActorFrame{
 	LoadActor("./TapNoteJudgments.lua", player),
 	LoadActor("./HoldsMinesRolls.lua", player),
 	LoadActor("./Time.lua", player),
+	LoadActor("./PeakBPMAndNPS.lua", player),
 }
 
 af[#af+1] = LoadActor("./DensityGraph.lua", {player, sidepane_width})

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -206,7 +206,8 @@ SplitBPMs=(split)
 
 ##############################################
 [ScreenGameplay]
-PeakNPS=Peak NPS
+PeakNPS=peak nps
+PeakBPM=peak bpm
 Remaining=remaining
 Song=song
 Course=course


### PR DESCRIPTION
# Motivation

For very long songs (particularly "mixes" of multiple songs), the current BPM may not be the peak BPM, and live stream viewers may want to know how fast the song eventually gets.

![Screen Shot 2021-01-31 at 5 45 26 PM](https://user-images.githubusercontent.com/1253483/106675162-9d0d9900-6582-11eb-8296-eff5fa259783.png)

# Changes
This adds a "peak bpm" label and value to the StepStats side pane.

![Screen Shot 2021-02-02 at 6 00 11 PM](https://user-images.githubusercontent.com/1253483/106675209-b4e51d00-6582-11eb-8c4b-dfdb214f5432.png)

## Testing performed

Tested in both normal gameplay and in CourseMode (the peak bpm updates with each new TrailEntry).

Tested using PLAYER_1 and then PLAYER_2.

Tested in the following layout conditions/aspect ratios:
  * 4:3
  * 16:9
  * 16:9 with Center1Player
  * 21:9
  * 21:9 with Center1Player
  * 21:9 with both StepStats panes active
  
  ## Considerations
  
  I've updated en.ini with new English text but not other language files.