### PR TITLE
Fix EditModeLastSeenSong validation

### DIFF
--- a/Scripts/99 SL-ThemePrefs.lua
+++ b/Scripts/99 SL-ThemePrefs.lua
@@ -108,10 +108,6 @@ SL_CustomPrefs.Get = function()
 		EditModeLastSeenSong =
 		{
 			Default = "",
-			Validation = function(val)
-				if SONGMAN:FindSong(val) then return true end
-				return false
-			end
 		},
 
 		-- - - - - - - - - - - - - - - - - - - -
@@ -222,12 +218,14 @@ SL_CustomPrefs.Validate = function()
 		-- loop through key/value pairs retrieved and do some basic validation
 		for k,v in pairs( file[theme_name] ) do
 			if sl_prefs[k] then
-				-- if we reach here, the setting exists in both the master definition as well as the user's ThemePrefs.ini
-				-- if the ThemePref has its own validation function, use that
-				-- otherwise check for type mismatch and presence in sl_prefs
-				if (type(sl_prefs[k].Validation)=="function" and sl_prefs[k].Validation(v) ~= true)
-				or type( v ) ~= type( sl_prefs[k].Default )
-				or not FindInTable(v, (sl_prefs[k].Values or sl_prefs[k].Choices))
+				-- if we reach here, the setting exists in both the master definition as well
+				-- as the user's ThemePrefs.ini so perform some rudimentary validation; check
+				-- for both type mismatch and presence in sl_prefs
+
+				local values = sl_prefs[k].Values or sl_prefs[k].Choices
+
+				if type( v ) ~= type( sl_prefs[k].Default )
+				or (values and not FindInTable(v, values))
 				then
 					-- overwrite the user's erroneous setting with the default value
 					ThemePrefs.Set(k, sl_prefs[k].Default)


### PR DESCRIPTION
Today I noticed following error in the SM logs:

```
/////////////////////////////////////////
WARNING: Lua runtime error: /Themes/Simply-Love-SM5/Scripts/99 SL-ThemePrefs.lua:112: attempt to index global 'SONGMAN' (a nil value)
WARNING: /Themes/Simply-Love-SM5/Scripts/99 SL-ThemePrefs.lua:112: Validation(val = ,(*temporary) = (null),(*temporary) = (null),(*temporary) = (null),(*temporary) = attempt to index global 'SONGMAN' (a nil value))
WARNING: /Themes/Simply-Love-SM5/Scripts/99 SL-ThemePrefs.lua:228: Validate(file = (null),sl_prefs = (null),theme_name = Simply-Love-SM5,(for generator) = (null),(for state) = (null),(for control) = EditModeLastSeenSong,k = EditModeLastSeenSong,v = )
WARNING: /Themes/Simply-Love-SM5/Scripts/99 SL-ThemePrefs.lua:254: Init()
WARNING: /Themes/Simply-Love-SM5/Scripts/99 SL-ThemePrefs.lua:261: main()
/////////////////////////////////////////
````

This was introduced in 19d3317514a7864a92dfb048de66b9ad6b187175 when adding the EditModeLastSeenSong theme preference. It's validation function calls SONGMAN:FindSong(), but at the point in the initialization sequence where the validation is performed SONGMAN is not initialized yet but nil.

The edit menu screen checks validity of the song path with SONGMAN:FindSong() again anyway, so we can just skip the validation in the first place and circumvent that issue.