### PR TITLE
fix if-else flow for ThemePrefs validation

### DIFF
--- a/Scripts/99 SL-ThemePrefs.lua
+++ b/Scripts/99 SL-ThemePrefs.lua
@@ -222,15 +222,29 @@ SL_CustomPrefs.Validate = function()
 		-- loop through key/value pairs retrieved and do some basic validation
 		for k,v in pairs( file[theme_name] ) do
 			if sl_prefs[k] then
-				-- if we reach here, the setting exists in both the master definition as well as the user's ThemePrefs.ini
-				-- if the ThemePref has its own validation function, use that
-				-- otherwise check for type mismatch and presence in sl_prefs
-				if (type(sl_prefs[k].Validation)=="function" and sl_prefs[k].Validation(v) ~= true)
-				or type( v ) ~= type( sl_prefs[k].Default )
-				or not FindInTable(v, (sl_prefs[k].Values or sl_prefs[k].Choices))
-				then
-					-- overwrite the user's erroneous setting with the default value
-					ThemePrefs.Set(k, sl_prefs[k].Default)
+				-- If we reach here, the setting exists in both the master definition
+				-- as well as the user's ThemePrefs.ini, so at this point,
+				-- perform validation on the value retrieved for this setting.
+				-- Maybe the user edited ThemePrefs.ini by hand and
+				-- introduced a value that isn't valid; this happens a lot.
+
+				-- if the ThemePref has its own custom validation function, prefer that
+				if type(sl_prefs[k].Validation) == "function" then
+					if not sl_prefs[k].Validation(v) then
+						-- the ThemePref value retrieved from disk failed validation,
+						-- so overwrite it with the default value
+						ThemePrefs.Set(k, sl_prefs[k].Default)
+					end
+
+				-- if this ThemePref doesn't have a custom validation function,
+				-- check for type mismatch and presence in sl_prefs
+				else
+					if (type( v ) ~= type( sl_prefs[k].Default ))
+					or (not FindInTable(v, (sl_prefs[k].Values or sl_prefs[k].Choices)))
+					then
+						-- Rudimentary validaiton failed, so overwrite with the default value.
+						ThemePrefs.Set(k, sl_prefs[k].Default)
+					end
 				end
 
 			-- It's possible a setting exists in the ThemePrefs.ini file, but does not exist


### PR DESCRIPTION
This fixes a logical flow bug I introduced in 19d3317514a7864a92dfb048de66b9ad6b187175, which added custom validation functions for SL's ThemePrefs.

In that commit, I'd used the statement:

```lua
if (type(sl_prefs[k].Validation)=="function" and sl_prefs[k].Validation(v) ~= true)
or type( v ) ~= type( sl_prefs[k].Default )
or not FindInTable(v, (sl_prefs[k].Values or sl_prefs[k].Choices))
then
     -- overwrite setting because it wasn't valid
end
```

Since not all of SL's ThemePrefs have custom Validation functions, I'd wanted this statement to:

A. prefer the Validation function if there is one
  A1. overwrite user setting if validation fails
  A2. allow user setting if validation passes

B. validate using Lua type() and setting presence in a predefined table
  B1. overwrite user setting if validation fails
  B2. allow user setting if validation fails

I'd wanted it to validate using A if available, or B if not, but never both. 

I'd failed to consider that if A was available, and it passed validation, logical evaluation of the statement would proceed to B where it might throw a Lua error.  In the case of `EditModeLastSeenSong`, its definition in `SL_CustomPrefs` doesn't have tables for `Choices` or `Values` and can't be indexed via `sl_prefs[k].Values`.

This commit rewrites the single if block into an if-else block that meets my original goals.