### PR TITLE
fix redirect when canceling PromptToResetPrefs

### DIFF
--- a/BGAnimations/ScreenPromptToResetPreferencesToStock overlay.lua
+++ b/BGAnimations/ScreenPromptToResetPreferencesToStock overlay.lua
@@ -24,7 +24,9 @@ local InputHandler = function(event)
 
 		elseif event.GameButton == "Back" or (event.GameButton == "Start" and active_index == 2) then
 			-- send the player back to the previous screen
-			SCREENMAN:GetTopScreen():SetNextScreenName("ScreenSelectGame"):StartTransitioningScreen("SM_GoToNextScreen")
+			local top_screen = SCREENMAN:GetTopScreen()
+			local prev_screen_name = top_screen:GetPrevScreenName()
+			top_screen:SetNextScreenName(prev_screen_name):StartTransitioningScreen("SM_GoToNextScreen")
 
 		elseif event.GameButton == "Start" and (active_index == 0 or active_index == 1) then
 


### PR DESCRIPTION
As already noted in the commit message for ce1413af25a0e07d9e45a2bff6c87f832b0ac618:

> ScreenSelectGame was renamed to ScreenSystemOptions in a80a3e887ac934afe11504809e882656d6285179.

This fixes a lingering hardcoded string literal of `"ScreenSelectGame"` in `BGAnimations/ScreenPromptToResetPreferencesToStock overlay.lua`.