### PR TITLE
Fix Lua error when entering the operator menu via key bind

### DIFF
--- a/BGAnimations/ScreenSystemLayer overlay.lua
+++ b/BGAnimations/ScreenSystemLayer overlay.lua
@@ -75,10 +75,12 @@ for player in ivalues(PlayerNumber) do
 			end
 
 			local screen = SCREENMAN:GetTopScreen()
-			if THEME:HasMetric(screen:GetName(), "ShowPlayerAvatar") then
-				self:visible( THEME:GetMetric(screen:GetName(), "ShowPlayerAvatar") )
-			else
-				self:visible( THEME:GetMetric(screen:GetName(), "ShowCreditDisplay") )
+			if screen then
+				if THEME:HasMetric(screen:GetName(), "ShowPlayerAvatar") then
+					self:visible( THEME:GetMetric(screen:GetName(), "ShowPlayerAvatar") )
+				else
+					self:visible( THEME:GetMetric(screen:GetName(), "ShowCreditDisplay") )
+				end
 			end
 		end,
 	}


### PR DESCRIPTION
```
/////////////////////////////////////////
WARNING: Error playing command:/Themes/Simply-Love-SM5/BGAnimations/ScreenSystemLayer overlay.lua:78: attempt to index local 'screen' (a nil value)
WARNING: /Themes/Simply-Love-SM5/BGAnimations/ScreenSystemLayer overlay.lua:78: unknown(self = (null),path = (null),screen = (null),(*temporary) = (null),(*temporary) = (null),(*temporary) = 0,(*temporary) = (null),(*temporary) = 32,(*temporary) = (null),(*temporary) = attempt to index local 'screen' (a nil value))
/////////////////////////////////////////
```

This is the only place in the file where we don't check for nil after calling `SCREENMAN:GetTopScreen()`.