### PR TITLE
bug fix: Ensure DateTime footer appears in CourseMode's Evaluation screen

### DIFF
--- a/BGAnimations/ScreenEvaluation decorations.lua
+++ b/BGAnimations/ScreenEvaluation decorations.lua
@@ -1,0 +1,67 @@
+-- Load ScreenWithMenuElements decorations.lua, which handles
+-- SL's normal header and footer, and then append an extra AF and BitmapText
+-- for displaying the date and time at the center-bottom of screens that
+-- inherit from ScreenEvaluation.  This includes ScreenEvaluationStage,
+-- ScreenEvaluationNonstop, and ScreenEvaluationSummary.
+
+-----------------------------------------------------------------------
+-- first, load the normal decorations used for ScreenWithMenuElements
+local decorations = LoadActor(THEME:GetPathB("ScreenWithMenuElements", "decorations.lua"))
+
+-----------------------------------------------------------------------
+-- next, define a BitmapText that displays the date and time, and add it to
+-- a local ActorFrame so that it can be assigned a custom update function
+-- that refreshes the date and time if the player stays on this screen for a while
+
+local DateFormat = "%04d/%02d/%02d %02d:%02d"
+local timestamp_bmt = nil
+
+local Update = function(af)
+	if timestamp_bmt then
+		timestamp_bmt:playcommand("Refresh")
+	end
+end
+
+local af = Def.ActorFrame{}
+af.Name="DateTimeAF"
+af.InitCommand=function(self)
+	self:SetUpdateFunction(Update)
+end
+
+-- add a BitmapText to this ActorFrame
+af[#af+1] = LoadFont("Wendy/_wendy monospace numbers")..{
+	Name="DateTime",
+	InitCommand=function(self)
+		timestamp_bmt = self
+
+		self:x(_screen.cx):horizalign(center)
+		self:zoom(0.18)
+	end,
+	OnCommand=function(self)
+		-- y offset for ScreenEvaluationStage or ScreenEvaluationNonstop
+		-- or anything else that inherits from ScreenEvaluation
+		self:y(_screen.h - 15)
+
+		-- use a slightly diffrent y offset for ScreenEvaluationSummary
+		local screen = SCREENMAN:GetTopScreen()
+		if screen then
+			if screen:GetName() == 'ScreenEvaluationSummary' then
+				self:y(_screen.h - 20)
+			end
+		end
+
+		self:diffuse(ThemePrefs.Get("RainbowMode") and Color.Black or Color.White)
+		self:playcommand("Refresh")
+	end,
+	RefreshCommand=function(self)
+		self:settext(DateFormat:format(Year(), MonthOfYear()+1, DayOfMonth(), Hour(), Minute()))
+	end
+}
+
+-----------------------------------------------------------------------
+-- finally, add the DateTimeAF to the decorations ActorFrame
+decorations[#decorations+1] = af
+
+-- return the decorations ActorFrame so that evaluation screens get
+-- a header, a footer, and a datetime
+return decorations

--- a/BGAnimations/ScreenSystemLayer overlay.lua
+++ b/BGAnimations/ScreenSystemLayer overlay.lua
@@ -103,13 +103,9 @@ t[#t+1] = Def.ActorFrame {
 -- or SM(text)
 
 local bmt = nil
-local timestamp = nil
 
 -- SystemMessage ActorFrame
 t[#t+1] = Def.ActorFrame {
-	InitCommand=function(self)
-		self:SetUpdateFunction(updateTimestamp)
-	end,
 	SystemMessageMessageCommand=function(self, params)
 		bmt:settext( params.Message )
 
@@ -209,49 +205,6 @@ t[#t+1] = LoadFont("Common Footer")..{
 		elseif GAMESTATE:GetCoinMode() == "CoinMode_Home" then
 			self:settext('')
 		end
-	end
-}
-
-function updateTimestamp(af)
-	if timestamp then
-		timestamp:playcommand("Refresh")
-	end
-end
-
--- Date & time at lower-center of screen
--- This is only shown on the ScreenEvaluationStage and ScreenEvaluationSummary
--- screens. The above actor is not shown on either screen, so it doesn't
--- overlap with it.
-t[#t+1] = LoadFont("Wendy/_wendy monospace numbers")..{
-	InitCommand=function(self)
-		timestamp = self
-
-		self:x(_screen.cx):horizalign(center)
-		self:zoom(0.18)
-	end,
-
-	OnCommand=function(self) self:playcommand("Refresh") end,
-	ScreenChangedMessageCommand=function(self) self:playcommand("Refresh") end,
-
-	RefreshCommand=function(self)
-		local screen = SCREENMAN:GetTopScreen()
-		local visible = false
-
-		if screen then
-			if screen:GetName() == 'ScreenEvaluationStage' then
-				visible = true
-				self:y(_screen.h - 15)
-			elseif screen:GetName() == 'ScreenEvaluationSummary' then
-				visible = true
-				self:y(_screen.h - 20)
-			end
-		end
-
-		self:visible(visible)
-		self:diffuse(ThemePrefs.Get("RainbowMode") and Color.Black or Color.White)
-
-		local DateFormat = "%04d/%02d/%02d %02d:%02d"
-		self:settext(DateFormat:format(Year(), MonthOfYear()+1, DayOfMonth(), Hour(), Minute()))
 	end
 }
 


### PR DESCRIPTION
# About

Commit e26408955220e706acc6145528adad9842fa5e7c added support for showing the date and time in a BitmapText actor at the bottom of SL's evaluation screens.

It did so by adding code to `ScreenSystemLayer overlay`, and then by toggling visibility of the BitmapText actor based on the current screen's name.  

This worked, though the implementation accidentally left `"ScreenEvaluationNonstop"` out of the if-else chain that checked screen name, causing the Date and Time to not appear at the bottom of CourseMode's evaluation screen.

# Fix

From a player's perspective, this pull request fixes a bug preventing the date and time from appearing at the bottom of CourseMode's evaluation screen.


## Details 

From a dev perspective, there are a handful of small changes here:

1. Extracted the BitmapText and accompanying ActorFrame out of `ScreenSystemLayer overlay` and moved them to `ScreenEvaluation decorations`<br>
Since the date and time only appear in evaluation screens, it didn't seem necessary to have their code in a global overlay.

2. Removed code to toggle visibility based on current screen name. It's not needed any longer. This flows directly from change 1.

3. Adjusted the y-offset code that relies on current screen name to more generally accommodate all screens that inherit from `ScreenEvaluation`. Again, this flows directly from change 1.<br>
In SL right now, this includes `ScreenEvaluationStage`, `ScreenEvaluationNonstop`, and `ScreenEvaluationSummary`.

4. Changed the scope of the update function be local to this file. There didn't seem to be a need to add it to Lua's global namespace.

5. Added inline comments providing context and explanation.