### PR TITLE
remove lingering references to ReceptorArrowsPosition

### DIFF
--- a/Languages/de.ini
+++ b/Languages/de.ini
@@ -634,7 +634,6 @@ GameplayExtras=Gameplay Extras
 GameplayExtrasB=Gameplay Extras
 MeasureCounterOptions=Measure Counter\nOptions
 MeasureCounter=Measure Counter
-ReceptorArrowsPosition=Receptor Arrows\nPosition
 LifeMeterType=Lebensenergie Art
 
 

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -626,7 +626,6 @@ GameplayExtras=Gameplay Extras
 GameplayExtrasB=Gameplay Extras
 MeasureCounterOptions=Measure Counter\nOptions
 MeasureCounter=Measure Counter
-ReceptorArrowsPosition=Receptor Arrows\nPosition
 LifeMeterType=LifeMeter Type
 ScreenAfterPlayerOptions2=What comes next?
 

--- a/Languages/es.ini
+++ b/Languages/es.ini
@@ -637,7 +637,6 @@ GameplayExtras=Extras de Juego
 GameplayExtrasB=Extras de Juego
 MeasureCounterOptions=Opciones de\nMedidor de pasos
 MeasureCounter=Medidor de Pasos
-ReceptorArrowsPosition=Posición de\nReceptores
 LifeMeterType=Tipo de Medidor de Vida
 ScreenAfterPlayerOptions2=Siguiente Pantalla
 

--- a/Languages/fr.ini
+++ b/Languages/fr.ini
@@ -521,7 +521,6 @@ GameplayExtras=Options additonnelles
 GameplayExtrasB=Options additonnelles
 MeasureCounterOptions=Options du\ncompteur de mesures
 MeasureCounter=Compteur de mesures
-ReceptorArrowsPosition=Position des\nrécepteurs
 LifeMeterType=Type de barre de vie
 
 # ScreenPlayerOptions3

--- a/Languages/it.ini
+++ b/Languages/it.ini
@@ -1230,7 +1230,6 @@ GameplayExtras=Opzioni Extra
 GameplayExtrasB=Opzioni Extra
 MeasureCounterOptions=Opzioni di\nConteggio misure
 MeasureCounter=Conteggio misure
-ReceptorArrowsPosition=Posizione dei\nRecettori
 LifeMeterType=Barra della vita
 WorstTimingWindow=Disabilita finestre\ndi timing
 

--- a/Languages/ja.ini
+++ b/Languages/ja.ini
@@ -484,7 +484,6 @@ GameplayExtras=Gameplay Extras
 GameplayExtrasB=Gameplay Extras
 MeasureCounterOptions=Measure Counter\nOptions
 MeasureCounter=Measure Counter
-ReceptorArrowsPosition=Receptor Arrows\nPosition
 LifeMeterType=LifeMeter Type
 
 # ScreenPlayAgain
@@ -641,7 +640,6 @@ MeasureCounterOptions=Measure Counterの表示をカスタマイズできます�
 MeasureCounter=Streamの小節数を表示することができます。
 TimingWindows=一部の判定を無効化します。
 ScreenAfterPlayerOptions2=他の曲を選択するか、一つ前のオプション画面に戻ります。
-ReceptorArrowsPosition=判定位置を上下に動かすことができます。
 LifeMeterType="Surround": ライフゲージが背景に縦向きに表示されます。\n"Vertical": ライフゲージがPlayField横に縦向きに表示されます。
 
 # Screen Profiles

--- a/Languages/pt-br.ini
+++ b/Languages/pt-br.ini
@@ -1226,7 +1226,6 @@ GameplayExtras=Extras do Jogo
 GameplayExtrasB=Extras do Jogo
 MeasureCounterOptions=Opções do\nMedidor de setas
 MeasureCounter=Medidor de setas
-ReceptorArrowsPosition=Posição dos\nReceptores
 LifeMeterType=Tipo de Medidor de Vida
 
 # ScreenPlayAgain

--- a/Scripts/SL-PlayerProfiles.lua
+++ b/Scripts/SL-PlayerProfiles.lua
@@ -7,46 +7,59 @@
 -- For now, this table is local to this file, but might be moved into the SL table (or something)
 -- in the future to facilitate type checking in ./Scripts/SL-PlayerOptions.lua and elsewhere.
 
-local profile_whitelist = {
-	SpeedModType = "string",
-	SpeedMod = "number",
-	Mini = "string",
-	NoteSkin = "string",
-	JudgmentGraphic = "string",
-	ComboFont = "string",
-	HoldJudgment = "string",
+local permitted_profile_settings = {
+
+	----------------------------------
+	-- "Main Modifiers"
+	-- OptionRows that appear in SL's first page of PlayerOptions
+
+	SpeedModType     = "string",
+	SpeedMod         = "number",
+	Mini             = "string",
+	NoteSkin         = "string",
+	JudgmentGraphic  = "string",
+	ComboFont        = "string",
+	HoldJudgment     = "string",
 	BackgroundFilter = "string",
 
-	HideTargets = "boolean",
-	HideSongBG = "boolean",
-	HideCombo = "boolean",
-	HideLifebar = "boolean",
-	HideScore = "boolean",
-	HideDanger = "boolean",
-	HideComboExplosions = "boolean",
+	----------------------------------
+	-- "Advanced Modifiers"
+	-- OptionRows that appear in SL's second page of PlayerOptions
 
-	LifeMeterType = "string",
-	DataVisualizations = "string",
-	TargetScore = "number",
+	HideTargets          = "boolean",
+	HideSongBG           = "boolean",
+	HideCombo            = "boolean",
+	HideLifebar          = "boolean",
+	HideScore            = "boolean",
+	HideDanger           = "boolean",
+	HideComboExplosions  = "boolean",
+
+	LifeMeterType        = "string",
+	DataVisualizations   = "string",
+	TargetScore          = "number",
 	ActionOnMissedTarget = "string",
 
-	MeasureCounter = "string",
-	MeasureCounterLeft = "boolean",
-	MeasureCounterUp = "boolean",
-	HideLookahead = "boolean",
+	MeasureCounter       = "string",
+	MeasureCounterLeft   = "boolean",
+	MeasureCounterUp     = "boolean",
+	HideLookahead        = "boolean",
 
-	ColumnFlashOnMiss = "boolean",
-	SubtractiveScoring = "boolean",
-	Pacemaker = "boolean",
-	MissBecauseHeld = "boolean",
-	NPSGraphAtTop = "boolean",
+	ColumnFlashOnMiss    = "boolean",
+	SubtractiveScoring   = "boolean",
+	Pacemaker            = "boolean",
+	MissBecauseHeld      = "boolean",
+	NPSGraphAtTop        = "boolean",
 
-	ReceptorArrowsPosition = "string",
+
+	----------------------------------
+	-- Profile Settings without OptionRows
+	-- these settings are saved per-profile, but are transparently managed by the theme
+	-- they have no player-facing OptionRows
 
 	PlayerOptionsString = "string",
 
-	EvalPanePrimary   = "number",
-	EvalPaneSecondary = "number",
+	EvalPanePrimary     = "number",
+	EvalPaneSecondary   = "number",
 }
 
 -- -----------------------------------------------------------------------
@@ -75,10 +88,10 @@ LoadProfileCustom = function(profile, dir)
 
 		-- for each key/value pair read in from the player's profile
 		for k,v in pairs(filecontents) do
-			-- ensure that the key has a corresponding key in profile_whitelist
-			if profile_whitelist[k]
-			--  ensure that the datatype of the value matches the datatype specified in profile_whitelist
-			and type(v)==profile_whitelist[k] then
+			-- ensure that the key has a corresponding key in permitted_profile_settings
+			if permitted_profile_settings[k]
+			--  ensure that the datatype of the value matches the datatype specified in permitted_profile_settings
+			and type(v)==permitted_profile_settings[k] then
 				-- if the datatype is string and this key corresponds with an OptionRow in ScreenPlayerOptions
 				-- ensure that the string read in from the player's profile
 				-- is a valid value (or choice) for the corresponding OptionRow
@@ -108,9 +121,9 @@ LoadProfileCustom = function(profile, dir)
 					GAMESTATE:GetPlayerState(player):GetPlayerOptions("ModsLevel_Preferred"):FailSetting( GetDefaultFailType() )
 				end
 
-				if k=="EvalPaneSecondary" and type(v)==profile_whitelist.EvalPaneSecondary then
+				if k=="EvalPaneSecondary" and type(v)==permitted_profile_settings.EvalPaneSecondary then
 					SL[pn].EvalPaneSecondary = v
-				elseif k=="EvalPanePrimary" and type(v)==profile_whitelist.EvalPanePrimary then
+				elseif k=="EvalPanePrimary" and type(v)==permitted_profile_settings.EvalPanePrimary then
 					SL[pn].EvalPanePrimary   = v
 				end
 			end
@@ -130,7 +143,7 @@ SaveProfileCustom = function(profile, dir)
 			local pn = ToEnumShortString(player)
 			local output = {}
 			for k,v in pairs(SL[pn].ActiveModifiers) do
-				if profile_whitelist[k] and type(v)==profile_whitelist[k] then
+				if permitted_profile_settings[k] and type(v)==permitted_profile_settings[k] then
 					output[k] = v
 				end
 			end

--- a/metrics.ini
+++ b/metrics.ini
@@ -682,7 +682,6 @@ LineMeasureCounter="lua,CustomOptionRow('MeasureCounter')"
 LineDataVisualizations="lua,CustomOptionRow('DataVisualizations')"
 LineTargetScore="lua,CustomOptionRow('TargetScore')"
 LineActionOnMissedTarget="lua,CustomOptionRow('ActionOnMissedTarget')"
-LineReceptorArrowsPosition="lua,CustomOptionRow('ReceptorArrowsPosition')"
 LineLifeMeterType="lua,CustomOptionRow('LifeMeterType')"
 
 # lists assembled by the engine


### PR DESCRIPTION
`ReceptorArrowsPosition` existed to accommodate "StomperZ" mode, which was removed in bdc9097eec5485bb900bee6e3ae9fe7c9b50cba8.  This commit removes leftover mentions of `ReceptorArrowsPosition`.

This commit also changes a local variable name in `./Scripts/SL-PlayerProfiles.lua` from `profile_whitelist` to
`permitted_profile_settings` as I've been fortunate enough to consider the context and impact of words since originally writing that code.