### PR TITLE
Speed up MsdFileParser, fix SSC parsing, and change to V3 of Hash generation

### DIFF
--- a/BGAnimations/ScreenEvaluation common/Panes/Pane6/GrooveStatsURL.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane6/GrooveStatsURL.lua
@@ -19,7 +19,7 @@ if steps then
 	difficulty = ToEnumShortString(difficulty)
 end
 
--- will need to update this to not be hardcoded to dance if GrooveStats supports other games in the future
+-- Will need to update this to not be hardcoded to dance if GrooveStats supports other games in the future
 local style = ""
 if GAMESTATE:GetCurrentStyle():GetStyleType() == "StyleType_OnePlayerTwoSides" then
 	style = "dance-double"
@@ -27,13 +27,13 @@ else
 	style = "dance-single"
 end
 
-local hash = GenerateHash(steps, style, difficulty):sub(1, 12)
+local hash = GenerateHash(steps, style, difficulty):sub(1, 16)
 
 -- ************* CURRENT QR VERSION *************
 -- * Update whenever we change relevant QR code *
 -- *  and when the backend GrooveStats is also  *
 -- *   updated to properly consume this value.  *
 -- **********************************************
-local qr_version = 2
+local qr_version = 3
 
 return ("https://groovestats.com/qr.php?h=%s&s=%s&f=%s&r=%s&v=%d"):format(hash, score, failed, rate, qr_version)

--- a/BGAnimations/ScreenEvaluation common/Panes/Pane6/GrooveStatsURL.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane6/GrooveStatsURL.lua
@@ -27,13 +27,13 @@ else
 	style = "dance-single"
 end
 
-local hash = GenerateHash(steps, style, difficulty):sub(1, 16)
+local hash = GenerateHash(steps, style, difficulty):sub(1, 12)
 
 -- ************* CURRENT QR VERSION *************
 -- * Update whenever we change relevant QR code *
 -- *  and when the backend GrooveStats is also  *
 -- *   updated to properly consume this value.  *
 -- **********************************************
-local qr_version = 3
+local qr_version = 2
 
 return ("https://groovestats.com/qr.php?h=%s&s=%s&f=%s&r=%s&v=%d"):format(hash, score, failed, rate, qr_version)

--- a/Scripts/SL-HashGenerator.lua
+++ b/Scripts/SL-HashGenerator.lua
@@ -89,6 +89,7 @@ local function NormalizeFloatDigits(param)
 	-- 3.95 usually uses three digits after the decimal point while
 	-- SM5 uses 6. We normalize everything here to 6. If for some reason
 	-- there are more than 6, we just remove the trailing ones.
+	--
 	-- local function NormalizeDecimal(decimal)
 	-- 	local int, frac = decimal:match('(.+)%.(.+)')
 	-- 	if frac ~= nil then
@@ -104,11 +105,26 @@ local function NormalizeFloatDigits(param)
 	-- end
 
 	-- V2, uses string.format to round all the decimals to 3 decimal places.
+	--
+	-- local function NormalizeDecimal(decimal)
+	-- 	-- Remove any control characters from the string to prevent conversion failures.
+	-- 	decimal = decimal:gsub("%c", "")
+	-- 	return string.format("%.3f", tonumber(decimal))
+
+	-- V3, uses a faster version of math.floor(x - 0.5) for rounding (no function call).
+	--   the V2 version would fail on "82.0625" where it would round it to 82.062 instead
+	--   of the expected 82.063
 	local function NormalizeDecimal(decimal)
 		-- Remove any control characters from the string to prevent conversion failures.
 		decimal = decimal:gsub("%c", "")
-		return string.format("%.3f", tonumber(decimal))
+		local rounded = tonumber(decimal)
+
+		-- Round to 3 decimal places
+		local mult = 10^3
+		rounded = (rounded * mult + 0.5 - (rounded * mult + 0.5) % 1) / mult
+		return string.format("%.3f", rounded)
 	end
+
 	local paramParts = {}
 	for beat_bpm in param:gmatch('[^,]+') do
 		local beat, bpm = beat_bpm:match('(.+)=(.+)')

--- a/Scripts/SL-MsdFileParser.lua
+++ b/Scripts/SL-MsdFileParser.lua
@@ -20,24 +20,24 @@ function ParseMsdFile(steps)
 		-- table.concat(table_name, separator, start, end)
 		local param = table.concat(p, '', 1, plen)
 
-		-- -- Normalize all line endings to \n and remove all leading and trailing whitespace.
+		-- Normalize all line endings to \n and remove all leading and trailing whitespace.
 		param = param:gsub('\r\n?', '\n'):match('^%s*(.-)%s*$')
 
 		-- Field specific modifications. We length check the last table to make sure we're
 		-- actually parsing what we want.
 		-- TODO(teejusb): We should probably do this for most fields for consistency.
 		if #t[#t] == 6 and (t[#t][1] == 'NOTES' or t[#t][1] == 'NOTES2') and fileType == "sm" then
-			-- Spaces don't matter for the chart data itself, remove them all.
+			-- Remove all whitespace that isn't the \n character.
 			-- NOTE(teejusb): NOTES in the SM file has multiple parts. We specifically only want to strip
 			-- the 6th part (the chart data), as the others can contain spaces e.g. chart description.
-			param = param:gsub(' ', '')
+			param = param:gsub('[\r\t\f\v ]+', '')
 		elseif #t[#t] == 1 and (t[#t][1] == 'NOTES' or t[#t][1] == 'NOTES2') and fileType == "ssc" then
-			-- Spaces don't matter for the chart data itself, remove them all.
+			-- Remove all whitespace that isn't the \n character.
 			-- NOTE(teejusb): NOTES in an SSC file only contains the chart data itself.
-			param = param:gsub(' ', '')
+			param = param:gsub('[\r\t\f\v ]+', '')
 		elseif #t[#t] == 1 and t[#t][1] == 'BPMS' then
-			-- Line endings and spaces don't matter for BPMs, remove them all.
-			param = param:gsub('\n? ?', '')
+			-- Whitespace doesn't matter for BPMs, remove them all.
+			param = param:gsub('%s+', '')
 		end
 
 		table.insert(t[#t], param)

--- a/Scripts/SL-MsdFileParser.lua
+++ b/Scripts/SL-MsdFileParser.lua
@@ -16,35 +16,31 @@
 -- we'll recover.
 
 function ParseMsdFile(steps)
-	local function AddParam(t, p, plen)
+	local function AddParam(t, p, plen, fileType)
 		-- table.concat(table_name, separator, start, end)
 		local param = table.concat(p, '', 1, plen)
 
 		-- -- Normalize all line endings to \n and remove all leading and trailing whitespace.
-		param = param:gsub('\r\n', '\n'):gsub('\r', '\n'):match('^%s*(.-)%s*$')
+		param = param:gsub('\r\n?', '\n'):match('^%s*(.-)%s*$')
 
 		-- Field specific modifications. We length check the last table to make sure we're
 		-- actually parsing what we want.
 		-- TODO(teejusb): We should probably do this for most fields for consistency.
-		-- NOTE(teejusb): This is for *.sm files only. This is easily changeable,
-		-- I just haven't got around to it yet.
-		if((#t[#t] == 6 and t[#t][1] == 'NOTES')) then
+		if #t[#t] == 6 and (t[#t][1] == 'NOTES' or t[#t][1] == 'NOTES2') and fileType == "sm" then
 			-- Spaces don't matter for the chart data itself, remove them all.
+			-- NOTE(teejusb): NOTES in the SM file has multiple parts. We specifically only want to strip
+			-- the 6th part (the chart data), as the others can contain spaces e.g. chart description.
 			param = param:gsub(' ', '')
-		elseif((#t[#t] == 1 and t[#t][1] == 'BPMS')) then
+		elseif #t[#t] == 1 and (t[#t][1] == 'NOTES' or t[#t][1] == 'NOTES2') and fileType == "ssc" then
+			-- Spaces don't matter for the chart data itself, remove them all.
+			-- NOTE(teejusb): NOTES in an SSC file only contains the chart data itself.
+			param = param:gsub(' ', '')
+		elseif #t[#t] == 1 and t[#t][1] == 'BPMS' then
 			-- Line endings and spaces don't matter for BPMs, remove them all.
-			param = param:gsub('\n', ''):gsub(' ', '')
+			param = param:gsub('\n? ?', '')
 		end
 
 		table.insert(t[#t], param)
-	end
-
-	local function AddValue(t)
-		table.insert(t, {})
-	end
-
-	local function at(s, i)
-		return s:sub(i, i)
 	end
 
 	local simfileString, fileType = GetSimfileString(steps)
@@ -64,17 +60,26 @@ function ParseMsdFile(steps)
 	local continue = false
 
 	while i < length do
-		if(i + 1 < length and at(simfileString, i+1) == '/' and at(simfileString, i+2) == '/') then
-			-- Skip a comment entirely; don't copy the comment to the value/parameter
-			i = i + 1
-			while i < length and at(simfileString, i+1) ~= '\n' do
-				i = i + 1
-			end
+		-- We create a local variable that we can reuse to minimize the number of sub() calls.
+		local curChar = simfileString:sub(i+1, i+1)
 
-			continue = true
+		if i + 1 < length then
+			if curChar == '/' and simfileString:sub(i+2, i+2) == '/' then
+				-- Skip a comment entirely; don't copy the comment to the value/parameter
+				i = simfileString:find('\n', i+1)
+				if i == nil then
+					-- If we can't find an endline, then assume we're done.
+					i = simfileString:len()
+				else
+					-- s:find() will return the index of the character found. We want the value before it.
+					i = i - 1
+				end
+
+				continue = true
+			end
 		end
 
-		if(not continue and ReadingValue and at(simfileString, i+1) == '#') then
+		if not continue and ReadingValue and curChar == '#' then
 			-- Unfortunately, many of these files are missing ;'s.
 			-- If we get a # when we thought we were inside a value, assume we
 			-- missed the ;.  Back up and end the value.
@@ -92,24 +97,24 @@ function ParseMsdFile(steps)
 
 			if not firstChar then
 				-- We're not the first char on a line.  Treat it as if it were a normal character.
-				processed[processedLen+1] = at(simfileString, i+1)
+				processed[processedLen+1] = curChar
 				processedLen = processedLen + 1
 				i = i + 1
 				continue = true
 			end
 
-			if(not continue) then
+			if not continue then
 				-- Skip newlines and whitespace before adding the value.
 				processedLen = j
-				while(processedLen > 0 and
-					  (processed[processedLen] == '\r' or
-					   processed[processedLen] == '\n' or
-					   processed[processedLen] == ' ' or
-					   processed[processedLen] == '\t')) do
+				while (processedLen > 0 and
+					   (processed[processedLen] == '\r' or
+					    processed[processedLen] == '\n' or
+					    processed[processedLen] == ' ' or
+					    processed[processedLen] == '\t')) do
 					processedLen = processedLen - 1
 				end
 
-				AddParam(final, processed, processedLen)
+				AddParam(final, processed, processedLen, fileType)
 
 				processedLen = 0
 				ReadingValue = false
@@ -117,13 +122,13 @@ function ParseMsdFile(steps)
 		end
 
 		-- # starts a new value.
-		if(not continue and not ReadingValue and at(simfileString, i+1) == '#') then
-			AddValue(final)
+		if not continue and not ReadingValue and curChar == '#' then
+			table.insert(final, {})
 			ReadingValue = true
 		end
 
-		if(not continue and not ReadingValue) then
-			if(at(simfileString, i+1) == '\\') then
+		if not continue and not ReadingValue then
+			if curChar == '\\' then
 				i = i + 2
 			else
 				i = i + 1
@@ -133,19 +138,19 @@ function ParseMsdFile(steps)
 		end
 
 		-- : and ; end the current param, if any.
-		if(not continue and processedLen ~= -1 and (at(simfileString, i+1) == ':' or at(simfileString, i+1) == ';')) then
-			AddParam(final, processed, processedLen)
+		if not continue and processedLen ~= -1 and (curChar == ':' or curChar == ';') then
+			AddParam(final, processed, processedLen, fileType)
 		end
 
 		-- # and : begin new params.
-		if(not continue and (at(simfileString, i+1) == '#' or at(simfileString, i+1) == ':')) then
+		if not continue and (curChar == '#' or curChar == ':') then
 			i = i + 1
 			processedLen = 0
 			continue = true
 		end
 
 		-- ; ends the current value.
-		if(not continue and at(simfileString, i+1) == ';') then
+		if not continue and curChar == ';' then
 			ReadingValue = false
 			i = i + 1
 			continue = true
@@ -155,13 +160,13 @@ function ParseMsdFile(steps)
 		-- ie \#, \\, \:, etc., or a regular character.
 		-- NOTE: There is usually an 'unescape' bool passed to this top level function,
 		-- but when reading SM/SSC files it's always set to true so we assume that.
-		if(not continue and i < length and at(simfileString, i+1) == '\\') then
+		if not continue and i < length and curChar == '\\' then
 			i = i + 1
 		end
 
 		-- Add any unterminated value at the very end.
-		if (not continue and i < length) then
-			processed[processedLen+1] = at(simfileString, i+1)
+		if not continue and i < length then
+			processed[processedLen+1] = curChar
 			processedLen = processedLen + 1
 			i = i + 1
 		end
@@ -169,8 +174,8 @@ function ParseMsdFile(steps)
 		continue = false
 	end
 
-	if(ReadingValue) then
-		AddParam(final, processed, processedLen)
+	if ReadingValue then
+		AddParam(final, processed, processedLen, fileType)
 	end
 
 	return final, fileType


### PR DESCRIPTION
Using the 24 hours of 100 BPM expert chart from Crapyard Scent we get the following results.

**Baseline:**
MSD took: 8.7779979705811

**With this change:**
MSD took: 3.0219993591309

Which is a **65%** speed up (even faster than the previous speedup attempt, but could be biased if the file was in my PC's cache). This is done by removing all the calls to `at()` since function calls add a lot of overhead. We went from 14 calls to at most 2. We did so by just caching the current character.


Also fix parsing for SSCs. Before there were some issues with trailing spaces but I think they're resolved.

Tested using the SM and SSC files for Time for Tea:

00:30.893: MSD took: 0.7549991607666
00:30.974: SM HASH IS: 0eaa5762f7923bca4ab6621bd9c82fe4327e47c257e94b9f8b341f4c47fe616a

00:42.391: MSD took: 0.63099670410156
00:42.469: SSC HASH IS: 0eaa5762f7923bca4ab6621bd9c82fe4327e47c257e94b9f8b341f4c47fe616a

We can see the hashes are the same.

This PR is basically the combination of:
 - https://github.com/Simply-Love/Simply-Love-SM5/pull/200 and
 - https://github.com/Simply-Love/Simply-Love-SM5/pull/204

Which were reverted but I realized I missed adding the fileType to one of the AddParam calls which is done in this PR. This PR also speeds up MsdFileParsing more than the previous PRs.

=========
The description of the previous PR #204 is still applicable here:

- SSC Chart data needs to be stripped of spaces like we do for SM files. The structure is a little different so I now specify the fileType when we AddParam. There are some comments in the code that add some more context.
- There was a bug in how we handle comments in the MsdFiles. string:find returns the index of where we find the \n character, but then by setting it to that index, we end up stripping it out. We still want to retain that character so now we subtract one.

Luckily, the hash generation on GrooveStats' side is accurate and handles comments correctly. The usage of "find" here deviates slightly from SM's implementation (which instead loops and searches for the '\n' character, which is what's being used on GrooveStats' side). Therefore this change would be a strict improvement in Simply Love's hash generation. Personally I'm a bit surprised it took so long for this to be found.

