### PR TITLE
[enhancement] track last seen stepchart in EditMode, too

### DIFF
--- a/BGAnimations/ScreenEditMenu underlay/LastSeenSong.lua
+++ b/BGAnimations/ScreenEditMenu underlay/LastSeenSong.lua
@@ -3,7 +3,7 @@
 -- This can be handy when a player is working on the same stepchart
 -- over the course of multiple days/SM5 restarts.
 --
--- These steps (retreiving strings from ThemePrefs and setting GAMESTATE)
+-- The 1st half of this (retreiving strings from ThemePrefs and setting GAMESTATE)
 -- can be performed immediately when this file is loaded.  None of it requires
 -- Actors.
 --

--- a/BGAnimations/ScreenEditMenu underlay/LastSeenSong.lua
+++ b/BGAnimations/ScreenEditMenu underlay/LastSeenSong.lua
@@ -1,0 +1,111 @@
+-- Retrieve ThemePref values and attempt to set the EditMenu
+-- to the "last seen" song and stepchart for quicker navigation.
+-- This can be handy when a player is working on the same stepchart
+-- over the course of multiple days/SM5 restarts.
+--
+-- These steps (retreiving strings from ThemePrefs and setting GAMESTATE)
+-- can be performed immediately when this file is loaded.  None of it requires
+-- Actors.
+--
+-- The 2nd half of this (writing the LastSeen string values to ThemePrefs)
+-- is handled lower in this file, and hooks into the screen's OffCommand.
+-- It will be run when the player chooses a song and stepchart and successfully
+-- proceeds to ScreenEdit, but not when the player backs out of ScreenEditMenu
+-- (Escape key or mapped BACK button).
+-- ----------------------------------------------------------------
+
+local song_str      = ThemePrefs.Get("EditModeLastSeenSong")
+local diff_str      = ThemePrefs.Get("EditModeLastSeenDifficulty")
+local stepstype_str = ThemePrefs.Get("EditModeLastSeenStepsType")
+local styletype_str = ThemePrefs.Get("EditModeLastSeenStyleType")
+
+if song_str ~= "" then
+	local song = SONGMAN:FindSong( song_str )
+
+	if song then
+		-- If a song was saved in ThemePrefs, set GAMESTATE's CurrentSong now
+		-- during Init.  In the engine's code, EditMenu::RefreshAll() is called
+		-- once at the end of EditMode::Load(), and uses GAMESTATE's current song.
+		GAMESTATE:SetCurrentSong( song )
+
+		-- The current song can be set indepenently from stepchart.
+		-- It's possible there could be invalid strings for
+		-- difficulty, stepstype, or styletype, but a valid song string.
+
+		-- don't both with empty strings
+		if stepstype_str ~= "" and diff_str ~= "" and styletype_str ~= "" then
+
+			-- transform a StepsType string like "StepsType_Dance_Single" into "single"
+			local style = stepstype_str:gsub("%w+_%w+_", ""):lower()
+
+			-- ensure string values retrieved from ThemePrefs are valid
+			for _style in ivalues(GAMEMAN:GetStylesForGame(GAMESTATE:GetCurrentGame():GetName())) do
+				-- style corresponds to an C++ object; ensure its name matches that of a valid style for this game
+				if  style == _style:GetName():lower()
+				-- difficulty, stepstype, and styletype are C++ enums; ensure the string values we retrieved are valid
+				and Difficulty:Reverse()[diff_str]     ~= nil
+				and StepsType:Reverse()[stepstype_str] ~= nil
+				and StyleType:Reverse()[styletype_str] ~= nil
+				then
+
+					-- ensure the correct number of players is joined for this StyleType
+					----------------------------------------------------------------------
+					-- unjoin any human players
+					for player in ivalues(GAMESTATE:GetHumanPlayers()) do GAMESTATE:UnjoinPlayer(player) end
+
+					-- most styles require that only one player be joined
+					-- and ScreenEditMenu.cpp is currently hardcoded to use PLAYER_1 for those
+					GAMESTATE:JoinPlayer(PLAYER_1)
+
+					-- but some styles (couple, routine) need both players joined
+					if StyleType:Reverse()[styletype_str] == 1 -- TwoPlayersTwoSides (couple)
+					or StyleType:Reverse()[styletype_str] == 3 -- TwoPlayersSharedSides (routine)
+					then
+						GAMESTATE:JoinPlayer(PLAYER_2)
+					end
+					----------------------------------------------------------------------
+
+					-- style MUST be set before setting steps or SM will crash
+					GAMESTATE:SetCurrentStyle( style )
+
+					-- ensure style has really been set
+					if GAMESTATE:GetCurrentStyle() ~= nil then
+						-- set steps
+						local steps = song:GetOneSteps(stepstype_str, diff_str)
+						GAMESTATE:SetCurrentSteps(PLAYER_1, steps)
+						break
+					end
+				end
+			end
+		end
+	end
+end
+
+-- -----------------------------------------------------------------------
+
+return Def.Actor{
+	OffCommand=function()
+		local song = GAMESTATE:GetCurrentSong()
+
+		if song then
+			-- the string returned by song:GetSongDir() isn't usable by SONGMAN:FindSong()
+			-- so build a string like "/Group Name/Song Name"
+			local songpath = ("/%s/%s"):format(song:GetGroupName(), Basename(song:GetSongDir()))
+
+			local steps = GAMESTATE:GetCurrentSteps(PLAYER_1)
+			if steps then
+				local difficulty = steps:GetDifficulty()
+				local stepstype  = steps:GetStepsType()
+				local styletype  = GAMESTATE:GetCurrentStyle():GetStyleType()
+
+				if difficulty and stepstype and styletype then
+					ThemePrefs.Set("EditModeLastSeenSong",       songpath)
+					ThemePrefs.Set("EditModeLastSeenStepsType",  stepstype)
+					ThemePrefs.Set("EditModeLastSeenStyleType",  styletype)
+					ThemePrefs.Set("EditModeLastSeenDifficulty", difficulty)
+					ThemePrefs.Save()
+				end
+			end
+		end
+	end
+}

--- a/BGAnimations/ScreenEditMenu underlay/default.lua
+++ b/BGAnimations/ScreenEditMenu underlay/default.lua
@@ -104,33 +104,6 @@ local t = Def.ActorFrame{
 	end
 }
 
-t[#t+1] = Def.Actor{
-	InitCommand=function()
-		local str = ThemePrefs.Get("EditModeLastSeenSong")
-
-		if str ~= "" then
-			local song = SONGMAN:FindSong( str )
-			if song then
-				-- If a song was saved in ThemePrefs, set GAMESTATE's CurrentSong now
-				-- during Init.  In the engine's code, EditMenu::RefreshAll() is called
-				-- once at the end of EditMode::Load(), and uses GAMESTATE's current song.
-				GAMESTATE:SetCurrentSong( song )
-			end
-		end
-	end,
-	OffCommand=function()
-		local song = GAMESTATE:GetCurrentSong()
-
-		if song then
-			-- the string returned by song:GetSongDir() isn't usable by SONGMAN:FindSong()
-			local path = ("/%s/%s"):format(song:GetGroupName(), Basename(song:GetSongDir()))
-			ThemePrefs.Set("EditModeLastSeenSong", path)
-			ThemePrefs.Save()
-		end
-	end
-}
-
-
 -- the overall BG
 t[#t+1] = Def.Quad {
 	InitCommand=function(self) self:zoomto(_screen.w*0.9, _screen.h*0.725):diffuse(0,0,0,1) end,
@@ -168,5 +141,12 @@ t[#t+1] = Def.Quad{
 t[#t+1] = Border(_screen.w*0.9, _screen.h*0.734, 2)..{
 	InitCommand=function(self) self:xy(_screen.cx, _screen.cy) end,
 }
+
+-- -----------------------------------------------------------------------
+
+t[#t+1] = LoadActor("./LastSeenSong.lua")
+
+-- -----------------------------------------------------------------------
+
 
 return t

--- a/BGAnimations/ScreenEditMenu underlay/default.lua
+++ b/BGAnimations/ScreenEditMenu underlay/default.lua
@@ -49,7 +49,7 @@ local t = Def.ActorFrame{
 					end
 
 					if cursorY == rowYvalues[4] then
-						editMenu:GetChild("StepsDisplay"):GetChild("Meter"):diffuse( 0,0,0,1 )
+						editMenu:GetChild("StepsDisplay"):diffuse( 0,0,0,1 )
 					end
 					if cursorY == rowYvalues[6] then
 						editMenu:GetChild("StepsDisplaySource"):GetChild("Meter"):diffuse( 0,0,0,1 )
@@ -65,7 +65,7 @@ local t = Def.ActorFrame{
 					end
 
 					if cursorY ~= rowYvalues[4] then
-						editMenu:GetChild("StepsDisplay"):GetChild("Meter"):diffuse(1,1,1,1)
+						editMenu:GetChild("StepsDisplay"):diffuse(1,1,1,1)
 					end
 					if cursorY ~= rowYvalues[6] then
 						editMenu:GetChild("StepsDisplaySource"):GetChild("Meter"):diffuse(1,1,1,1)
@@ -97,7 +97,7 @@ local t = Def.ActorFrame{
 			if cursor then
 				local cursorY = cursor:GetY()
 				if cursorY == rowYvalues[4] then
-					editMenu:GetChild("StepsDisplay"):GetChild("Meter"):diffuse(0,0,0,1)
+					editMenu:GetChild("StepsDisplay"):diffuse(0,0,0,1)
 				end
 			end
 		end

--- a/Scripts/99 SL-ThemePrefs.lua
+++ b/Scripts/99 SL-ThemePrefs.lua
@@ -109,6 +109,18 @@ SL_CustomPrefs.Get = function()
 		{
 			Default = "",
 		},
+		EditModeLastSeenStepsType =
+		{
+			Default = "",
+		},
+		EditModeLastSeenStyleType =
+		{
+			Default = "",
+		},
+		EditModeLastSeenDifficulty =
+		{
+			Default = "",
+		},
 
 		-- - - - - - - - - - - - - - - - - - - -
 		-- MenuTimer values for various screens

--- a/metrics.ini
+++ b/metrics.ini
@@ -1879,7 +1879,13 @@ PreviewLengthFormat="%s: %.3f secs\n"
 [StepsDisplay]
 ShowMeter=true
 MeterSetCommand=%function(self, param) MESSAGEMAN:Broadcast("MeterSet") end;
-ShowDescription=false
+ShowDescription=true
+DescriptionY=0
+DescriptionX=-265
+DescriptionOnCommand=zoom,0.8;horizalign,left;vertspacing,-9;_wrapwidthpixels,345
+DescriptionSetCommand=%function(self,params) self:visible(params.Steps ~= nil and params.Steps:GetDifficulty()=="Difficulty_Edit")  end
+
+
 
 [ScreenEditMenu]
 PrevScreen="ScreenTitleMenu"


### PR DESCRIPTION
# About

This builds on #251 by allowing ScreenEditMenu to initialize into the last seen stepchart as well as the last seen song.

## Implementation

There are three new ThemePref values: 
 * `EditModeLastSeenStepsType` - a string like "StepsType_Dance_Single"
 * `EditModeLastSeenStyleType` - a string like "StyleType_OnePlayerOneSide"
 * `EditModeLastSeenDifficulty` - a string like "Difficulty_Challenge"

These are needed to configure GAMESTATE appropriately  and set the stepchart.

The code for getting and setting and validating these ThemePrefs grew quite a bit, so I moved it to a separate file and `LoadActor`'d that into `ScreenEditMenu underlay`.

## Considerations

I validate and set the song independently from the stepchart.

It's possible to switch games (i.e. from `dance` to `techno`) which would invalidate the `EditModeLastSeenStepsType` but not necessarily `EditModeLastSeenSong`, and I figured it's better to at least set the song rather than both-or-none.

With regard to "bad" data being retrieved from ThemePrefs, I've tested:
  * empty strings
  * garbage values
  * switching between stepmania games (dance to techno to pump)
  * mismatched StyleType and StepsType

## Miscellaneous

During testing, I found that the _fallback theme's `ThemePrefs.Get()` seems to choke if the string being read includes square brackets (i.e. `/Tachyon Epsilon/The Skies Are Not Enough - [Mad Matt]` and returns an empty string.  This is a problem, but outside the scope of this pull request.