### PR TITLE
Add the Density Graph behind the Scatter Plot in ScreenEval.

### DIFF
--- a/BGAnimations/ScreenEvaluation common/PerPlayer/Lower/Graphs.lua
+++ b/BGAnimations/ScreenEvaluation common/PerPlayer/Lower/Graphs.lua
@@ -28,7 +28,7 @@ local af = Def.ActorFrame{
 -- Course mode needs to get all subsong density graphs and put them togetehr which we
 -- don't currently support.
 if not GAMESTATE:IsCourseMode() then
-	af[#af+1] = NPS_Histogram(player, GraphWidth, GraphHeight, 0.7)..{
+	af[#af+1] = NPS_Histogram(player, GraphWidth, GraphHeight, 0.5)..{
 		Name="DensityGraph",
 		OnCommand=function(self)
 			self:addx(-GraphWidth/2):addy(GraphHeight)

--- a/BGAnimations/ScreenEvaluation common/PerPlayer/Lower/Graphs.lua
+++ b/BGAnimations/ScreenEvaluation common/PerPlayer/Lower/Graphs.lua
@@ -28,7 +28,7 @@ local af = Def.ActorFrame{
 -- Course mode needs to get all subsong density graphs and put them togetehr which we
 -- don't currently support.
 if not GAMESTATE:IsCourseMode() then
-	af[#af+1] = NPS_Histogram(player, GraphWidth, GraphHeight)..{
+	af[#af+1] = NPS_Histogram(player, GraphWidth, GraphHeight, 0.7)..{
 		Name="DensityGraph",
 		OnCommand=function(self)
 			self:addx(-GraphWidth/2):addy(GraphHeight)

--- a/BGAnimations/ScreenEvaluation common/PerPlayer/Lower/Graphs.lua
+++ b/BGAnimations/ScreenEvaluation common/PerPlayer/Lower/Graphs.lua
@@ -6,7 +6,7 @@ local NumPlayers = #GAMESTATE:GetHumanPlayers()
 local GraphWidth  = THEME:GetMetric("GraphDisplay", "BodyWidth")
 local GraphHeight = THEME:GetMetric("GraphDisplay", "BodyHeight")
 
-return Def.ActorFrame{
+local af = Def.ActorFrame{
 	InitCommand=function(self)
 		self:y(_screen.cy + 124)
 		if NumPlayers == 1 then
@@ -22,34 +22,51 @@ return Def.ActorFrame{
 			self:zoomto(GraphWidth, GraphHeight):diffuse(color("#101519")):vertalign(top)
 		end
 	},
-
-	LoadActor("./ScatterPlot.lua", {player=player, GraphWidth=GraphWidth, GraphHeight=GraphHeight} ),
-
-	-- The GraphDisplay provided by the engine provides us a solid color histogram detailing
-	-- the player's lifemeter during gameplay capped by a white line.
-	-- in normal gameplay (non-CourseMode), we hide the solid color but leave the white line.
-	-- in CourseMode, we hide the white line (for aesthetic reasons) and leave the solid color
-	-- as ScatterPlot.lua does not yet support CourseMode.
-	Def.GraphDisplay{
-		Name="GraphDisplay",
-		InitCommand=function(self)
-			self:vertalign(top)
-
-			local ColorIndex = ((SL.Global.ActiveColorIndex + (player==PLAYER_1 and -1 or 1)) % #SL.Colors) + 1
-			self:Load("GraphDisplay" .. ColorIndex )
-
-			local playerStageStats = STATSMAN:GetCurStageStats():GetPlayerStageStats(player)
-			local stageStats = STATSMAN:GetCurStageStats()
-			self:Set(stageStats, playerStageStats)
-
-			if GAMESTATE:IsCourseMode() then
-				-- hide the GraphDisplay's stroke ("Line")
-				self:GetChild("Line"):visible(false)
-			else
-			    -- hide the GraphDisplay's body (2nd unnamed child)
-			    self:GetChild("")[2]:visible(false)
-				 self:GetChild("Line"):addy(1)
-			end
-		end
-	},
 }
+
+-- Only add the background histogram in normal gameplay.
+-- Course mode needs to get all subsong density graphs and put them togetehr which we
+-- don't currently support.
+if not GAMESTATE:IsCourseMode() then
+	af[#af+1] = NPS_Histogram(player, GraphWidth, GraphHeight)..{
+		Name="DensityGraph",
+		OnCommand=function(self)
+			self:addx(-GraphWidth/2):addy(GraphHeight)
+			-- Lower the opacity otherwise some of the scatter plot points might become hard to see.
+			self:diffusealpha(0.5)
+			self:queuecommand("Redraw")
+		end,
+	}
+end
+
+af[#af+1] = LoadActor("./ScatterPlot.lua", {player=player, GraphWidth=GraphWidth, GraphHeight=GraphHeight} )
+
+-- The GraphDisplay provided by the engine provides us a solid color histogram detailing
+-- the player's lifemeter during gameplay capped by a white line.
+-- in normal gameplay (non-CourseMode), we hide the solid color but leave the white line.
+-- in CourseMode, we hide the white line (for aesthetic reasons) and leave the solid color
+-- as ScatterPlot.lua does not yet support CourseMode.
+af[#af+1] = Def.GraphDisplay{
+	Name="GraphDisplay",
+	InitCommand=function(self)
+		self:vertalign(top)
+
+		local ColorIndex = ((SL.Global.ActiveColorIndex + (player==PLAYER_1 and -1 or 1)) % #SL.Colors) + 1
+		self:Load("GraphDisplay" .. ColorIndex )
+
+		local playerStageStats = STATSMAN:GetCurStageStats():GetPlayerStageStats(player)
+		local stageStats = STATSMAN:GetCurStageStats()
+		self:Set(stageStats, playerStageStats)
+
+		if GAMESTATE:IsCourseMode() then
+			-- hide the GraphDisplay's stroke ("Line")
+			self:GetChild("Line"):visible(false)
+		else
+			-- hide the GraphDisplay's body (2nd unnamed child)
+			self:GetChild("")[2]:visible(false)
+				self:GetChild("Line"):addy(1)
+		end
+	end
+}
+
+return af

--- a/BGAnimations/ScreenEvaluation common/PerPlayer/Lower/ScatterPlot.lua
+++ b/BGAnimations/ScreenEvaluation common/PerPlayer/Lower/ScatterPlot.lua
@@ -13,8 +13,10 @@ local sequential_offsets = SL[ToEnumShortString(player)].Stages.Stats[SL.Global.
 
 -- a table to store the AMV's vertices
 local verts= {}
+local Steps = GAMESTATE:GetCurrentSteps(player)
+local TimingData = Steps:GetTimingData()
 -- TotalSeconds is used in scaling the x-coordinates of the AMV's vertices
-local FirstSecond = GAMESTATE:GetCurrentSong():GetFirstSecond()
+local FirstSecond = math.min(TimingData:GetElapsedTimeFromBeat(0), 0)
 local TotalSeconds = GAMESTATE:GetCurrentSong():GetLastSecond()
 
 -- variables that will be used and re-used in the loop while calculating the AMV's vertices

--- a/Scripts/SL-Histogram.lua
+++ b/Scripts/SL-Histogram.lua
@@ -1,4 +1,4 @@
-local function gen_vertices(player, width, height)
+local function gen_vertices(player, width, height, desaturation)
 	local Song, Steps
 	local first_step_has_occurred = false
 	local pn = ToEnumShortString(player)
@@ -44,6 +44,19 @@ local function gen_vertices(player, width, height)
 		-- magic numbers obtained from Photoshop's Eyedrop tool in rgba percentage form (0 to 1)
 		local blue   = {0,    0.678, 0.753, 1}
 		local purple = {0.51, 0,     0.631, 1}
+
+		if desaturation ~= nil then
+			local function Desaturate(color, desaturation)
+				local luma = 0.3 * color[1] + 0.59 * color[2] + 0.11 * color[3]
+				color[1] = color[1] + desaturation * (luma - color[1])
+				color[2] = color[2] + desaturation * (luma - color[2])
+				color[3] = color[3] + desaturation * (luma - color[3])
+				return color
+			end
+			blue = Desaturate(blue, desaturation)
+			purple = Desaturate(purple, desaturation)
+		end
+
 		local upper
 
 		for i, nps in ipairs(NPSperMeasure) do
@@ -96,7 +109,7 @@ function interpolate_vert(v1, v2, offset)
 end
 
 
-function NPS_Histogram(player, width, height)
+function NPS_Histogram(player, width, height, desaturation)
 	local pn = ToEnumShortString(player)
 	local amv = Def.ActorMultiVertex{
 		InitCommand=function(self)
@@ -109,7 +122,7 @@ function NPS_Histogram(player, width, height)
 			-- we've reached a new song, so reset the vertices for the density graph
 			-- this will occur at the start of each new song in CourseMode
 			-- and at the start of "normal" gameplay
-			local verts = gen_vertices(player, width, height)
+			local verts = gen_vertices(player, width, height, desaturation)
 			self:SetNumVertices(#verts):SetVertices(verts)
 		end
 	}
@@ -118,7 +131,7 @@ function NPS_Histogram(player, width, height)
 end
 
 
-function Scrolling_NPS_Histogram(player, width, height)
+function Scrolling_NPS_Histogram(player, width, height, desaturation)
 	local verts, visible_verts
 	local left_idx, right_idx
 
@@ -134,7 +147,7 @@ function Scrolling_NPS_Histogram(player, width, height)
 		end,
 
 		LoadCurrentSong=function(self, scaled_width)
-			verts = gen_vertices(player, scaled_width, height)
+			verts = gen_vertices(player, scaled_width, height, desaturation)
 
 			left_idx = 1
 			right_idx = 2


### PR DESCRIPTION
This is nice because you can see where in a run someone may have failed.

![image](https://user-images.githubusercontent.com/5017202/112701629-65b6bc80-8e4e-11eb-83bc-d442195d2ad7.png)
