### PR TITLE
UTF-8 aware screenshots

### DIFF
--- a/BGAnimations/ScreenEvaluation common/Shared/ScreenshotHandler.lua
+++ b/BGAnimations/ScreenEvaluation common/Shared/ScreenshotHandler.lua
@@ -25,7 +25,7 @@ spr.CodeMessageCommand=function(self, params)
 		-- song titles can be very long, and the engine's SaveScreenshot() function
 		-- is already hardcoded to make the filename long via DateTime::GetNowDateTime()
 		-- so, let's use only the first 10 characters of the title in the screenshot filename
-		title = title:sub(1,10)
+		title = title:utf8sub(1,10)
 
 		-- some song titles have slashes in them, which is interpreted as a folder in the path as
 		-- screenshot is saved. we'll substitute those slashes with underscores to prevent this.


### PR DESCRIPTION
Issue #279 on GitHub reported:

> Screenshots created by Simply Love apparently contain the first 10 bytes
> of the song title, even if the 10-byte boundary falls in the middle of a
> UTF-8 character. This can result in invalid UTF-8 sequences in the
> resulting filename.
>
> For example:
>
> Neko Neko☆Super Fever Night
> 
> gets shortened to:
>
> Neko Neko�
>
> because the "☆" character is 3 bytes long in UTF-8.

This commit resolves that issue by replacing a call to Lua 5.1's native
`string.sub()` with `string.utf8sub()` which is made available from
[./Scripts/utf8.lua](https://github.com/Simply-Love/Simply-Love-SM5/blob/25079812ec71169494baac65e7c5b7dbc5a95490/Scripts/utf8.lua#L389)

With this commit, the example provided in the bug report will now be shortened
to: `Neko Neko☆`.