### PR TITLE
Add Song Search

### DIFF
--- a/BGAnimations/ScreenSelectMusic overlay/SongSearch/CandidateItemMT.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SongSearch/CandidateItemMT.lua
@@ -1,0 +1,69 @@
+-- the metatable for an item in the song search results.
+return {
+	__index = {
+		create_actors = function(self, name)
+			self.name=name
+
+			local af = Def.ActorFrame{
+				Name=name,
+
+				InitCommand=function(subself)
+					self.container = subself
+					subself:MaskDest()
+					subself:diffusealpha(0)
+				end,
+			}
+
+			-- Song Name
+			af[#af+1] = Def.BitmapText{
+				Font="Common Normal",
+				Name="Song",
+				InitCommand=function(subself)
+					self.song_name = subself
+					subself:y(0):diffusealpha(0)
+				end,
+				OnCommand=function(subself)
+					subself:sleep(0.13):linear(0.05):diffusealpha(1)
+				end
+			}
+
+			return af
+		end,
+
+		transform = function(self, item_index, num_items, has_focus)
+			self.container:finishtweening()
+
+			if has_focus then
+				self.container:accelerate(0.15)
+				self.container:diffuse( GetCurrentColor() )
+				self.container:glow(color("1,1,1,0.5"))
+			else
+				self.container:glow(color("1,1,1,0"))
+				self.container:accelerate(0.15)
+				self.container:diffuse(color("#888888"))
+				self.container:glow(color("1,1,1,0"))
+			end
+
+			self.container:y(30 * item_index)
+
+			if item_index < 1 or item_index > num_items then
+				self.container:diffusealpha(0)
+			else
+				self.container:diffusealpha(1)
+			end
+		end,
+
+		set = function(self, songOrExit)
+			if songOrExit == nil then self.song_name:settext("") return end
+
+			-- We need some way to differentiate between Songs and the "Exit" text.
+			-- Don't want to run into the issue of someone searching for "Exit".
+			if type(songOrExit) == "string" then
+				self.song_name:settext(songOrExit)
+			else
+				self.song_name:settext(songOrExit:GetDisplayMainTitle())
+			end
+			self.song_name.songOrExit = songOrExit
+		end
+	}
+}

--- a/BGAnimations/ScreenSelectMusic overlay/SongSearch/CandidateItemMT.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SongSearch/CandidateItemMT.lua
@@ -55,9 +55,6 @@ return {
 			else
 				self.container:diffusealpha(1)
 			end
-
-			self.container:diffusealpha(1)
-
 		end,
 
 		set = function(self, info)

--- a/BGAnimations/ScreenSelectMusic overlay/SongSearch/CandidateItemMT.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SongSearch/CandidateItemMT.lua
@@ -1,3 +1,6 @@
+local paneHeight = 319
+local paneWidth = 319
+
 -- the metatable for an item in the song search results.
 return {
 	__index = {
@@ -20,7 +23,7 @@ return {
 				Name="Song",
 				InitCommand=function(subself)
 					self.song_name = subself
-					subself:y(0):diffusealpha(0)
+					subself:y(0):diffusealpha(0):maxwidth(155)
 				end,
 				OnCommand=function(subself)
 					subself:sleep(0.13):linear(0.05):diffusealpha(1)
@@ -32,36 +35,42 @@ return {
 
 		transform = function(self, item_index, num_items, has_focus)
 			self.container:finishtweening()
-
+	
 			if has_focus then
-				self.container:accelerate(0.15)
+				self.container:accelerate(0.1)
 				self.container:diffuse( GetCurrentColor() )
 				self.container:glow(color("1,1,1,0.5"))
+				MESSAGEMAN:Broadcast("UpdateSearchResult", {songOrExit=self.song_name.songOrExit})
 			else
 				self.container:glow(color("1,1,1,0"))
-				self.container:accelerate(0.15)
+				self.container:accelerate(0.1)
 				self.container:diffuse(color("#888888"))
 				self.container:glow(color("1,1,1,0"))
 			end
 
 			self.container:y(30 * item_index)
 
-			if item_index < 1 or item_index > num_items then
+			if item_index <= 1 or item_index >= num_items then
 				self.container:diffusealpha(0)
 			else
 				self.container:diffusealpha(1)
 			end
+
+			self.container:diffusealpha(1)
+
 		end,
 
-		set = function(self, songOrExit)
-			if songOrExit == nil then self.song_name:settext("") return end
+		set = function(self, info)
+			if info == nil then self.song_name:settext("") return end
+
+			local songOrExit = info.songOrExit
 
 			-- We need some way to differentiate between Songs and the "Exit" text.
 			-- Don't want to run into the issue of someone searching for "Exit".
 			if type(songOrExit) == "string" then
-				self.song_name:settext(songOrExit)
+				self.song_name:settext(songOrExit):diffuse(Color.Red)
 			else
-				self.song_name:settext(songOrExit:GetDisplayMainTitle())
+				self.song_name:settext(songOrExit:GetDisplayMainTitle()):diffuse(Color.White)
 			end
 			self.song_name.songOrExit = songOrExit
 		end

--- a/BGAnimations/ScreenSelectMusic overlay/SongSearch/CandidateItemMT.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SongSearch/CandidateItemMT.lua
@@ -30,6 +30,20 @@ return {
 				end
 			}
 
+			-- Song Name
+			af[#af+1] = Def.BitmapText{
+				Font="Common Bold",
+				Name="Exit",
+				Text="Exit",
+				InitCommand=function(subself)
+					self.exit_text = subself
+					subself:y(0):diffusealpha(0):maxwidth(155):zoom(0.5):diffuse(Color.Red)
+				end,
+				OnCommand=function(subself)
+					subself:sleep(0.13):linear(0.05):diffusealpha(1)
+				end
+			}
+
 			return af
 		end,
 
@@ -62,12 +76,14 @@ return {
 
 			local songOrExit = info.songOrExit
 
-			-- We need some way to differentiate between Songs and the "Exit" text.
+			-- We use type(songOrExit) as a way to differentiate between Songs and the "Exit" text.
 			-- Don't want to run into the issue of someone searching for "Exit".
 			if type(songOrExit) == "string" then
-				self.song_name:settext(songOrExit):diffuse(Color.Red)
+				self.song_name:diffusealpha(0)
+				self.exit_text:diffusealpha(1)
 			else
-				self.song_name:settext(songOrExit:GetDisplayMainTitle()):diffuse(Color.White)
+				self.exit_text:diffusealpha(0)
+				self.song_name:diffusealpha(1):settext(songOrExit:GetDisplayMainTitle()):diffuse(Color.White)
 			end
 			self.song_name.songOrExit = songOrExit
 		end

--- a/BGAnimations/ScreenSelectMusic overlay/SongSearch/InputHandler.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SongSearch/InputHandler.lua
@@ -1,0 +1,28 @@
+local candidatesScroller = ...
+
+local input = function(event)
+    SM(event)
+    if not (event and event.PlayerNumber and event.button) then
+        return false
+    end
+
+    local overlay = SCREENMAN:GetTopScreen():GetChild("SongSearch")
+    
+    if event.type ~= "InputEventType_Release" then
+		if event.GameButton == "MenuRight" or event.GameButton == "MenuDown" then
+            SM("down")
+            candidatesScroller:scroll_by_amount(1)
+        elseif event.GameButton == "MenuLeft" or event.GameButton == "MenuUp" then
+            SM("Up")
+            candidatesScroller:scroll_by_amount(-1)
+        elseif event.GameButton == "Start" then
+            local focus = candidatesScroller:get_actor_item_at_focus_pos()
+            SM(TableToString(focus))
+        elseif event.GameButton == "Back" or event.GameButton == "Select" then
+            overlay:queuecommand("DirectInputToEngine")
+        end
+    end
+    return false
+end
+
+return input

--- a/BGAnimations/ScreenSelectMusic overlay/SongSearch/InputHandler.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SongSearch/InputHandler.lua
@@ -1,28 +1,35 @@
 local candidatesScroller = ...
 
 local input = function(event)
-    SM(event)
-    if not (event and event.PlayerNumber and event.button) then
-        return false
-    end
+	if not (event and event.PlayerNumber and event.button) then
+		return false
+	end
 
-    local overlay = SCREENMAN:GetTopScreen():GetChild("SongSearch")
-    
-    if event.type ~= "InputEventType_Release" then
+	local overlay = SCREENMAN:GetTopScreen():GetChild("Overlay"):GetChild("SongSearch")
+	
+	if event.type ~= "InputEventType_Release" then
+		local info = candidatesScroller:get_info_at_focus_pos()
+		local index = type(info)=="table" and info.index or 0
+		local num_items = type(info)=="table" and info.totalItems or candidatesScroller.num_items
 		if event.GameButton == "MenuRight" or event.GameButton == "MenuDown" then
-            SM("down")
-            candidatesScroller:scroll_by_amount(1)
-        elseif event.GameButton == "MenuLeft" or event.GameButton == "MenuUp" then
-            SM("Up")
-            candidatesScroller:scroll_by_amount(-1)
-        elseif event.GameButton == "Start" then
-            local focus = candidatesScroller:get_actor_item_at_focus_pos()
-            SM(TableToString(focus))
-        elseif event.GameButton == "Back" or event.GameButton == "Select" then
-            overlay:queuecommand("DirectInputToEngine")
-        end
-    end
-    return false
+			candidatesScroller:scroll_by_amount(1)
+		elseif event.GameButton == "MenuLeft" or event.GameButton == "MenuUp" then
+			candidatesScroller:scroll_by_amount(-1)
+		elseif event.GameButton == "Start" then
+			local focus = candidatesScroller:get_actor_item_at_focus_pos()
+			local songOrExit = focus.song_name.songOrExit
+			if type(songOrExit) ~= "string" then
+				GAMESTATE:SetPreferredSong(songOrExit)
+				local screen = SCREENMAN:GetTopScreen()
+				screen:SetNextScreenName("ScreenReloadSSM")
+				screen:StartTransitioningScreen("SM_GoToNextScreen")
+			end
+			overlay:queuecommand("DirectInputToEngine")
+		elseif event.GameButton == "Back" or event.GameButton == "Select" then
+			overlay:queuecommand("DirectInputToEngine")
+		end
+	end
+	return false
 end
 
 return input

--- a/BGAnimations/ScreenSelectMusic overlay/SongSearch/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SongSearch/default.lua
@@ -124,7 +124,7 @@ local overlay = Def.ActorFrame {
 		end
 	},
 
-	candidatesScroller:create_actors("Candidates", 10, candidateItemMt, -paneWidth/4, -paneHeight/2 - textHeight/2)
+	candidatesScroller:create_actors("Candidates", 12, candidateItemMt, -paneWidth/4, -paneHeight/2 - textHeight * 2.5)
 }
 
 local songDetails = {

--- a/BGAnimations/ScreenSelectMusic overlay/SongSearch/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SongSearch/default.lua
@@ -1,30 +1,7 @@
 -- sick_wheel_mt is a metatable with global scope defined in ./Scripts/Consensual-sick_wheel.lua
 local candidatesScroller = setmetatable({}, sick_wheel_mt)
 local candidateItemMt = LoadActor("CandidateItemMT.lua")
-local inputHandler = function(event)
-    SM(event)
-    if not (event and event.PlayerNumber and event.button) then
-        return false
-    end
-
-    -- local overlay = SCREENMAN:GetTopScreen():GetChild("SongSearch")
-    
-    if event.type ~= "InputEventType_Release" then
-		if event.GameButton == "MenuRight" or event.GameButton == "MenuDown" then
-            SM("down")
-            candidatesScroller:scroll_by_amount(1)
-        elseif event.GameButton == "MenuLeft" or event.GameButton == "MenuUp" then
-            SM("Up")
-            candidatesScroller:scroll_by_amount(-1)
-        elseif event.GameButton == "Start" then
-            local focus = candidatesScroller:get_actor_item_at_focus_pos()
-            SM(TableToString(focus))
-        elseif event.GameButton == "Back" or event.GameButton == "Select" then
-            -- overlay:queuecommand("DirectInputToEngine")
-        end
-    end
-    return false
-end
+local inputHandler = LoadActor("InputHandler.lua", candidatesScroller)
 
 local paneHeight = 319
 local paneWidth = 319
@@ -33,106 +10,197 @@ local borderWidth = 2
 local textHeight = 15
 
 local af = Def.ActorFrame {
-    Name="SongSearch",
-    InitCommand=function(self)
-        self:visible(false)
-    end,
-    DisplaySearchResultsMessageCommand=function(self, params)
-        self:visible(true)
-
-        SCREENMAN:GetTopScreen():AddInputCallback(inputHandler)
-        for player in ivalues(PlayerNumber) do
-            SCREENMAN:set_input_redirected(player, true)
-        end
-        self:playcommand("AssessCandidates", params)
-    end,
-    DirectInputToEngineCommand=function(self)
-        -- SCREENMAN:GetTopScreen():RemoveInputCallback(inputHandler)
-        -- for player in ivalues(PlayerNumber) do
-        --     SCREENMAN:set_input_redirected(player, false)
-        -- end
-        -- self:visible(false)
-    end,
-    -- slightly darken the entire screen
-    Def.Quad {
-        InitCommand=function(self)
-            self:FullScreen():diffuse(Color.Black):diffusealpha(0.8)
-        end
-    },
-    
-    Def.ActorFrame {
-        Name="Overlay",
-        InitCommand=function(self)
-            self:xy(_screen.cx, _screen.cy + 40)
-        end,
-
-        AssessCandidatesCommand=function(self, params)
-            self:GetChild("SearchText"):playcommand("UpdateText", params)
-            self:GetChild("NumResults"):playcommand("UpdateText", params)
-            table.insert(params.candidates, "Exit")
-            candidatesScroller.disable_wrapping = true
-            candidatesScroller.focus_pos = 1
-            candidatesScroller:set_info_set(params.candidates, 0)
-        end,
-
-        -- White border
-        Def.Quad {
-            InitCommand=function(self)
-                self:diffuse(Color.White)
-                self:zoomto(paneWidth + borderWidth, paneHeight + borderWidth)
-            end,
-        },
-
-        -- Main black body
-        Def.Quad {
-            InitCommand=function(self)
-                self:diffuse(Color.Black)
-                self:zoomto(paneWidth, paneHeight)
-            end,
-        },
-
-        Def.Quad {
-            InitCommand=function(self)
-                self:diffuse(color("0.2,0.2,0.2"))
-                self:zoomto(borderWidth, paneHeight - 10)
-            end,
-        },
-
-        LoadFont("Common Normal").. {
-            Text="Search Results For:",
-            InitCommand=function(self)
-                self:diffuse(Color.White)
-                self:y(-paneHeight/2 - textHeight * 5)
-            end,
-        },
-
-        LoadFont("Common Normal").. {
-            Name="SearchText",
-            InitCommand=function(self)
-                self:diffuse(Color.White)
-                self:y(-paneHeight/2 - textHeight * 3)
-            end,
-            UpdateTextCommand=function(self, params)
-                self:settext("\""..params.searchText.."\"")
-                self:AddAttribute(1, {Length=#self:GetText()-2; Diffuse=Color.Green})
-            end,
-        },
-
-        LoadFont("Common Normal").. {
-            Name="NumResults",
-            InitCommand=function(self)
-                self:diffuse(Color.White)
-                self:maxwidth(paneWidth/2)
-                self:y(-paneHeight/2 - textHeight)
-            end,
-            UpdateTextCommand=function(self, params)
-                self:settext(#params.candidates.." Results Found")
-            end
-        },
-
-        candidatesScroller:create_actors("Candidates", 10, candidateItemMt, -paneWidth/4, -paneHeight/2 - textHeight/2)
-    }
-
+	Name="SongSearch",
+	InitCommand=function(self)
+		self:visible(false)
+	end,
+	DisplaySearchResultsMessageCommand=function(self, params)
+		self:visible(true)
+		self:playcommand("AssessCandidates", params)
+		-- We have to wait a little bit before adding the input handler.
+		self:sleep(0.25):queuecommand("AddInputCallback")
+	end,
+	AddInputCallbackCommand=function(self)
+		SCREENMAN:GetTopScreen():AddInputCallback(inputHandler)
+		for player in ivalues(PlayerNumber) do
+			SCREENMAN:set_input_redirected(player, true)
+		end
+	end,
+	DirectInputToEngineCommand=function(self)
+		SCREENMAN:GetTopScreen():RemoveInputCallback(inputHandler)
+		for player in ivalues(PlayerNumber) do
+			SCREENMAN:set_input_redirected(player, false)
+		end
+		self:visible(false)
+	end,
+	-- slightly darken the entire screen
+	Def.Quad {
+		InitCommand=function(self)
+			self:FullScreen():diffuse(Color.Black):diffusealpha(0.8)
+		end
+	},
 }
+
+local overlay = Def.ActorFrame {
+	Name="Overlay",
+	InitCommand=function(self)
+		self:xy(_screen.cx, _screen.cy + 40)
+	end,
+
+	AssessCandidatesCommand=function(self, params)
+		self:GetChild("SearchText"):playcommand("UpdateText", params)
+		self:GetChild("NumResults"):playcommand("UpdateText", params)
+		local candidates = {}
+		for candidate in ivalues(params.candidates) do
+			table.insert(candidates, {
+				index=#candidates,
+				songOrExit=candidate,
+				totalItems=#params.candidates + 1
+			})
+		end
+		table.insert(candidates, {
+			index=#candidates,
+			songOrExit="Exit",
+			totalItems=#params.candidates + 1
+		})
+		-- candidatesScroller.disable_wrapping = true
+		-- candidatesScroller.focus_pos = 1
+		candidatesScroller:set_info_set(candidates, 1)
+		self:playcommand("UpdateScrollbar",  {numCandidates = #params.candidates})
+	end,
+
+	-- White border
+	Def.Quad {
+		InitCommand=function(self)
+			self:diffuse(Color.White)
+			self:zoomto(paneWidth + borderWidth, paneHeight + borderWidth)
+		end,
+	},
+
+	-- Main black body
+	Def.Quad {
+		InitCommand=function(self)
+			self:diffuse(Color.Black)
+			self:zoomto(paneWidth, paneHeight)
+		end,
+	},
+
+	Def.Quad {
+		InitCommand=function(self)
+			self:diffuse(color("0.2,0.2,0.2"))
+			self:zoomto(borderWidth, paneHeight - 10)
+		end,
+	},
+
+	LoadFont("Common Normal").. {
+		Text="Search Results For:",
+		InitCommand=function(self)
+			self:diffuse(Color.White)
+			self:y(-paneHeight/2 - textHeight * 5)
+		end,
+	},
+
+	LoadFont("Common Normal").. {
+		Name="SearchText",
+		InitCommand=function(self)
+			self:diffuse(Color.White)
+			self:y(-paneHeight/2 - textHeight * 3)
+		end,
+		UpdateTextCommand=function(self, params)
+			self:settext("\""..params.searchText.."\"")
+			self:AddAttribute(1, {Length=#self:GetText()-2; Diffuse=Color.Green})
+		end,
+	},
+
+	LoadFont("Common Normal").. {
+		Name="NumResults",
+		InitCommand=function(self)
+			self:diffuse(Color.White)
+			self:maxwidth(paneWidth/2)
+			self:y(-paneHeight/2 - textHeight)
+		end,
+		UpdateTextCommand=function(self, params)
+			self:settext(#params.candidates.." Results Found")
+		end
+	},
+
+	candidatesScroller:create_actors("Candidates", 10, candidateItemMt, -paneWidth/4, -paneHeight/2 - textHeight/2)
+}
+
+local songDetails = {
+	{ "Pack", function(song) return song:GetGroupName() end },
+	{ "Song", function(song) return song:GetDisplayMainTitle() end },
+	{ "Subtitle", function(song) return song:GetDisplaySubTitle() end },
+	{ "BPMs", function(song)
+		local bpms = song:GetDisplayBpms()
+		if bpms[2]-bpms[1] == 0 then
+			return string.format("%.0f", bpms[1])
+		else
+			return string.format("%.0f - %.0f", bpms[1], bpms[2])
+		end
+	end },
+	{ "Difficulties", function(song)
+		local stepsType = GAMESTATE:GetCurrentStyle():GetStepsType()
+		local difficulties = {
+			"Difficulty_Beginner",
+			"Difficulty_Easy",
+			"Difficulty_Medium",
+			"Difficulty_Hard",
+			"Difficulty_Challenge"
+		}
+		local outstring = ""
+		for difficulty in ivalues(difficulties) do
+			local steps = song:GetOneSteps(stepsType, difficulty)
+			if steps then
+				outstring = outstring .. steps:GetMeter() .. "   "
+			end
+		end
+		return outstring
+	end },
+}
+
+for i, details in ipairs(songDetails) do
+	local name = details[1]
+	local formatter = details[2]
+	overlay[#overlay+1] = LoadFont("Common Normal").. {
+		Name=name,
+		Text=name..": ",
+		InitCommand=function(self)
+			local zoom = 0.8
+			self:diffuse(color("#aaaaff")):zoom(zoom):maxwidth(145/zoom):horizalign(left)
+			self:xy(10, -paneHeight/2 + textHeight * zoom * (i*2-1) + 8*(i*2-1))
+		end,
+		UpdateSearchResultMessageCommand=function(self, params)
+			local songOrExit = params.songOrExit
+			if type(songOrExit) == "string" then
+				self:visible(false)
+			else
+				self:visible(true)
+			end
+		end,
+	}
+
+	overlay[#overlay+1] = LoadFont("Common Normal").. {
+		Name=name.."Text",
+		Text=name,
+		InitCommand=function(self)
+			local zoom = 0.8
+			self:diffuse(Color.White):zoom(zoom):maxwidth(115/zoom):horizalign(left)
+			self:xy(40, -paneHeight/2 + textHeight * zoom * (i*2) + 8*(i*2))
+		end,
+		UpdateSearchResultMessageCommand=function(self, params)
+			local songOrExit = params.songOrExit
+			if type(songOrExit) == "string" then
+				self:visible(false)
+			else
+				self:visible(true)
+				self:settext(formatter(songOrExit))
+			end
+		end
+	}
+end
+
+af[#af+1] = overlay
+
 
 return af

--- a/BGAnimations/ScreenSelectMusic overlay/SongSearch/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SongSearch/default.lua
@@ -1,0 +1,141 @@
+-- sick_wheel_mt is a metatable with global scope defined in ./Scripts/Consensual-sick_wheel.lua
+local candidatesScroller = setmetatable({}, sick_wheel_mt)
+local candidateItemMt = LoadActor("CandidateItemMT.lua")
+local inputHandler = function(event)
+    SM(event)
+    if not (event and event.PlayerNumber and event.button) then
+        return false
+    end
+
+    -- local overlay = SCREENMAN:GetTopScreen():GetChild("SongSearch")
+    
+    if event.type ~= "InputEventType_Release" then
+		if event.GameButton == "MenuRight" or event.GameButton == "MenuDown" then
+            SM("down")
+            candidatesScroller:scroll_by_amount(1)
+        elseif event.GameButton == "MenuLeft" or event.GameButton == "MenuUp" then
+            SM("Up")
+            candidatesScroller:scroll_by_amount(-1)
+        elseif event.GameButton == "Start" then
+            local focus = candidatesScroller:get_actor_item_at_focus_pos()
+            SM(TableToString(focus))
+        elseif event.GameButton == "Back" or event.GameButton == "Select" then
+            -- overlay:queuecommand("DirectInputToEngine")
+        end
+    end
+    return false
+end
+
+local paneHeight = 319
+local paneWidth = 319
+local borderWidth = 2
+
+local textHeight = 15
+local numScrollers = 6
+local scrollerHeight = (paneHeight - (numScrollers - 1) * borderWidth)/numScrollers
+local scrollerWidth = paneWidth/2
+
+local af = Def.ActorFrame {
+    Name="SongSearch",
+    InitCommand=function(self)
+        self:visible(false)
+    end,
+    DisplaySearchResultsMessageCommand=function(self, params)
+        self:visible(true)
+
+        SCREENMAN:GetTopScreen():AddInputCallback(inputHandler)
+        for player in ivalues(PlayerNumber) do
+            SCREENMAN:set_input_redirected(player, true)
+        end
+        self:playcommand("AssessCandidates", params)
+    end,
+    DirectInputToEngineCommand=function(self)
+        -- SCREENMAN:GetTopScreen():RemoveInputCallback(inputHandler)
+        -- for player in ivalues(PlayerNumber) do
+        --     SCREENMAN:set_input_redirected(player, false)
+        -- end
+        -- self:visible(false)
+    end,
+    -- slightly darken the entire screen
+    Def.Quad {
+        InitCommand=function(self)
+            self:FullScreen():diffuse(Color.Black):diffusealpha(0.8)
+        end
+    },
+    
+    Def.ActorFrame {
+        Name="Overlay",
+        InitCommand=function(self)
+            self:xy(_screen.cx, _screen.cy + 40)
+        end,
+
+        AssessCandidatesCommand=function(self, params)
+            self:GetChild("SearchText"):playcommand("UpdateText", params)
+            self:GetChild("NumResults"):playcommand("UpdateText", params)
+            table.insert(params.candidates, "Exit")
+            candidatesScroller.disable_wrapping = true
+            candidatesScroller.focus_pos = 1
+            candidatesScroller:set_info_set(params.candidates, 0)
+        end,
+
+        -- White border
+        Def.Quad {
+            InitCommand=function(self)
+                self:diffuse(Color.White)
+                self:zoomto(paneWidth + borderWidth, paneHeight + borderWidth)
+            end,
+        },
+
+        -- Main black body
+        Def.Quad {
+            InitCommand=function(self)
+                self:diffuse(Color.Black)
+                self:zoomto(paneWidth, paneHeight)
+            end,
+        },
+
+        Def.Quad {
+            InitCommand=function(self)
+                self:diffuse(color("0.2,0.2,0.2"))
+                self:zoomto(borderWidth, paneHeight - 10)
+            end,
+        },
+
+        LoadFont("Common Normal").. {
+            Text="Search Results For:",
+            InitCommand=function(self)
+                self:diffuse(Color.White)
+                self:y(-paneHeight/2 - textHeight * 5)
+            end,
+        },
+
+        LoadFont("Common Normal").. {
+            Name="SearchText",
+            InitCommand=function(self)
+                self:diffuse(Color.White)
+                self:y(-paneHeight/2 - textHeight * 3)
+            end,
+            UpdateTextCommand=function(self, params)
+                self:settext("\""..params.searchText.."\"")
+                self:AddAttribute(1, {Length=#self:GetText()-2; Diffuse=Color.Green})
+            end,
+        },
+
+        LoadFont("Common Normal").. {
+            Name="NumResults",
+            InitCommand=function(self)
+                self:diffuse(Color.White)
+                self:maxwidth(paneWidth/2)
+                self:y(-paneHeight/2 - textHeight)
+            end,
+            UpdateTextCommand=function(self, params)
+                self:settext(#params.candidates.." Results Found")
+            end
+        },
+
+        candidatesScroller:create_actors("Candidates", 10, candidateItemMt, -paneWidth/4, -paneHeight/2 - textHeight/2)
+    }
+
+}
+
+return af

--- a/BGAnimations/ScreenSelectMusic overlay/SongSearch/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SongSearch/default.lua
@@ -31,9 +31,6 @@ local paneWidth = 319
 local borderWidth = 2
 
 local textHeight = 15
-local numScrollers = 6
-local scrollerHeight = (paneHeight - (numScrollers - 1) * borderWidth)/numScrollers
-local scrollerWidth = paneWidth/2
 
 local af = Def.ActorFrame {
     Name="SongSearch",

--- a/BGAnimations/ScreenSelectMusic overlay/SortMenu/SortMenu_InputHandler.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SortMenu/SortMenu_InputHandler.lua
@@ -29,7 +29,6 @@ local input = function(event)
 				MESSAGEMAN:Broadcast('Sort',{order=focus.sort_by})
 				overlay:queuecommand("DirectInputToEngine")
 
-
 			-- the player wants to change modes, for example from ITG to FA+
 			elseif focus.kind == "ChangeMode" then
 				SL.Global.GameMode = focus.change
@@ -43,7 +42,6 @@ local input = function(event)
 				-- Reload the SortMenu's available options and queue "DirectInputToEngine"
 				-- to return input from Lua back to the engine and hide the SortMenu from view
 				sortmenu:playcommand("AssessAvailableChoices"):queuecommand("DirectInputToEngine")
-
 
 			-- the player wants to change styles, for example from single to double
 			elseif focus.kind == "ChangeStyle" then
@@ -72,6 +70,10 @@ local input = function(event)
 				elseif focus.new_overlay == "Leaderboard" then
 					-- The leaderboard entry is removed altogether if the service isn't available.
 					sortmenu:queuecommand("DirectInputToLeaderboard")
+				elseif focus.new_overlay == "SongSearch" then
+					-- Direct the input back to the engine, so that the ScreenTextEntry overlay
+					-- works correctly.
+					overlay:playcommand("DirectInputToEngine", {songSearch=true})
 				end
 			end
 

--- a/BGAnimations/ScreenSelectMusic overlay/SortMenu/SortMenu_InputHandler.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SortMenu/SortMenu_InputHandler.lua
@@ -73,7 +73,7 @@ local input = function(event)
 				elseif focus.new_overlay == "SongSearch" then
 					-- Direct the input back to the engine, so that the ScreenTextEntry overlay
 					-- works correctly.
-					overlay:playcommand("DirectInputToEngine", {songSearch=true})
+					overlay:queuecommand("DirectInputToEngineForSongSearch")
 				end
 			end
 

--- a/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
@@ -355,10 +355,12 @@ local t = Def.ActorFrame {
 			end
 		end
 
-		for device in ivalues(INPUTMAN:GetDescriptions()) do
-			-- Only display this option if a Keyboard is actually connected.
-			if device == "Keyboard" then
-				table.insert(wheel_options, {"WhereforeArtThou", "SongSearch"})
+		if not GAMESTATE:IsCourseMode() then
+			for device in ivalues(INPUTMAN:GetDescriptions()) do
+				-- Only display this option if a Keyboard is actually connected.
+				if device == "Keyboard" then
+					table.insert(wheel_options, {"WhereforeArtThou", "SongSearch"})
+				end
 			end
 		end
 

--- a/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
@@ -38,14 +38,14 @@ local hasSong = GAMESTATE:GetCurrentSong() and true or false
 
 local FilterTable = function(arr, func)
 	local new_index = 1
-    local size_orig = #arr
-    for v in ivalues(arr) do
-        if func(v) then
-            arr[new_index] = v
-            new_index = new_index + 1
-        end
-    end
-    for i = new_index, size_orig do arr[i] = nil end
+	local size_orig = #arr
+	for v in ivalues(arr) do
+		if func(v) then
+			arr[new_index] = v
+			new_index = new_index + 1
+		end
+	end
+	for i = new_index, size_orig do arr[i] = nil end
 end
 
 local GetBpmTier = function(bpm)
@@ -53,10 +53,10 @@ local GetBpmTier = function(bpm)
 end
 
 local SongSearchSettings = {
-    Question="Search: ",
-    InitialAnswer="",
-    MaxInputLength=30,
-    OnOK=function(input)
+	Question="'pack/song' format will search for songs in specific packs\n'[###]' format will search for BPMs/Difficulties",
+	InitialAnswer="",
+	MaxInputLength=30,
+	OnOK=function(input)
 		if #input == 0 then return end
 
 		-- Lowercase the input text for comparison
@@ -150,7 +150,7 @@ local SongSearchSettings = {
 
 		-- Even if we don't have any results, we want to show that to the player.
 		MESSAGEMAN:Broadcast("DisplaySearchResults", {searchText=input, candidates=candidates})
-    end,
+	end,
 }
 
 ------------------------------------------------------------

--- a/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
@@ -44,13 +44,17 @@ local SongSearchSettings = {
     OnOK=function(input)
 		local searchText = input:lower()
 		local candidates = {}
+		local stepsType = GAMESTATE:GetCurrentStyle():GetStepsType()
         if #input ~= 0 then
 			local allSongs = SONGMAN:GetAllSongs()
 			for song in ivalues(allSongs) do
-				-- Search both the normal title as well as the transliterated title.
-				if song:GetDisplayFullTitle():lower():find(searchText) ~= nil or
-						song:GetTranslitFullTitle():lower():find(searchText) ~= nil then
-					table.insert(candidates, song)
+				-- Only add valid candidates if there are steps in the current mode.
+				if song:HasStepsType(stepsType) then
+					-- Search both the normal title as well as the transliterated title.
+					if song:GetDisplayFullTitle():lower():find(searchText) ~= nil or
+							song:GetTranslitFullTitle():lower():find(searchText) ~= nil then
+						table.insert(candidates, song)
+					end
 				end
 			end
 

--- a/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
@@ -135,7 +135,22 @@ local t = Def.ActorFrame {
 		overlay:playcommand("ShowLeaderboard")
 	end,
 	-- this returns input back to the engine and its ScreenSelectMusic
-	DirectInputToEngineCommand=function(self, params)
+	DirectInputToEngineCommand=function(self)
+		local screen = SCREENMAN:GetTopScreen()
+		local overlay = self:GetParent()
+
+		screen:RemoveInputCallback(sortmenu_input)
+		screen:RemoveInputCallback(testinput_input)
+		screen:RemoveInputCallback(leaderboard_input)
+
+		for player in ivalues(PlayerNumber) do
+			SCREENMAN:set_input_redirected(player, false)
+		end
+		self:playcommand("HideSortMenu")
+		overlay:playcommand("HideTestInput")
+		overlay:playcommand("HideLeaderboard")
+	end,
+	DirectInputToEngineForSongSearchCommand=function(self)
 		local screen = SCREENMAN:GetTopScreen()
 		local overlay = self:GetParent()
 
@@ -150,12 +165,6 @@ local t = Def.ActorFrame {
 		overlay:playcommand("HideTestInput")
 		overlay:playcommand("HideLeaderboard")
 
-		-- Begin the song search if we're redirecting to the engine because of that.
-		if params.songSearch then
-			self:queuecommand("StartSongSearch")
-		end
-	end,
-	StartSongSearchCommand=function(self)
 		-- Then add the ScreenTextEntry on top.
 		SCREENMAN:AddNewScreenToTop("ScreenTextEntry")
 		SCREENMAN:GetTopScreen():Load(SongSearchSettings)

--- a/BGAnimations/ScreenSelectMusic overlay/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/default.lua
@@ -48,6 +48,8 @@ local af = Def.ActorFrame{
 	-- a yes/no prompt overlay for backing out of SelectMusic when in EventMode can be
 	-- activated via "CodeEscapeFromEventMode" under [ScreenSelectMusic] in Metrics.ini
 	LoadActor("./EscapeFromEventMode.lua"),
+
+	LoadActor("./SongSearch/default.lua"),
 }
 
 return af

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -172,6 +172,10 @@ TestInput=Test Input
 GrooveStats=GrooveStats
 Leaderboard=Leaderboard
 
+# Song Search Text
+SongSearch=Song Search
+WhereforeArtThou=Wherefore Art Thou?
+
 # prompt players before exiting via LLRRLLRR
 PromptBeforeExiting=Do you want to exit this game?
 YesInfo=I'm finished.


### PR DESCRIPTION
For an initial implementation this seems pretty sufficient. There is definitely room for improvement especially in terms of styling and the supplementary content we display, but that can be added later.

- Song search is added to the sort menu (ONLY when not in course mode AND a keyboard is connected)
![image](https://user-images.githubusercontent.com/5017202/116981206-0c774f80-ac7c-11eb-8e5c-97d5209af687.png)

- This brings up a ScreenTextEntry where a user can enter a search term:
![image](https://user-images.githubusercontent.com/5017202/116981459-5c561680-ac7c-11eb-9bbb-5f9261a247c4.png)

- We then display some details of the resultant songs
![image](https://user-images.githubusercontent.com/5017202/116981514-7263d700-ac7c-11eb-8a7c-badc9bddbfb9.png)

- Selecting a song from this wheel will reload SSM on the selected song.
![image](https://user-images.githubusercontent.com/5017202/116981975-18174600-ac7d-11eb-8e76-565c2b0e6e6c.png)

- We also support special tags:
`[number]` -> Used for difficulty and bpm tier filters (if number is <= 35 it's a difficulty, otherwise a bpm)
`pack/song` -> performs two separate searches one for the the pack name and one for the song name. We separate on the first instance of a `/` character.

For example `[14] [190] sharp/aim` will return:
![image](https://user-images.githubusercontent.com/5017202/116981661-b1922800-ac7c-11eb-92eb-d4b904e99bbb.png)

As `Aim Burst` is a `190` bpm tier song from `SharpnelStreamz` that has a `14` difficulty.


