### PR TITLE
Align NPS graph, scatter plot and lifebar on the eval screen

### DIFF
--- a/BGAnimations/ScreenEvaluation common/PerPlayer/Lower/Graphs.lua
+++ b/BGAnimations/ScreenEvaluation common/PerPlayer/Lower/Graphs.lua
@@ -54,6 +54,24 @@ af[#af+1] = Def.GraphDisplay{
 		local ColorIndex = ((SL.Global.ActiveColorIndex + (player==PLAYER_1 and -1 or 1)) % #SL.Colors) + 1
 		self:Load("GraphDisplay" .. ColorIndex )
 
+		if not GAMESTATE:IsCourseMode() then
+			local steps = GAMESTATE:GetCurrentSteps(player)
+			local timingData = steps:GetTimingData()
+			local firstSecond = math.min(timingData:GetElapsedTimeFromBeat(0), 0)
+			local chartStartSecond = GAMESTATE:GetCurrentSong():GetFirstSecond()
+			local lastSecond = GAMESTATE:GetCurrentSong():GetLastSecond()
+			local duration = lastSecond - firstSecond
+
+			-- GraphDisplay starts at chartStartSecond, but the NPS graph
+			-- and the scatter plot start at firstSecond, so we have to
+			-- move the lifebar to the correct offset to align it with the
+			-- NPS graph.
+			local offsetFactor = (chartStartSecond - firstSecond) / duration
+			local offset = GraphWidth * offsetFactor
+			self:addx(offset/2)
+			self:SetWidth(GraphWidth - offset)
+		end
+
 		local playerStageStats = STATSMAN:GetCurStageStats():GetPlayerStageStats(player)
 		local stageStats = STATSMAN:GetCurStageStats()
 		self:Set(stageStats, playerStageStats)
@@ -68,5 +86,6 @@ af[#af+1] = Def.GraphDisplay{
 		end
 	end
 }
+
 
 return af

--- a/BGAnimations/ScreenEvaluation common/PerPlayer/Lower/ScatterPlot.lua
+++ b/BGAnimations/ScreenEvaluation common/PerPlayer/Lower/ScatterPlot.lua
@@ -15,9 +15,9 @@ local sequential_offsets = SL[ToEnumShortString(player)].Stages.Stats[SL.Global.
 local verts= {}
 local Steps = GAMESTATE:GetCurrentSteps(player)
 local TimingData = Steps:GetTimingData()
--- TotalSeconds is used in scaling the x-coordinates of the AMV's vertices
+-- FirstSecond and LastSecond are used in scaling the x-coordinates of the AMV's vertices
 local FirstSecond = math.min(TimingData:GetElapsedTimeFromBeat(0), 0)
-local TotalSeconds = GAMESTATE:GetCurrentSong():GetLastSecond()
+local LastSecond = GAMESTATE:GetCurrentSong():GetLastSecond()
 
 -- variables that will be used and re-used in the loop while calculating the AMV's vertices
 local Offset, CurrentSecond, TimingWindow, x, y, c, r, g, b
@@ -58,7 +58,7 @@ for t in ivalues(sequential_offsets) do
 	end
 
 	-- pad the right end because the time measured seems to lag a little...
-	x = scale(CurrentSecond, FirstSecond, TotalSeconds + 0.05, 0, GraphWidth)
+	x = scale(CurrentSecond, FirstSecond, LastSecond + 0.05, 0, GraphWidth)
 
 	if Offset ~= "Miss" then
 		-- DetermineTimingWindow() is defined in ./Scripts/SL-Helpers.lua

--- a/Scripts/SL-Histogram.lua
+++ b/Scripts/SL-Histogram.lua
@@ -92,6 +92,15 @@ local function gen_vertices(player, width, height, desaturation)
 				end
 			end
 		end
+
+		-- Insert a 0 NPS datapoint at the end of the graph, otherwise
+		-- the last measure will not have a nice downwards slope like
+		-- all the other measures but end abruptly at the start of the
+		-- measure.
+		if NPSperMeasure[#NPSperMeasure] ~= 0 then
+			verts[#verts+1] = {{width, 0, 0}, blue}
+			verts[#verts+1] = {{width, 0, 0}, blue}
+		end
 	end
 
 	return verts


### PR DESCRIPTION
Two things are necessary to do this:
- Offset the lifebar to the correct position; GraphDisplay starts at the first note, but the NPS graph and the scatterplot start at the
  beginning of the music.
- (more subtle) Insert a 0 NPS datapoint at the end of the NPS graph to not make it end abruptly, but have a downward slope for the last measure.

# Before

![Screenshot_20210509_174950](https://user-images.githubusercontent.com/27127/117579616-02c66f80-b0f4-11eb-8fba-b5fd678065f1.png)

# After

![Screenshot_20210509_175145](https://user-images.githubusercontent.com/27127/117579621-0c4fd780-b0f4-11eb-85a0-302a4586c9cb.png)
![Screenshot_20210509_180325](https://user-images.githubusercontent.com/27127/117579626-0ce86e00-b0f4-11eb-90a8-066590038abc.png)

Thanks, @Roujo for reporting the issue!
