### PR TITLE
Clear stream data if we can't parse a chart

### DIFF
--- a/BGAnimations/ScreenSelectMusic overlay/PerPlayer/DensityGraph.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/PerPlayer/DensityGraph.lua
@@ -233,7 +233,7 @@ for i, row in ipairs(layout) do
 					local streamMeasures, breakMeasures = GetTotalStreamAndBreakMeasures(pn)
 					local totalMeasures = streamMeasures + breakMeasures
 					if streamMeasures == 0 then
-						self:settext("None (0.00%)")
+						self:settext("None (0.0%)")
 					else
 						self:settext(string.format("%d/%d (%0.1f%%)", streamMeasures, totalMeasures, streamMeasures/totalMeasures*100))
 					end

--- a/Scripts/SL-ChartParser.lua
+++ b/Scripts/SL-ChartParser.lua
@@ -707,6 +707,8 @@ ParseChartInfo = function(steps, pn)
 			SL[pn].Streams.Difficulty ~= difficulty or
 			SL[pn].Streams.Description ~= description) then
 		local simfileString, fileType = GetSimfileString( steps )
+		local parsed = false
+
 		if simfileString then
 			-- Parse out just the contents of the notes
 			local chartString, BPMs = GetSimfileChartString(simfileString, stepsType, difficulty, description, fileType)
@@ -738,7 +740,28 @@ ParseChartInfo = function(steps, pn)
 				SL[pn].Streams.StepsType = stepsType
 				SL[pn].Streams.Difficulty = difficulty
 				SL[pn].Streams.Description = description
+
+				parsed = true
 			end
+		end
+
+		-- Clear stream data if we can't parse the chart
+		if not parsed then
+			SL[pn].Streams.NotesPerMeasure = {}
+			SL[pn].Streams.PeakNPS = 0
+			SL[pn].Streams.NPSperMeasure = {}
+			SL[pn].Streams.Hash = ''
+
+			SL[pn].Streams.Crossovers = 0
+			SL[pn].Streams.Footswitches = 0
+			SL[pn].Streams.Sideswitches = 0
+			SL[pn].Streams.Jacks = 0
+			SL[pn].Streams.Brackets = 0
+
+			SL[pn].Streams.Filename = filename
+			SL[pn].Streams.StepsType = stepsType
+			SL[pn].Streams.Difficulty = difficulty
+			SL[pn].Streams.Description = description
 		end
 	end
 end

--- a/Scripts/SL-ChartParserHelpers.lua
+++ b/Scripts/SL-ChartParserHelpers.lua
@@ -106,7 +106,7 @@ end
 -- minimization_level = 3  -> Aggregating total streams
 --    80 Total
 GenerateBreakdownText = function(pn, minimization_level)
-	if #SL[pn].Streams.NotesPerMeasure == 0 then return 'No Streams!' end
+	if #SL[pn].Streams.NotesPerMeasure == 0 then return 'Not available!' end
 
 	-- Assume 16ths for the breakdown text
 	local segments = GetStreamSequences(SL[pn].Streams.NotesPerMeasure, 16)


### PR DESCRIPTION
That way we show an empty NPS graph and pattern info instead of the data from the previously selected song.