### PR TITLE
Don't use the engine's BinaryToHex function.

### DIFF
--- a/Scripts/SL-ChartParser.lua
+++ b/Scripts/SL-ChartParser.lua
@@ -27,7 +27,8 @@ local GetSimfileString = function(steps)
 end
 
 -- ----------------------------------------------------------------
--- Prefer using the engine's BinaryToHex function if it's available.
+-- We use our own BinaryToHex function as it seems like the current
+-- implementation from the engine doesn't handle sequential zeroes correctly.
 local Bin2Hex = function(s)
 	local hex_bytes = {}
 	for i = 1, string.len(s), 1 do

--- a/Scripts/SL-ChartParser.lua
+++ b/Scripts/SL-ChartParser.lua
@@ -28,7 +28,7 @@ end
 
 -- ----------------------------------------------------------------
 -- Prefer using the engine's BinaryToHex function if it's available.
-local Bin2Hex = type(BinaryToHex)=="function" and BinaryToHex or function(s)
+local Bin2Hex = function(s)
 	local hex_bytes = {}
 	for i = 1, string.len(s), 1 do
 		hex_bytes[#hex_bytes+1] = string.format('%02x', string.byte(s, i))


### PR DESCRIPTION
It seems like the engine's function doesn't handle sequential zeroes correctly.

Example: If you build SM from head, the challenge chart for Polaris from Tachyon Zeta no longer works (it truncates the hash when it encounters a 00 in the hash).

I believe this is because of the following:
- 00 maps to '\0' which is the null character and denotes the "end of string"
- https://github.com/stepmania/stepmania/blob/984dc8668f1fedacf553f279a828acdebffc5625/src/RageUtil.cpp#L242
We pass in a binary string but calling .size() on it will return truncate the hash because of the existence of this null character. 