### PR TITLE
Update text when any request has timed out

### DIFF
--- a/BGAnimations/ScreenEvaluation common/Shared/AutoSubmitScore.lua
+++ b/BGAnimations/ScreenEvaluation common/Shared/AutoSubmitScore.lua
@@ -31,6 +31,12 @@ end
 local AutoSubmitRequestProcessor = function(res, overlay)
 	local P1SubmitText = overlay:GetChild("AutoSubmitMaster"):GetChild("P1SubmitText")
 	local P2SubmitText = overlay:GetChild("AutoSubmitMaster"):GetChild("P2SubmitText")
+	if res == nil then
+		if P1SubmitText then P1SubmitText:queuecommand("TimedOut") end
+		if P2SubmitText then P2SubmitText:queuecommand("TimedOut") end
+		return
+	end
+
 	local panes = overlay:GetChild("Panes")
 	local hasRpgData = false
 
@@ -177,7 +183,7 @@ end
 
 local af = Def.ActorFrame {
 	Name="AutoSubmitMaster",
-	RequestResponseActor("AutoSubmit", 10)..{
+	RequestResponseActor("AutoSubmit", 30)..{
 		OnCommand=function(self)
 			local sendRequest = false
 			local data = {
@@ -278,6 +284,9 @@ af[#af+1] = LoadFont("Common Normal").. {
 	ServiceDisabledCommand=function(self)
 		self:settext("Submit Disabled")
 	end,
+	TimedOutCommand=function(self)
+		self:settext("Timed Out")
+	end
 }
 
 af[#af+1] = LoadFont("Common Normal").. {
@@ -303,6 +312,9 @@ af[#af+1] = LoadFont("Common Normal").. {
 	ServiceDisabledCommand=function(self)
 		self:settext("Submit Disabled")
 	end,
+	TimedOutCommand=function(self)
+		self:settext("Timed Out")
+	end
 }
 
 af[#af+1] = Def.Sprite{

--- a/BGAnimations/ScreenSelectMusic overlay/Leaderboard.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/Leaderboard.lua
@@ -94,6 +94,24 @@ end
 
 local LeaderboardRequestProcessor = function(res, master)
 	if master == nil then return end
+
+	if res == nil then
+		for i=1, 2 do
+			local pn = "P"..i
+			local leaderboard = master:GetChild(pn.."Leaderboard")
+			for j=1, NumEntries do
+				local entry = leaderboard:GetChild("LeaderboardEntry"..j)
+				if j == 1 then
+					SetEntryText("", "Timed Out", "", "", entry)
+				else
+					-- Empty out the remaining rows.
+					SetEntryText("", "", "", "", entry)
+				end
+			end
+		end
+		return
+	end
+
 	local data = res["status"] == "success" and res["data"] or nil
 
 	for i=1, 2 do
@@ -136,9 +154,9 @@ local LeaderboardRequestProcessor = function(res, master)
 			local leaderboardData = leaderboardList[1]
 			SetLeaderboardForPlayer(i, leaderboard, leaderboardData, master[pn].isRanked)
 		elseif res["status"] == "fail" then
-			for i=1, NumEntries do
-				local entry = leaderboard:GetChild("LeaderboardEntry"..i)
-				if i == 1 then
+			for j=1, NumEntries do
+				local entry = leaderboard:GetChild("LeaderboardEntry"..j)
+				if j == 1 then
 					SetEntryText("", "Failed to Load 😞", "", "", entry)
 				else
 					-- Empty out the remaining rows.
@@ -146,9 +164,9 @@ local LeaderboardRequestProcessor = function(res, master)
 				end
 			end
 		elseif res["status"] == "disabled" then
-			for i=1, NumEntries do
-				local entry = leaderboard:GetChild("LeaderboardEntry"..i)
-				if i == 1 then
+			for j=1, NumEntries do
+				local entry = leaderboard:GetChild("LeaderboardEntry"..j)
+				if j == 1 then
 					SetEntryText("", "Leaderboard Disabled", "", "", entry)
 				else
 					-- Empty out the remaining rows.

--- a/BGAnimations/ScreenSelectMusic overlay/PaneDisplay.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/PaneDisplay.lua
@@ -67,6 +67,16 @@ local GetScoresRequestProcessor = function(res, master)
 	-- we don't run the RequestResponseActor in CourseMode.
 	if GAMESTATE:GetCurrentSong() == nil then return end
 
+	if res == nil then
+		for i=1,2 do
+			local paneDisplay = master:GetChild("PaneDisplayP"..i)
+			local loadingText = paneDisplay:GetChild("Loading")
+			loadingText:settext("Timed Out")
+		end
+
+		return
+	end
+
 	for i=1,2 do
 		local paneDisplay = master:GetChild("PaneDisplayP"..i)
 

--- a/BGAnimations/ScreenSystemLayer overlay.lua
+++ b/BGAnimations/ScreenSystemLayer overlay.lua
@@ -243,7 +243,7 @@ t[#t+1] = RequestResponseActor("PingLauncher", 10)..{
 			callback=function(res, args)
 				SL.GrooveStats.Launcher = true
 				MESSAGEMAN:Broadcast("NewSessionRequest")
-			end
+			end,
 		})
 	end
 }
@@ -268,6 +268,11 @@ local NewSessionRequestProcessor = function(res, gsInfo)
 	service1:visible(false)
 	service2:visible(false)
 	service3:visible(false)
+
+	if res == nil then
+		groovestats:settext("Timed Out")
+		return
+	end
 
 	if not res["status"] == "success" then
 		if res["status"] == "fail" then
@@ -361,7 +366,6 @@ local NewSessionRequestProcessor = function(res, gsInfo)
 	DiffuseEmojis(service1:ClearAttributes())
 	DiffuseEmojis(service2:ClearAttributes())
 	DiffuseEmojis(service3:ClearAttributes())
-
 end
 
 local function DiffuseText(bmt)
@@ -448,7 +452,7 @@ t[#t+1] = Def.ActorFrame{
 				MESSAGEMAN:Broadcast("NewSession", {
 					data={action="groovestats/new-session", ChartHashVersion=SL.GrooveStats.ChartHashVersion},
 					args=self:GetParent(),
-					callback=NewSessionRequestProcessor
+					callback=NewSessionRequestProcessor,
 				})
 			end
 		end

--- a/BGAnimations/ScreenSystemLayer overlay.lua
+++ b/BGAnimations/ScreenSystemLayer overlay.lua
@@ -241,6 +241,8 @@ t[#t+1] = RequestResponseActor("PingLauncher", 10)..{
 			data={action="ping", protocol=1},
 			args={},
 			callback=function(res, args)
+				if res == nil then return end
+
 				SL.GrooveStats.Launcher = true
 				MESSAGEMAN:Broadcast("NewSessionRequest")
 			end,


### PR DESCRIPTION
This PR does a couple of things
- Adds timeout support to the RequestResponseActor (if the data is nil, this indicates a timeout). I originally had a separate callback specifically for timeouts but I felt like I ended up just duplicated a lot of the code. Current implementation seems to get the job done and makes sense since we won't have any data if the response never succeeds so it makes sense.
- Updates AutoSubmit timeout to 30s (from 10s)
- Empty string handling when parsing a response (jsong.decode doesnt accept empty strings afaict)
- Added a stoptweening + initial 100ms sleep before the initial wait.