### PR TITLE
ScreenEvaluation - Pane 5 - Bugfix test input graph during double mode if controller is P2

### DIFF
--- a/BGAnimations/ScreenEvaluation common/Panes/Pane5/default.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane5/default.lua
@@ -10,14 +10,15 @@ if not (game=="dance" or game=="pump" or game=="techno") then return end
 
 -- -----------------------------------------------------------------------
 
-local player = unpack(...)
+local player, controller = unpack(...)
 
 local style = ToEnumShortString(GAMESTATE:GetCurrentStyle():GetStyleType())
 
 local pane = Def.ActorFrame{
 	InitCommand=function(self)
 		if style == "OnePlayerTwoSides" then
-			self:x( 50)
+			if controller == PLAYER_2 then self:x(-260) 
+			else self:x(50) end
 		end
 	end,
 	-- ExpandForDoubleCommand() does not do anything here, but we check for its presence in


### PR DESCRIPTION
Hello! I've found this graphic issue on ScreenEvalutation\Pane5, which is reproducible only during Double Mode and when the pane "controller" is the P2 side.

Here a screenshot as is:
![2021-07-14_145403](https://user-images.githubusercontent.com/10159143/125625441-11e0c990-baee-4c42-a1f8-5aae9fa914e6.png)

And after my fix, here the screenshot:
![2021-07-14_145739](https://user-images.githubusercontent.com/10159143/125625941-e162a61b-51df-4904-8d24-1cff12180fa5.png)

Hoping this can be helpful :)
Viper