### PR TITLE
Fix display of negative score/rate deltas in the RPG overlay

### DIFF
--- a/BGAnimations/ScreenEvaluation common/Shared/RpgOverlay.lua
+++ b/BGAnimations/ScreenEvaluation common/Shared/RpgOverlay.lua
@@ -159,12 +159,12 @@ local GetPaneFunctions = function(rpgAf, rpgData, player)
 
 	table.insert(paneTexts, string.format(
 		"Skill Improvements\n\n"..
-		"%.2f%% (%s%.2f%%) at\n"..
-		"%.2fx (%s%.2fx) rate\n\n"..
+		"%.2f%% (%+.2f%%) at\n"..
+		"%.2fx (%+.2fx) rate\n\n"..
 		"%s"..
 		"%s",
-		score, scoreDelta < 0 and "-" or "+", scoreDelta,
-		rate, rateDelta < 0 and "-" or "+", rateDelta,
+		score, scoreDelta,
+		rate, rateDelta,
 		#statImprovements == 0 and "" or table.concat(statImprovements, "\n").."\n\n",
 		#skillImprovements == 0 and "" or table.concat(skillImprovements, "\n").."\n\n"
 	))


### PR DESCRIPTION
Previously negative deltas were displayed with two minus signs prepended to them. %.2f in a format string prepends a '-' for negative values, but doesn't include a sign for positive values. Let's use %+.2f instead, which always formatts in the sign, so we don't have to special case negative values.