### PR TITLE
Note animation settings

### DIFF
--- a/Graphics/Player judgment.lua
+++ b/Graphics/Player judgment.lua
@@ -60,7 +60,10 @@ return Def.ActorFrame{
 		--sprite:zoom(0.8):decelerate(0.1):zoom(0.75):sleep(0.6):accelerate(0.2):zoom(0)
 
 		-- this should match the behaviour of Etterna
-		sprite:zoom(0.75)
+		--sprite:zoom(0.75)
+
+		-- this should match the behaviour of ITG2/ITG3
+		sprite:zoom(1):decelerate(0.2):zoom(0.75):sleep(0.6):accelerate(0.2):zoom(0)
 
 	end,
 

--- a/Graphics/Player judgment.lua
+++ b/Graphics/Player judgment.lua
@@ -8,6 +8,7 @@ local sprite
 -- If so, use the first available Judgment graphic
 -- If that fails too, fail gracefully and do nothing
 local mode = SL.Global.GameMode
+local judgmentBehaviour = mods.JudgmentBehaviour
 if mode == "Casual" then mode = "ITG" end
 local available_judgments = GetJudgmentGraphics(SL.Global.GameMode)
 
@@ -56,14 +57,19 @@ return Def.ActorFrame{
 		self:playcommand("Reset")
 
 		sprite:visible(true):setstate(frame)
-		-- this should match the custom JudgmentTween() from SL for 3.95
-		--sprite:zoom(0.8):decelerate(0.1):zoom(0.75):sleep(0.6):accelerate(0.2):zoom(0)
 
+		-- this should match the custom JudgmentTween() from SL for 3.95
+		if judgmentBehaviour == "Default" then
+			sprite:zoom(0.8):decelerate(0.1):zoom(0.75):sleep(0.6):accelerate(0.2):zoom(0)
+		
 		-- this should match the behaviour of Etterna
-		--sprite:zoom(0.75)
+		elseif judgmentBehaviour == "Etterna" then
+			sprite:zoom(0.75)
 
 		-- this should match the behaviour of ITG2/ITG3
-		sprite:zoom(1):decelerate(0.2):zoom(0.75):sleep(0.6):accelerate(0.2):zoom(0)
+		elseif judgmentBehaviour == "ITG3" then
+			sprite:zoom(1):decelerate(0.2):zoom(0.75):sleep(0.6):accelerate(0.2):zoom(0)
+		end
 
 	end,
 

--- a/Graphics/Player judgment.lua
+++ b/Graphics/Player judgment.lua
@@ -57,7 +57,11 @@ return Def.ActorFrame{
 
 		sprite:visible(true):setstate(frame)
 		-- this should match the custom JudgmentTween() from SL for 3.95
-		sprite:zoom(0.8):decelerate(0.1):zoom(0.75):sleep(0.6):accelerate(0.2):zoom(0)
+		--sprite:zoom(0.8):decelerate(0.1):zoom(0.75):sleep(0.6):accelerate(0.2):zoom(0)
+
+		-- this should match the behaviour of Etterna
+		sprite:zoom(0.75):sleep(0.6):accelerate(0.2):zoom(0)
+
 	end,
 
 	Def.Sprite{

--- a/Graphics/Player judgment.lua
+++ b/Graphics/Player judgment.lua
@@ -60,7 +60,7 @@ return Def.ActorFrame{
 		--sprite:zoom(0.8):decelerate(0.1):zoom(0.75):sleep(0.6):accelerate(0.2):zoom(0)
 
 		-- this should match the behaviour of Etterna
-		sprite:zoom(0.75):sleep(0.6):accelerate(0.2):zoom(0)
+		sprite:zoom(0.75)
 
 	end,
 

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -622,6 +622,7 @@ Mini=Mini
 Perspective=Perspective
 NoteSkin=NoteSkin
 JudgmentGraphic=Judgment Font
+JudgmentBehaviour=Judgment Behaviour
 ComboFont=Combo Font
 BackgroundFilter=Background Filter
 MusicRate=Music Rate
@@ -798,6 +799,7 @@ Mini=Change the size of your arrows.
 Perspective=Change the viewing angle of the arrow stream.
 NoteSkin=Change the appearance of the arrows.
 JudgmentGraphic=Pick your judgment font.
+JudgmentBehaviour = Change the animation the judge font uses.
 ComboFont=Choose the font to count your combo. This font will also be used for the Measure Counter if that is enabled.
 BackgroundFilter=Darken the underside of the playing field.\nThis will partially obscure background art.
 MusicRate=Change the native speed of the music itself.
@@ -910,6 +912,11 @@ CustomSongsMaxSeconds=You should set this to correspond with "2-Round Song Time"
 X=X (multiplier)
 C=C (constant)
 M=M (maximum)
+
+# JudgmentBehaviour
+Default=Default
+Etterna=Etterna
+ITG3=ITG3
 
 # BackgroundFilter
 Off=Off

--- a/Scripts/SL-PlayerOptions.lua
+++ b/Scripts/SL-PlayerOptions.lua
@@ -214,6 +214,10 @@ local Overrides = {
 		end
 	},
 	-------------------------------------------------------------------------
+	JudgmentBehaviour = {
+		Values = { 'Default','Etterna','ITG3' },
+	},
+	-------------------------------------------------------------------------
 	HoldJudgment = {
 		LayoutType = "ShowOneInRow",
 		ExportOnChange = true,

--- a/Scripts/SL-PlayerProfiles.lua
+++ b/Scripts/SL-PlayerProfiles.lua
@@ -18,6 +18,7 @@ local permitted_profile_settings = {
 	Mini             = "string",
 	NoteSkin         = "string",
 	JudgmentGraphic  = "string",
+	JudgmentBehaviour= "string",
 	ComboFont        = "string",
 	HoldJudgment     = "string",
 	BackgroundFilter = "string",

--- a/Scripts/SL_Init.lua
+++ b/Scripts/SL_Init.lua
@@ -7,6 +7,7 @@ local PlayerDefaults = {
 				SpeedModType = "X",
 				SpeedMod = 1.00,
 				JudgmentGraphic = "Love 2x6 (doubleres).png",
+				JudgmentBehaviour = "Default",
 				ComboFont = "Wendy",
 				HoldJudgment = "Love 1x2 (doubleres).png",
 				NoteSkin = nil,

--- a/metrics.ini
+++ b/metrics.ini
@@ -646,7 +646,7 @@ RowPositionTransformFunction=function(self,positionIndex,itemIndex,numItems) sel
 RepeatRate=30
 AllowRepeatingChangeValueInput=true
 LineNames=(function() \
-	local lines = "SpeedModType,SpeedMod,Mini,Perspective,NoteSkinSL,Judgment,ComboFont,HoldJudgment,BackgroundFilter,MusicRate,Stepchart,ScreenAfterPlayerOptions" \
+	local lines = "SpeedModType,SpeedMod,Mini,Perspective,NoteSkinSL,Judgment,JudgmentBehaviour,ComboFont,HoldJudgment,BackgroundFilter,MusicRate,Stepchart,ScreenAfterPlayerOptions" \
 	if GAMESTATE:GetCurrentGame():GetName() == "pump" then lines = lines:gsub("HoldJudgment,","") end \
 	return lines \
 end)()
@@ -658,6 +658,7 @@ LineSpeedMod="lua,CustomOptionRow('SpeedMod')"
 LineMini="lua,CustomOptionRow('Mini')"
 LineNoteSkinSL="lua,CustomOptionRow('NoteSkin')"
 LineJudgment="lua,CustomOptionRow('JudgmentGraphic')"
+LineJudgmentBehaviour="lua,CustomOptionRow('JudgmentBehaviour')"
 LineComboFont="lua,CustomOptionRow('ComboFont')"
 LineBackgroundFilter="lua,CustomOptionRow('BackgroundFilter')"
 LineMusicRate="lua,CustomOptionRow('MusicRate')"


### PR DESCRIPTION
Sick of getting distracted by your judgefont?
Perhaps you want your judgefont to be more distracting for some reason?
I got you covered.

This pull request adds a new option row on SL Playeroptions 1 that changes the animation of the judgefont.
![ezgif-4-3362a2fe8a08](https://user-images.githubusercontent.com/45429988/129750240-937cf605-38ad-4f03-a7fb-79d0bc6375ad.gif)

