### PR TITLE
Raise music rate limit to 3

### DIFF
--- a/Scripts/06 SL-Utilities.lua
+++ b/Scripts/06 SL-Utilities.lua
@@ -111,7 +111,7 @@ range = function(start, stop, step)
 		start = 1
 	end
 
-	step = step or (start < stop and 1 or -1)
+	step = step or 1
 
 	-- if step has been explicitly provided as a positive number
 	-- but the start and stop values tell us to decrement
@@ -121,9 +121,8 @@ range = function(start, stop, step)
 	end
 
 	local t = {}
-	while start < stop+step do
-		t[#t+1] = start
-		start = start + step
+	for i = start, stop, step do
+		t[#t+1] = i
 	end
 	return t
 end

--- a/Scripts/SL-PlayerOptions.lua
+++ b/Scripts/SL-PlayerOptions.lua
@@ -273,7 +273,7 @@ local Overrides = {
 	MusicRate = {
 		Choices = function()
 			local first	= 0.05
-			local last 	= 2
+			local last 	= 3
 			local step 	= 0.01
 
 			return stringify( range(first, last, step), "%g")


### PR DESCRIPTION
That limit is enforced by the engine, so we can't go any higher.

I had to modify range() to make this work, because the way it was implemented accumulated floating point errors, resulting in inaccurate values. The error didn't show when only going up to 2, but when going up to 3 it makes a difference.

@teejusb Do you see a reason for not doing this?