### PR TITLE
Support for Step Statistics in Ultrawide Double

### DIFF
--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/Score.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/Score.lua
@@ -5,7 +5,7 @@ local mods = SL[pn].ActiveModifiers
 local IsUltraWide = (GetScreenAspectRatio() > 21/9)
 local NumPlayers = #GAMESTATE:GetHumanPlayers()
 local IsEX = SL[pn].ActiveModifiers.ShowEXScore
-
+local IsDouble = GAMESTATE:GetCurrentStyle():GetName() == "double"
 -- -----------------------------------------------------------------------
 -- first, check for conditions where we might not draw the score actor at all
 
@@ -86,8 +86,8 @@ return LoadFont("Wendy/_wendy monospace numbers")..{
 		-- assume "normal" score positioning first, but there are many reasons it will need to be moved
 		self:xy( pos[player].x, pos[player].y )
 
-		if mods.NPSGraphAtTop and styletype ~= "OnePlayerTwoSides" then
-			-- if NPSGraphAtTop and Step Statistics and not double,
+		if mods.NPSGraphAtTop then
+			-- if NPSGraphAtTop and Step Statistics,
 			-- move the score down into the stepstats pane under
 			-- the judgment breakdown
 			if mods.DataVisualizations=="Step Statistics" then
@@ -97,8 +97,12 @@ return LoadFont("Wendy/_wendy monospace numbers")..{
 				-- but current conditions might be such that it won't actually appear.
 				-- Ensure the StepStats ActorFrame is present before trying to traverse it.
 				if step_stats then
+					self:y( 282 )
+
 					if player==PLAYER_1 then
-						if NoteFieldIsCentered then
+						if IsDouble then
+							self:xy(step_stats:GetX() + 20, 240)
+						elseif NoteFieldIsCentered then
 							self:x( pos[ OtherPlayer[player] ].x + SL_WideScale( 94, 112.5) )
 						else
 							self:x( pos[ OtherPlayer[player] ].x - SL_WideScale(-84, -60) )
@@ -106,14 +110,14 @@ return LoadFont("Wendy/_wendy monospace numbers")..{
 
 					-- PLAYER_2
 					else
-						if NoteFieldIsCentered then
+						if IsDouble then
+							self:xy(step_stats:GetX() + 110, 240)
+						elseif NoteFieldIsCentered then
 							self:x( pos[ OtherPlayer[player] ].x - 65.5 )
 						else
 							self:x( pos[ OtherPlayer[player] ].x - SL_WideScale(-6, -2))
 						end
 					end
-
-					self:y( 282 )
 				end
 
 			-- if NPSGraphAtTop but not Step Statistics

--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/StepStatistics/Banner.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/StepStatistics/Banner.lua
@@ -1,6 +1,7 @@
 local player = ...
 local NoteFieldIsCentered = (GetNotefieldX(player) == _screen.cx)
 local IsUltraWide = (GetScreenAspectRatio() > 21/9)
+local IsOnSameSideAsPlayer = IsUltraWide and (#GAMESTATE:GetHumanPlayers() > 1 or GAMESTATE:GetCurrentStyle():GetName() == "double")
 
 return Def.Banner{
 	CurrentSongChangedMessageCommand=function(self)
@@ -13,8 +14,8 @@ return Def.Banner{
 			self:x( 72 * (player==PLAYER_1 and 1 or -1) )
 		end
 
-		-- ultrawide and both players joined
-		if IsUltraWide and #GAMESTATE:GetHumanPlayers() > 1 then
+		-- stats on same side as player
+		if IsOnSameSideAsPlayer then
 			self:x(self:GetX() * -1)
 		end
 	end

--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/StepStatistics/DensityGraph.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/StepStatistics/DensityGraph.lua
@@ -11,6 +11,8 @@ local life_verts = {}
 local offset = 0
 
 local IsUltraWide = (GetScreenAspectRatio() > 21/9)
+local StyleName = GAMESTATE:GetCurrentStyle():GetName()
+local IsOnSameSideAsPlayer = IsUltraWide and (#GAMESTATE:GetHumanPlayers() > 1 or StyleName == "double")
 local NoteFieldIsCentered = (GetNotefieldX(player) == _screen.cx)
 
 -- -----------------------------------------------------------------------
@@ -90,9 +92,8 @@ local text = LoadFont("Common Normal")..{
 		self:halign( PlayerNumber:Reverse()[OtherPlayer[player]] )
 		self:vertalign(bottom)
 
-		-- flip alignment if ultrawide and both players joined because the pane
-		-- will now appear on the player's side of the screen rather than opposite
-		if IsUltraWide and #GAMESTATE:GetHumanPlayers() > 1 then
+		-- flip alignment if the pane will appear on the player's side of the screen rather than opposite
+		if IsOnSameSideAsPlayer then
 			self:halign( PlayerNumber:Reverse()[player] )
 		end
 	end,
@@ -107,19 +108,17 @@ local text = LoadFont("Common Normal")..{
 		if player == PLAYER_1 then
 			self:x(_screen.w*0.5 - SL_WideScale(6,59))
 
-			if NoteFieldIsCentered then
-				self:x(_screen.w*0.5 - 134)
-			end
-			if IsUltraWide and #GAMESTATE:GetHumanPlayers() > 1 then
+			if IsOnSameSideAsPlayer then
 				self:x(52)
+			elseif NoteFieldIsCentered then
+				self:x(_screen.w*0.5 - 134)
 			end
 		else
 			self:x(SL_WideScale(6,130))
-			if NoteFieldIsCentered then
-				self:x(69)
-			end
-			if IsUltraWide and #GAMESTATE:GetHumanPlayers() > 1 then
+			if IsOnSameSideAsPlayer then
 				self:x(180)
+			elseif NoteFieldIsCentered then
+				self:x(69)
 			end
 		end
 

--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/StepStatistics/HoldsMinesRolls.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/StepStatistics/HoldsMinesRolls.lua
@@ -2,6 +2,7 @@ local player = ...
 
 local IsUltraWide = (GetScreenAspectRatio() > 21/9)
 local NoteFieldIsCentered = (GetNotefieldX(player) == _screen.cx)
+local IsOnSameSideAsPlayer = IsUltraWide and (#GAMESTATE:GetHumanPlayers() > 1 or GAMESTATE:GetCurrentStyle():GetName() == "double")
 
 -- gray is used for leading 0s
 local gray = color("#5A6166")
@@ -95,8 +96,8 @@ af.InitCommand=function(self)
 		self:x( player==PLAYER_1 and 155 or -88 )
 	end
 
-	-- adjust for smaller panes when ultrawide and both players joined
-	if IsUltraWide and #GAMESTATE:GetHumanPlayers() > 1 then
+	-- adjust for smaller panes when stats are on same side as player
+	if IsOnSameSideAsPlayer then
 		self:x( player==PLAYER_1 and 14 or 50 )
 	end
 end

--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/StepStatistics/TapNoteJudgments.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/StepStatistics/TapNoteJudgments.lua
@@ -3,6 +3,8 @@ local pn = ToEnumShortString(player)
 
 local IsUltraWide = (GetScreenAspectRatio() > 21/9)
 local NoteFieldIsCentered = (GetNotefieldX(player) == _screen.cx)
+local IsDouble = GAMESTATE:GetCurrentStyle():GetName() == "double"
+local IsOnSameSideAsPlayer = IsUltraWide and (#GAMESTATE:GetHumanPlayers() > 1 or IsDouble)
 
 local StepsOrTrail = (GAMESTATE:IsCourseMode() and GAMESTATE:GetCurrentTrail(player)) or GAMESTATE:GetCurrentSteps(player)
 local total_tapnotes = StepsOrTrail:GetRadarValues(player):GetValue( "RadarCategory_Notes" )
@@ -74,12 +76,13 @@ af.InitCommand=function(self)
 	self:x( SL_WideScale(152,204) * (player==PLAYER_1 and -1 or 1))
 
 	if NoteFieldIsCentered and IsUsingWideScreen() then
-		self:x( 156 * (player==PLAYER_1 and -1 or 1))
+		self:x(156 * (player==PLAYER_1 and -1 or 1))
 	end
 
-	-- adjust for smaller panes when ultrawide and both players joined
-	if IsUltraWide and #GAMESTATE:GetHumanPlayers() > 1 then
-		self:x( 154 * (player==PLAYER_1 and 1 or -1))
+	-- adjust for smaller panes when stats are on the same side as the player
+	if IsOnSameSideAsPlayer then
+		local x = IsDouble and 204 or 154
+		self:x(x * (player==PLAYER_1 and 1 or -1))
 	end
 end
 
@@ -94,8 +97,8 @@ for index, window in ipairs(TNS.Types) do
 			self:y((index-1)*row_height - 280)
 			self:halign( PlayerNumber:Reverse()[player] )
 
-			-- flip alignment when ultrawide and both players joined
-			if IsUltraWide and #GAMESTATE:GetHumanPlayers() > 1 then
+			-- flip alignment when stats are on the same side as the player
+			if IsOnSameSideAsPlayer then
 				self:halign( PlayerNumber:Reverse()[OtherPlayer[player]] )
 			end
 
@@ -162,8 +165,8 @@ for index, window in ipairs(TNS.Types) do
 					self:y((index-1) * row_height - 279)
 					self:diffuse( TNS.Colors[index] )
 
-					-- flip alignment when ultrawide and both players joined
-					if IsUltraWide and #GAMESTATE:GetHumanPlayers() > 1 then
+					-- flip alignment when stats are on the same side as the player
+					if IsOnSameSideAsPlayer then
 						self:halign( PlayerNumber:Reverse()[OtherPlayer[player]] )
 						self:x(self:GetX() * -1)
 					end

--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/StepStatistics/Time.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/StepStatistics/Time.lua
@@ -5,6 +5,8 @@ local rate = SL.Global.ActiveModifiers.MusicRate
 
 local NoteFieldIsCentered = (GetNotefieldX(player) == _screen.cx)
 local IsUltraWide = (GetScreenAspectRatio() > 21/9)
+local IsDouble = GAMESTATE:GetCurrentStyle():GetName() == "double"
+local IsOnSameSideAsPlayer = IsUltraWide and (#GAMESTATE:GetHumanPlayers() > 1 or IsDouble)
 
 -- -----------------------------------------------------------------------
 -- reference to the BitmapText actor that will display remaining time
@@ -137,12 +139,14 @@ af.InitCommand=function(self)
 	self:x(SL_WideScale(150,202) * (player==PLAYER_1 and -1 or 1))
 	self:y(-40)
 
-	if NoteFieldIsCentered and IsUsingWideScreen() then
-		self:x( 154 * (player==PLAYER_1 and -1 or 1) )
+	if IsDouble then
+		self:x(253 * (player==PLAYER_1 and -1 or 1))
+	elseif NoteFieldIsCentered and IsUsingWideScreen() then
+		self:x(154 * (player==PLAYER_1 and -1 or 1))
 	end
 
-	-- flip alignment when ultrawide and both players joined
-	if IsUltraWide and #GAMESTATE:GetHumanPlayers() > 1 then
+	-- flip alignment when the stats are on the same side as the player
+	if IsOnSameSideAsPlayer then
 		self:x(self:GetX() * -1)
 	end
 end
@@ -173,8 +177,8 @@ af[#af+1] = LoadFont("Common Normal")..{
 		self:halign(PlayerNumber:Reverse()[player]):vertalign(bottom)
 
 		-- flip alignment and adjust for smaller pane size
-		-- when ultrawide and both players joined
-		if IsUltraWide and #GAMESTATE:GetHumanPlayers() > 1 then
+		-- when the stats are on the same side as the player
+		if IsOnSameSideAsPlayer then
 			self:halign( PlayerNumber:Reverse()[OtherPlayer[player]] )
 			self:x(50 * (player==PLAYER_1 and -1 or 1))
 		end
@@ -201,8 +205,8 @@ af[#af+1] = LoadFont("Common Normal")..{
 		self:zoom(0.833)
 
 		-- flip alignment and adjust for smaller pane size
-		-- when ultrawide and both players joined
-		if IsUltraWide and #GAMESTATE:GetHumanPlayers() > 1 then
+		-- when the stats are on the same side as the player
+		if IsOnSameSideAsPlayer then
 			self:halign( PlayerNumber:Reverse()[OtherPlayer[player]] )
 			self:x(50 * (player==PLAYER_1 and -1 or 1))
 		end
@@ -214,8 +218,8 @@ af[#af+1] = LoadFont("Common Normal")..{
 			self:x(-32 - (total_width-28))
 		end
 
-		-- flip offset when ultrawide and both players
-		if IsUltraWide and #GAMESTATE:GetHumanPlayers() > 1 then
+		-- flip offset when the stats are on the same side as the player
+		if IsOnSameSideAsPlayer then
 			if player==PLAYER_1 then
 				self:x(-86 - (total_width-28))
 			else
@@ -232,7 +236,7 @@ af[#af+1] = LoadFont("Common Normal")..{
 	InitCommand=function(self)
 		self:xy(0,20)
 		self:halign(PlayerNumber:Reverse()[player]):vertalign(bottom)
-		if IsUltraWide and #GAMESTATE:GetHumanPlayers() > 1 then
+		if IsOnSameSideAsPlayer then
 			self:halign( PlayerNumber:Reverse()[OtherPlayer[player]] )
 			self:x(50 * (player==PLAYER_1 and -1 or 1))
 		end
@@ -248,7 +252,7 @@ af[#af+1] = LoadFont("Common Normal")..{
 	InitCommand=function(self)
 		self:zoom(0.833)
 		self:halign(PlayerNumber:Reverse()[player]):vertalign(bottom)
-		if IsUltraWide and #GAMESTATE:GetHumanPlayers() > 1 then
+		if IsOnSameSideAsPlayer then
 			self:halign( PlayerNumber:Reverse()[OtherPlayer[player]] )
 		end
 
@@ -263,8 +267,8 @@ af[#af+1] = LoadFont("Common Normal")..{
 		end
 		self:y(20)
 
-		-- flip offset when ultrawide and both players
-		if IsUltraWide and #GAMESTATE:GetHumanPlayers() > 1 then
+		-- flip offset when the stats are on the same side as the player
+		if IsOnSameSideAsPlayer then
 			if player==PLAYER_1 then
 				self:x(-86 - (total_width-28))
 			else

--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/StepStatistics/default.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/StepStatistics/default.lua
@@ -3,19 +3,22 @@ local pn = ToEnumShortString(player)
 local ar = GetScreenAspectRatio()
 local IsUltraWide = (GetScreenAspectRatio() > 21/9)
 local NoteFieldIsCentered = (GetNotefieldX(player) == _screen.cx)
+local IsDouble = GAMESTATE:GetCurrentStyle():GetName() == "double"
 
 -- -----------------------------------------------------------------------
 -- if the conditions aren't right, don't bother
+-- Note: These conditions should be kept in sync with those for DataVisualizations in "SL-PlayerOptions.lua"
 
 local stylename = GAMESTATE:GetCurrentStyle():GetName()
 
+-- No use computing this if the visualization isn't enabled
 if (SL[pn].ActiveModifiers.DataVisualizations ~= "Step Statistics")
-or (not IsUltraWide and stylename == "versus")
+-- No step statistics in Casual
 or (SL.Global.GameMode == "Casual")
-or (GetNotefieldWidth() > _screen.w/2)
-or (NoteFieldIsCentered and not IsUsingWideScreen())
+-- There's not enough space in non-ultra-wide for more than a single notefield
 or (not IsUltraWide and stylename ~= "single")
-or (    IsUltraWide and not (stylename == "single" or stylename == "versus"))
+-- Even in "single", if you center the playfield but don't have a wide screen then there's not enough space
+or (NoteFieldIsCentered and not IsUsingWideScreen())
 then
 	return
 end
@@ -41,8 +44,14 @@ if not IsUltraWide then
 
 -- ultrawide or wider
 else
-	if #GAMESTATE:GetHumanPlayers() > 1 then
-		sidepane_width = _screen.w/5
+	if #GAMESTATE:GetHumanPlayers() > 1 or IsDouble then
+		if IsDouble then
+			-- The space between the notefield and the edge of the screen, minus some (arbitrary) padding
+			sidepane_width = _screen.cx - (GetNotefieldWidth() / 2) - 10
+		else
+			sidepane_width = _screen.w/5
+		end
+
 		if player==PLAYER_1 then
 			sidepane_pos_x = sidepane_width/2
 		else
@@ -79,7 +88,7 @@ af[#af+1] = Def.ActorFrame{
 				self:zoom( zoom )
 			end
 		else
-			if #GAMESTATE:GetHumanPlayers() > 1 then
+			if #GAMESTATE:GetHumanPlayers() > 1 or IsDouble then
 				self:zoom(zoomfactor.ultrawide):addy(-55)
 			end
 		end

--- a/Scripts/SL-PlayerOptions.lua
+++ b/Scripts/SL-PlayerOptions.lua
@@ -459,21 +459,19 @@ local Overrides = {
 
 			-- None and Target Score Graph should always be available to players
 			-- but Step Statistics needs a lot of space and isn't always possible
-			-- remove it as an available option if we aren't in single or if the current
-			-- notefield width already uses more than half the screen width
+			-- remove it as an available option if it wouldn't fit
+			-- Note: These conditions should be kept in sync with those in "BGAnimations/ScreenGameplay underlay/default.lua"
 			local style = GAMESTATE:GetCurrentStyle()
-			local notefieldwidth = GetNotefieldWidth()
 			local IsUltraWide = (GetScreenAspectRatio() > 21/9)
 			local mpn = GAMESTATE:GetMasterPlayerNumber()
+			local NoteFieldIsCentered = mpn and GetNotefieldX(mpn) == _screen.cx
 
-			-- Never available in double
-			if style and style:GetName() == "double"
-			-- In 4:3 versus mode
-			or (not IsUsingWideScreen() and style and style:GetName() == "versus")
-			-- if the notefield takes up more than half the screen width
-			or (notefieldwidth and notefieldwidth > _screen.w/2)
-			-- if the notefield is centered with 4:3 aspect ratio
-			or (mpn and GetNotefieldX(mpn) == _screen.cx and not IsUsingWideScreen())
+			-- No step statistics in Casual
+			if (SL.Global.GameMode == "Casual")
+			-- There's not enough space in non-ultra-wide for more than a single notefield
+			or (not IsUltraWide and style and style:GetName() ~= "single")
+			-- Even in "single", if you center the playfield but don't have a wide screen then there's not enough space
+			or (NoteFieldIsCentered and not IsUsingWideScreen())
 			then
 				table.remove(choices, 3)
 			end


### PR DESCRIPTION
Lots of values are arbitrary and hardcoded, but this looks pretty okay.

![image](https://user-images.githubusercontent.com/706916/147615009-63af0b98-4f21-41ef-8f25-4a8ff6b95b6d.png)

What's missing is QA and code review. The test cases I'll have to go through are combinations of the following:

Resolutions:
- Ultrawide
- 16:9
- 4:3

Styles:
- P1 Single
- P1 Centered Single
- P1 Double
- P2 Single
- P2 Centered Single
- P2 Double
- P1 + P2 (Versus)

Game Modes:
- Pump It Up Support, since the notefield is larger. Do we want to support and test this as well?