### PR TITLE
Add EX score to Screen Evaluation

### DIFF
--- a/BGAnimations/ScreenEvaluation common/Panes/Pane1/JudgmentLabels.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane1/JudgmentLabels.lua
@@ -22,14 +22,12 @@ TapNoteScores.Names = map(GetTNSStringFromTheme, TapNoteScores.Types)
 local RadarCategories = {
 	THEME:GetString("ScreenEvaluation", 'Holds'),
 	THEME:GetString("ScreenEvaluation", 'Mines'),
-	THEME:GetString("ScreenEvaluation", 'Hands'),
 	THEME:GetString("ScreenEvaluation", 'Rolls')
 }
 
 local EnglishRadarCategories = {
 	[THEME:GetString("ScreenEvaluation", 'Holds')] = "Holds",
 	[THEME:GetString("ScreenEvaluation", 'Mines')] = "Mines",
-	[THEME:GetString("ScreenEvaluation", 'Hands')] = "Hands",
 	[THEME:GetString("ScreenEvaluation", 'Rolls')] = "Rolls",
 }
 
@@ -65,7 +63,17 @@ for i=1, #TapNoteScores.Types do
 	end
 end
 
--- labels: holds, mines, hands, rolls
+t[#t+1] = LoadFont("Wendy/_wendy small")..{
+	Text="EX",
+	InitCommand=function(self) self:zoom(0.5):horizalign(right) end,
+	BeginCommand=function(self)
+		self:x( (controller == PLAYER_1 and -160) or 90 )
+		self:y(38)
+		self:diffuse( SL.JudgmentColors[SL.Global.GameMode][1] )
+	end
+}
+
+-- labels: holds, mines, rolls
 for index, label in ipairs(RadarCategories) do
 
 	local performance = stats:GetRadarActual():GetValue( "RadarCategory_"..firstToUpper(EnglishRadarCategories[label]) )
@@ -76,7 +84,7 @@ for index, label in ipairs(RadarCategories) do
 		InitCommand=function(self) self:zoom(0.833):horizalign(right) end,
 		BeginCommand=function(self)
 			self:x( (controller == PLAYER_1 and -160) or 90 )
-			self:y((index-1)*28 + 41)
+			self:y(index*28 + 41)
 		end
 	}
 end

--- a/BGAnimations/ScreenEvaluation common/Panes/Pane1/JudgmentLabels.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane1/JudgmentLabels.lua
@@ -20,12 +20,14 @@ TapNoteScores.Types = { 'W1', 'W2', 'W3', 'W4', 'W5', 'Miss' }
 TapNoteScores.Names = map(GetTNSStringFromTheme, TapNoteScores.Types)
 
 local RadarCategories = {
+	THEME:GetString("ScreenEvaluation", 'Hands'),
 	THEME:GetString("ScreenEvaluation", 'Holds'),
 	THEME:GetString("ScreenEvaluation", 'Mines'),
 	THEME:GetString("ScreenEvaluation", 'Rolls')
 }
 
 local EnglishRadarCategories = {
+	[THEME:GetString("ScreenEvaluation", 'Hands')] = "Hands",
 	[THEME:GetString("ScreenEvaluation", 'Holds')] = "Holds",
 	[THEME:GetString("ScreenEvaluation", 'Mines')] = "Mines",
 	[THEME:GetString("ScreenEvaluation", 'Rolls')] = "Rolls",
@@ -63,30 +65,32 @@ for i=1, #TapNoteScores.Types do
 	end
 end
 
-t[#t+1] = LoadFont("Wendy/_wendy small")..{
-	Text="EX",
-	InitCommand=function(self) self:zoom(0.5):horizalign(right) end,
-	BeginCommand=function(self)
-		self:x( (controller == PLAYER_1 and -160) or 90 )
-		self:y(38)
-		self:diffuse( SL.JudgmentColors[SL.Global.GameMode][1] )
-	end
-}
-
--- labels: holds, mines, rolls
+-- labels: hands/ex, holds, mines, rolls
 for index, label in ipairs(RadarCategories) do
+	-- Replace hands with the EX score when not in Casual mode.
+	if index == 1 and SL.Global.GameMode ~= "Casual" then
+		t[#t+1] = LoadFont("Wendy/_wendy small")..{
+			Text="EX",
+			InitCommand=function(self) self:zoom(0.5):horizalign(right) end,
+			BeginCommand=function(self)
+				self:x( (controller == PLAYER_1 and -160) or 90 )
+				self:y(38)
+				self:diffuse( SL.JudgmentColors[SL.Global.GameMode][1] )
+			end
+		}
+	else
+		local performance = stats:GetRadarActual():GetValue( "RadarCategory_"..firstToUpper(EnglishRadarCategories[label]) )
+		local possible = stats:GetRadarPossible():GetValue( "RadarCategory_"..firstToUpper(EnglishRadarCategories[label]) )
 
-	local performance = stats:GetRadarActual():GetValue( "RadarCategory_"..firstToUpper(EnglishRadarCategories[label]) )
-	local possible = stats:GetRadarPossible():GetValue( "RadarCategory_"..firstToUpper(EnglishRadarCategories[label]) )
-
-	t[#t+1] = LoadFont("Common Normal")..{
-		Text=label,
-		InitCommand=function(self) self:zoom(0.833):horizalign(right) end,
-		BeginCommand=function(self)
-			self:x( (controller == PLAYER_1 and -160) or 90 )
-			self:y(index*28 + 41)
-		end
-	}
+		t[#t+1] = LoadFont("Common Normal")..{
+			Text=label,
+			InitCommand=function(self) self:zoom(0.833):horizalign(right) end,
+			BeginCommand=function(self)
+				self:x( (controller == PLAYER_1 and -160) or 90 )
+				self:y((index-1)*28 + 41)
+			end
+		}
+	end
 end
 
 return t

--- a/BGAnimations/ScreenEvaluation common/Panes/Pane1/JudgmentNumbers.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane1/JudgmentNumbers.lua
@@ -10,7 +10,7 @@ local TapNoteScores = {
 }
 
 local RadarCategories = {
-	Types = { 'Holds', 'Mines', 'Rolls' },
+	Types = { 'Hands', 'Holds', 'Mines', 'Rolls' },
 	-- x values for P1 and P2
 	x = { P1=-180, P2=218 }
 }
@@ -64,47 +64,49 @@ for i=1,#TapNoteScores.Types do
 
 end
 
-t[#t+1] = LoadFont("Wendy/_wendy white")..{
-	Name="Percent",
-	Text=("%.2f"):format(CalculateExScore(player)),
-	InitCommand=function(self)
-		self:horizalign(right):zoom(0.4)
-		self:x( ((controller == PLAYER_1) and -114) or 286 )
-		self:y(47)
-		self:diffuse( SL.JudgmentColors[SL.Global.GameMode][1] )
-	end
-}
-
--- then handle holds, mines, rolls
+-- then handle hands/ex, holds, mines, rolls
 for index, RCType in ipairs(RadarCategories.Types) do
+	-- Replace hands with the EX score when not in Casual mode.
+	if index == 1 and SL.Global.GameMode ~= "Casual" then
+		t[#t+1] = LoadFont("Wendy/_wendy white")..{
+			Name="Percent",
+			Text=("%.2f"):format(CalculateExScore(player)),
+			InitCommand=function(self)
+				self:horizalign(right):zoom(0.4)
+				self:x( ((controller == PLAYER_1) and -114) or 286 )
+				self:y(47)
+				self:diffuse( SL.JudgmentColors[SL.Global.GameMode][1] )
+			end
+		}
+	else
+		local performance = pss:GetRadarActual():GetValue( "RadarCategory_"..RCType )
+		local possible = pss:GetRadarPossible():GetValue( "RadarCategory_"..RCType )
+		possible = clamp(possible, 0, 999)
 
-	local performance = pss:GetRadarActual():GetValue( "RadarCategory_"..RCType )
-	local possible = pss:GetRadarPossible():GetValue( "RadarCategory_"..RCType )
-	possible = clamp(possible, 0, 999)
+		-- player performance value
+		-- use a RollingNumber to animate the count tallying up for visual effect
+		t[#t+1] = Def.RollingNumbers{
+			Font="Wendy/_ScreenEvaluation numbers",
+			InitCommand=function(self) self:zoom(0.5):horizalign(right):Load("RollingNumbersEvaluationB") end,
+			BeginCommand=function(self)
+				self:x( RadarCategories.x[ToEnumShortString(controller)] )
+				self:y((index-1)*35 + 53)
+				self:targetnumber(performance)
+			end
+		}
 
-	-- player performance value
-	-- use a RollingNumber to animate the count tallying up for visual effect
-	t[#t+1] = Def.RollingNumbers{
-		Font="Wendy/_ScreenEvaluation numbers",
-		InitCommand=function(self) self:zoom(0.5):horizalign(right):Load("RollingNumbersEvaluationB") end,
-		BeginCommand=function(self)
-			self:x( RadarCategories.x[ToEnumShortString(controller)] )
-			self:y(index*35 + 53)
-			self:targetnumber(performance)
-		end
-	}
-
-	-- slash and possible value
-	t[#t+1] = LoadFont("Wendy/_ScreenEvaluation numbers")..{
-		InitCommand=function(self) self:zoom(0.5):horizalign(right) end,
-		BeginCommand=function(self)
-			self:x( ((controller == PLAYER_1) and -114) or 286 )
-			self:y(index*35 + 53)
-			self:settext(("/%03d"):format(possible))
-			local leadingZeroAttr = { Length=4-tonumber(tostring(possible):len()), Diffuse=color("#5A6166") }
-			self:AddAttribute(0, leadingZeroAttr )
-		end
-	}
+		-- slash and possible value
+		t[#t+1] = LoadFont("Wendy/_ScreenEvaluation numbers")..{
+			InitCommand=function(self) self:zoom(0.5):horizalign(right) end,
+			BeginCommand=function(self)
+				self:x( ((controller == PLAYER_1) and -114) or 286 )
+				self:y((index-1)*35 + 53)
+				self:settext(("/%03d"):format(possible))
+				local leadingZeroAttr = { Length=4-tonumber(tostring(possible):len()), Diffuse=color("#5A6166") }
+				self:AddAttribute(0, leadingZeroAttr )
+			end
+		}
+	end
 end
 
 return t

--- a/BGAnimations/ScreenEvaluation common/Panes/Pane1/JudgmentNumbers.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane1/JudgmentNumbers.lua
@@ -10,7 +10,7 @@ local TapNoteScores = {
 }
 
 local RadarCategories = {
-	Types = { 'Holds', 'Mines', 'Hands', 'Rolls' },
+	Types = { 'Holds', 'Mines', 'Rolls' },
 	-- x values for P1 and P2
 	x = { P1=-180, P2=218 }
 }
@@ -64,8 +64,18 @@ for i=1,#TapNoteScores.Types do
 
 end
 
+t[#t+1] = LoadFont("Wendy/_wendy white")..{
+	Name="Percent",
+	Text=("%.2f"):format(CalculateExScore(player)),
+	InitCommand=function(self)
+		self:horizalign(right):zoom(0.4)
+		self:x( ((controller == PLAYER_1) and -114) or 286 )
+		self:y(47)
+		self:diffuse( SL.JudgmentColors[SL.Global.GameMode][1] )
+	end
+}
 
--- then handle holds, mines, hands, rolls
+-- then handle holds, mines, rolls
 for index, RCType in ipairs(RadarCategories.Types) do
 
 	local performance = pss:GetRadarActual():GetValue( "RadarCategory_"..RCType )
@@ -78,8 +88,8 @@ for index, RCType in ipairs(RadarCategories.Types) do
 		Font="Wendy/_ScreenEvaluation numbers",
 		InitCommand=function(self) self:zoom(0.5):horizalign(right):Load("RollingNumbersEvaluationB") end,
 		BeginCommand=function(self)
-			self:y((index-1)*35 + 53)
 			self:x( RadarCategories.x[ToEnumShortString(controller)] )
+			self:y(index*35 + 53)
 			self:targetnumber(performance)
 		end
 	}
@@ -88,8 +98,8 @@ for index, RCType in ipairs(RadarCategories.Types) do
 	t[#t+1] = LoadFont("Wendy/_ScreenEvaluation numbers")..{
 		InitCommand=function(self) self:zoom(0.5):horizalign(right) end,
 		BeginCommand=function(self)
-			self:y((index-1)*35 + 53)
 			self:x( ((controller == PLAYER_1) and -114) or 286 )
+			self:y(index*35 + 53)
 			self:settext(("/%03d"):format(possible))
 			local leadingZeroAttr = { Length=4-tonumber(tostring(possible):len()), Diffuse=color("#5A6166") }
 			self:AddAttribute(0, leadingZeroAttr )

--- a/BGAnimations/ScreenEvaluation common/Panes/Pane1/Percentage.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane1/Percentage.lua
@@ -15,7 +15,7 @@ return Def.ActorFrame{
 	-- dark background quad behind player percent score
 	Def.Quad{
 		InitCommand=function(self)
-			self:diffuse(color("#101519")):zoomto(158.5, 88)
+			self:diffuse(color("#101519")):zoomto(158.5, SL.Global.GameMode == "Casual" and 60 or 88)
 			self:horizalign(controller==PLAYER_1 and left or right)
 			self:x(150 * (controller == PLAYER_1 and -1 or 1))
 			self:y(14)

--- a/BGAnimations/ScreenEvaluation common/Panes/Pane1/Percentage.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane1/Percentage.lua
@@ -15,9 +15,10 @@ return Def.ActorFrame{
 	-- dark background quad behind player percent score
 	Def.Quad{
 		InitCommand=function(self)
-			self:diffuse(color("#101519")):zoomto(158.5, 60)
+			self:diffuse(color("#101519")):zoomto(158.5, 88)
 			self:horizalign(controller==PLAYER_1 and left or right)
 			self:x(150 * (controller == PLAYER_1 and -1 or 1))
+			self:y(14)
 		end
 	},
 

--- a/BGAnimations/ScreenEvaluation common/Panes/Pane1/Percentage.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane1/Percentage.lua
@@ -18,7 +18,9 @@ return Def.ActorFrame{
 			self:diffuse(color("#101519")):zoomto(158.5, SL.Global.GameMode == "Casual" and 60 or 88)
 			self:horizalign(controller==PLAYER_1 and left or right)
 			self:x(150 * (controller == PLAYER_1 and -1 or 1))
-			self:y(14)
+			if SL.Global.GameMode ~= "Casual" then
+				self:y(14)
+			end
 		end
 	},
 

--- a/BGAnimations/ScreenEvaluation common/Panes/Pane1/default.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane1/default.lua
@@ -6,11 +6,11 @@
 
 return Def.ActorFrame{
 
-	-- labels like "FANTASTIC", "MISS", "holds", "rolls", etc.
-	LoadActor("./JudgmentLabels.lua", ...),
-
 	-- score displayed as a percentage
 	LoadActor("./Percentage.lua", ...),
+
+	-- labels like "FANTASTIC", "MISS", "holds", "rolls", etc.
+	LoadActor("./JudgmentLabels.lua", ...),
 
 	-- numbers (How many Fantastics? How many Misses? etc.)
 	LoadActor("./JudgmentNumbers.lua", ...),

--- a/Scripts/SL_Init.lua
+++ b/Scripts/SL_Init.lua
@@ -378,6 +378,21 @@ SL = {
 			InitialValue=0.5,
 		},
 	},
+	ExWeights = {
+		-- W0 is not necessarily a "real" window.
+		-- In ITG mode it is emulated based off the value of TimingWindowW1 defined
+		-- for FA+ mode.
+		W0=3.5,
+		W1=3,
+		W2=2,
+		W3=1,
+		W4=0,
+		W5=0,
+		Miss=0,
+		LetGo=0,
+		Held=3.5,  -- Should be same as W0 as that is how SM handles it internally.
+		HitMine=-1
+	},
 	-- Fields used to determine the existence of the launcher and the
 	-- available GrooveStats services.
 	GrooveStats = {


### PR DESCRIPTION
I removed the "Hands" count in favor of displaying an EX score (useful for timing events). The current weights are still being finalized, but they're easily modifiable.

This is shown in both ITG mode and FA+ mode (see below):

FA+ Mode:
![image](https://user-images.githubusercontent.com/5017202/147868370-29e3a69f-5eaf-48e4-a717-a0489042c5a9.png)

Verified calculation:
![image](https://user-images.githubusercontent.com/5017202/147868381-fb8c6575-78e8-4234-960c-cf66a5aab321.png)

ITG Mode:
![image](https://user-images.githubusercontent.com/5017202/147868504-a5ae75b5-5ed7-4ca9-b5cf-8f2e626c5142.png)

Verified calculation:
![image](https://user-images.githubusercontent.com/5017202/147868508-df2bee23-7bd4-4f52-85d5-a7b6df819ba3.png)

Note that I still have to display the white fantastic count in ITG mode some where but I will make a separate PR for that.

