### PR TITLE
Fix getting score as integer

### DIFF
--- a/BGAnimations/ScreenEvaluation common/Shared/AutoSubmitScore.lua
+++ b/BGAnimations/ScreenEvaluation common/Shared/AutoSubmitScore.lua
@@ -203,8 +203,7 @@ local af = Def.ActorFrame {
 
 					if valid and not stats:GetFailed() and SL[pn].IsPadPlayer then
 						local percentDP = stats:GetPercentDancePoints()
-						local score = FormatPercentScore(percentDP)
-						score = tonumber(score:gsub("%%", "") * 100)
+						local score = tonumber(("%.0f"):format(percentDP * 10000))
 
 						local profileName = ""
 						if PROFILEMAN:IsPersistentProfile(player) and PROFILEMAN:GetProfile(player) then


### PR DESCRIPTION
We expect `score` to be an integer, but it sometimes ends up being a float in disguise, e.g.:

```
> num = tonumber(("77.40%"):gsub("%%", "") * 100)
> print(num)
7740
> print(("%.50f"):format(num))
7740.0000000000009094947017729282379150390625000000000
```

This commit first explicitly strips away everything after the decimal point and only converts to a number after that.

It also skips the intermediate step of getting the score as a string from `FormatPercentScore` while still making sure that the result is properly rounded (`"%.0f"` rounds nicely, e.g. `("%.0f"):format(9.99)` -> `10`).