### PR TITLE
ScreenPlayerOptions: show dancing character "cards" as visual preview

### DIFF
--- a/BGAnimations/ScreenPlayerOptions overlay/OptionRowPreviews/DancingCharacter.lua
+++ b/BGAnimations/ScreenPlayerOptions overlay/OptionRowPreviews/DancingCharacter.lua
@@ -1,0 +1,29 @@
+local af = ...
+
+-- add one choice to represent empty string, e.g. "no character"
+-- GAMESTATE:SetCharacter() doesn't actually accept this
+-- once a dancing character is chosen this way, there aren't
+-- Lua hooks available to set it back to "no character"
+-- the SM5 engine would need to be patched
+af[#af+1] = Def.Actor{
+	Name="Characters_",
+	InitCommand=function(self) self:visible(false) end
+}
+
+for dancing_character in ivalues( CHARMAN:GetAllCharacters() ) do
+	local path = dancing_character:GetCardPath()
+
+	if path ~= "" and FILEMAN:DoesFileExist(path) then
+		af[#af+1] = LoadActor( path )..{
+			Name="Characters_"..dancing_character:GetDisplayName(),
+			InitCommand=function(self)
+				local texture = self:GetTexture()
+				local row_height = 70
+				self:zoomtoheight(row_height)
+				self:zoomtowidth( row_height * (texture:GetImageWidth()/texture:GetImageHeight()))
+				self:visible(false) end,
+		}
+	else
+		af[#af+1] = Def.Actor{ Name=("Characters_"..dancing_character:GetDisplayName()), InitCommand=function(self) self:visible(false) end }
+	end
+end

--- a/BGAnimations/ScreenPlayerOptions overlay/default.lua
+++ b/BGAnimations/ScreenPlayerOptions overlay/default.lua
@@ -170,6 +170,10 @@ LoadActor("./OptionRowPreviews/JudgmentGraphic.lua", t)
 LoadActor("./OptionRowPreviews/ComboFont.lua", t)
 LoadActor("./OptionRowPreviews/HoldJudgment.lua", t)
 LoadActor("./OptionRowPreviews/MusicRate.lua", t)
+-- load visual previews of dancing characters if any characters are available
+if CHARMAN:GetCharacterCount() > 0 then
+	LoadActor("./OptionRowPreviews/DancingCharacter.lua", t)
+end
 
 -- some functionality needed in both PlayerOptions, PlayerOptions2, and PlayerOptions3
 t[#t+1] = LoadActor(THEME:GetPathB("ScreenPlayerOptions", "common"))

--- a/Graphics/OptionRow Frame.lua
+++ b/Graphics/OptionRow Frame.lua
@@ -114,7 +114,7 @@ t[#t+1] = Def.Quad {
 -- in the hours to implement a proper fix and the community will surely be better for it. :)
 -- -----------------------------------------------------------------------
 
-local rows_with_proxies = { "NoteSkin", "JudgmentGraphic", "ComboFont", "HoldJudgment", "MusicRate" }
+local rows_with_proxies = { "NoteSkin", "JudgmentGraphic", "ComboFont", "HoldJudgment", "MusicRate", "Characters" }
 
 for player in ivalues( GAMESTATE:GetHumanPlayers() ) do
 	local pn = ToEnumShortString(player)

--- a/Scripts/SL-PlayerOptions.lua
+++ b/Scripts/SL-PlayerOptions.lua
@@ -559,6 +559,39 @@ local Overrides = {
 		Values = { "Standard", "Surround", "Vertical" },
 	},
 	-------------------------------------------------------------------------
+	-- Dancing Characters
+	-- maintain the OptionRow name as "Characters" to maintain localization compatibility with _fallback theme
+	Characters = {
+		ExportOnChange = true,
+		Choices = function()
+			local t = {THEME:GetString("OptionRowHandler", "Off")}
+			for char in ivalues(CHARMAN:GetAllCharacters()) do
+				table.insert(t, char:GetDisplayName())
+			end
+			return t
+		end,
+		Values = function()
+			local t = {""}
+			for char in ivalues(CHARMAN:GetAllCharacters()) do
+				table.insert(t, char:GetCharacterID())
+			end
+			return t
+		end,
+		SaveSelections = function(self, list, pn)
+			local mods = SL[ToEnumShortString(pn)].ActiveModifiers
+
+			for i, val in ipairs(self.Values) do
+				if list[i] then
+					mods.Characters = val
+					GAMESTATE:SetCharacter(pn, val)
+					break
+				end
+			end
+			-- Broadcast a message that ./Graphics/OptionRow Frame.lua will be listening for so it can change the Dancing Character preview
+			MESSAGEMAN:Broadcast("RefreshActorProxy", {Player=pn, Name="Characters", Value=mods.Characters})
+		end
+	},
+	-------------------------------------------------------------------------
 	ScreenAfterPlayerOptions = {
 		Values = function()
 			local choices = { "Gameplay", "Select Music", "Options2", "Options3"  }

--- a/metrics.ini
+++ b/metrics.ini
@@ -645,9 +645,11 @@ RowPositionTransformFunction=function(self,positionIndex,itemIndex,numItems) sel
 
 RepeatRate=30
 AllowRepeatingChangeValueInput=true
+# remove Characters if no dancing character directories were found
 LineNames=(function() \
-	local lines = "SpeedModType,SpeedMod,Mini,Perspective,NoteSkinSL,Judgment,ComboFont,HoldJudgment,BackgroundFilter,MusicRate,Stepchart,ScreenAfterPlayerOptions" \
+	local lines = "SpeedModType,SpeedMod,Mini,Perspective,NoteSkinSL,Judgment,ComboFont,HoldJudgment,BackgroundFilter,Characters,MusicRate,Stepchart,ScreenAfterPlayerOptions" \
 	if GAMESTATE:GetCurrentGame():GetName() == "pump" then lines = lines:gsub("HoldJudgment,","") end \
+	if #CHARMAN:GetAllCharacters() < 1 then lines = lines:gsub("Characters,", "") end \
 	return lines \
 end)()
 
@@ -660,6 +662,7 @@ LineNoteSkinSL="lua,CustomOptionRow('NoteSkin')"
 LineJudgment="lua,CustomOptionRow('JudgmentGraphic')"
 LineComboFont="lua,CustomOptionRow('ComboFont')"
 LineBackgroundFilter="lua,CustomOptionRow('BackgroundFilter')"
+LineCharacters="lua,CustomOptionRow('Characters')"
 LineMusicRate="lua,CustomOptionRow('MusicRate')"
 LineStepchart="lua,CustomOptionRow('Stepchart')"
 LineScreenAfterPlayerOptions="lua,CustomOptionRow('ScreenAfterPlayerOptions')"
@@ -746,11 +749,9 @@ NextScreen=SL.Global.ScreenAfter.PlayerOptions3
 NavigationMode="toggle"
 OptionRowNormalMetricsGroup="OptionRowExtendedPlayerOptions"
 
-# remove Characters if no dancing character directories were found
 LineNames=(function() \
-	local lines = "Insert,Remove,Holds,11,12,13,Attacks,Characters,ScreenAfterPlayerOptions3" \
+	local lines = "Insert,Remove,Holds,11,12,13,Attacks,ScreenAfterPlayerOptions3" \
 	if not IsUsingWideScreen() then lines = lines:gsub("Remove", "RemoveA,RemoveB") end \
-	if #CHARMAN:GetAllCharacters() < 1 then lines = lines:gsub("Characters,", "") end \
 	return lines \
 end)()
 
@@ -763,7 +764,6 @@ LineRemoveA="list,RemoveA"
 LineRemoveB="list,RemoveB"
 LineHolds="list,Holds"
 LineAttacks="list,Attacks"
-LineCharacters="list,Characters"
 
 
 


### PR DESCRIPTION
# Visual Preview for Dancing Characters
Issue #354 requested the ability to 
> see the character I'm selecting

using each DancingCharacter's "card."  This commit adds limited support for this.

https://user-images.githubusercontent.com/1253483/152685340-80643fb0-70f0-4a57-9214-1f994822f078.mp4

Note that the "card" file provided with dancing characters is
  * optional, and
  * not necessarily visually representative of the dancing character you're going to get (see P2 in the video)


## History of Dancing Character support in Simply-Love-SM5

In #354's discussion, @natano wrote:
> Hey, I don't think I understand what you mean. What characters are you talking about?

I added support for dancing characters in a8ee38689f87a91e741d3b1677c7be3827a4f8b8, and later moved it to `ScreenPlayerOptions3` as part of a98fe480374c598099aa3a462a4a430b921d48d7.

This history is difficult to piece together because I wrecked the utility of `git blame` by using version control as a narrative device throughout 2019.  I'm sorry about the mess.


# Problems with this implementation

There are a number of shortcomings with this implementation that prevent me from seriously recommending it be merged into upstream Simply-Love-SM5.

---

1. **I had to move the OptionRow from Page3 to Page1.**

   Simply Love's visual previews system currently depends on the `ExportOnChange` value being respected, causing the OptionRows's `SaveSelections()` function to fire off when scrolling through available choices.  This does not happen if *any* OptionRows in the current Options screen are of SelectType `"SelectMultiple"`.
   
   It does not matter that DancingCharacters is `"SelectOne"`; the presence of any `"SelectMultiple"` OptionRows will alter the overall input handling, and a result of that is that `SaveSelections()` only fires off when pressing START to proceed to the next row, rather than with each change as is needed for visual previews.

   The OptionRow for DancingCharacters had been relegated to ScreenPlayerOptions3 which has many `"SelectMultiple"` rows.  To achieve a visual preview for Dancing Characters, I had to move the OptionRow from Page3 to Page1.
   
   I don't think this feature makes enough sense with current post-ITG meta to warrant having on Page1, but it's a necessity for the visual previews to function right now.  
   
   The proper fix would involve rewriting the visual preview system, a custom all-Lua player options menu system, or both.

2. **Once a dancing character is selected, there's no way to reset back to "Off"**

   Simply Love's visual previews system also requires a custom OptionRow "spec" to be defined in ./Scripts/SL-PlayerOptions.lua, so that it can include a MESSAGEMAN broadcast that ./Graphics/OptionRow Frame.lua can listen for.
   
   Unfortunately, it doesn't appear to be currently possible to fully recreate the engine's "conf"-based OptionRow for dancing characters using Lua.  Specifically, there's no way to un-set a player's dancing character back to "Off" once one has been set.
   
   The engine's OptionRowHandler.cpp has a special case for dancing characters that
sets GAMESTATE's character member to `nullptr`. See: https://github.com/stepmania/stepmania/blob/21bb1dbdd3332c698e2db81133af9132f6e0f573/src/OptionRowHandler.cpp#L691-L696
   
   I don't see a way to achieve this using the available Lua API.  We can set a player's dancing character, and then change it on the next song, and continue to change it with each new song, but **we can't ever un-set to Off once it's been set**.

3. **Doesn't play well with Simply Love's [GUEST] profile(?)**

   At least with this implementation, if there are dancing characters installed, **choosing [GUEST] on ScreenSelectProfile** exhibits a bug in which the player's choice of dancing character is always ignored, and **a random dancing character is always shown for each stepchart**.
   
   From a cursory glance at the engine, it appears that characters may be intertwined with profiles in StepMania, but I haven't dug into this enough to really say.

---


# Closing Thoughts

As noted, I can't seriously recommend this commit be merged into upstream due to these shortcomings, but I can post it on GitHub with these notes, and maybe it works for some people's specific setups and helps them enjoy dance games a little bit more. 💛