### PR TITLE
Keep track of W0 count during gameplay in ITG mode

### DIFF
--- a/BGAnimations/ScreenEvaluation common/Panes/Pane8/JudgmentNumbers.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane8/JudgmentNumbers.lua
@@ -24,9 +24,7 @@ local RadarCategories = {
 	x = { P1=-180, P2=218 }
 }
 
--- TODO(teejusb): Explicitly track this value instead of (re)computing the count here
--- as it will be useful to display the count during gameplay.
-local W0_count = GetW0Count(player)
+local W0_count = SL[pn].Stages.Stats[SL.Global.Stages.PlayedThisGame + 1].W0_count
 
 local GetCount = function(window)
 	if window == 'W0' then

--- a/BGAnimations/ScreenEvaluation common/Shared/EventOverlay.lua
+++ b/BGAnimations/ScreenEvaluation common/Shared/EventOverlay.lua
@@ -282,9 +282,7 @@ local GetRpgPaneFunctions = function(eventAf, rpgData, player)
 end
 
 local GetItlPaneFunctions = function(eventAf, itlData, player)
-	local pss = STATSMAN:GetCurStageStats():GetPlayerStageStats(player)
-	-- TODO(teejusb): THIS SHOULD BE EX SCORE NOT MACHINE SCORE
-	local score = pss:GetPercentDancePoints() * 100
+	local score = CalculateExScore(player) * 100
 	local paneTexts = {}
 	local paneFunctions = {}
 

--- a/BGAnimations/ScreenGameplay overlay/JudgmentOffsetTracking.lua
+++ b/BGAnimations/ScreenGameplay overlay/JudgmentOffsetTracking.lua
@@ -24,6 +24,21 @@ return Def.Actor{
 			-- Store judgment offsets (including misses) in an indexed table as they occur.
 			-- Also store the CurMusicSeconds for Evaluation's scatter plot.
 			sequential_offsets[#sequential_offsets+1] = { GAMESTATE:GetCurMusicSeconds(), offset }
+
+			-- Only check/update FA+ count if we received a TNS in the top window.
+			if params.TapNoteScore == "TapNoteScore_W1" and SL.Global.GameMode == "ITG"  then
+				local prefs = SL.Preferences["FA+"]
+				local scale = PREFSMAN:GetPreference("TimingWindowScale")
+				local W0 = prefs["TimingWindowSecondsW1"] * scale + prefs["TimingWindowAdd"]
+
+				local storage = SL[ToEnumShortString(player)].Stages.Stats[SL.Global.Stages.PlayedThisGame + 1]
+
+				offset = math.abs(offset)
+				if offset <= W0 then
+					-- Initialized in ScreenGameplay overlay/default.lua
+					storage.W0_count = storage.W0_count + 1
+				end
+			end
 		end
 	end,
 	OffCommand=function(self)

--- a/BGAnimations/ScreenGameplay overlay/default.lua
+++ b/BGAnimations/ScreenGameplay overlay/default.lua
@@ -34,7 +34,9 @@ for player in ivalues( GAMESTATE:GetHumanPlayers() ) do
 	--
 	-- Sadly, the full details of this Stages.Stats[stage_index] data structure
 	-- is not documented anywhere. :(
-	SL[pn].Stages.Stats[SL.Global.Stages.PlayedThisGame+1] = {}
+	SL[pn].Stages.Stats[SL.Global.Stages.PlayedThisGame+1] = {
+		W0_count = 0, -- Only really used to keep track of the FA Plus window in ITG mode.
+	}
 
 	af[#af+1] = LoadActor("./TrackTimeSpentInGameplay.lua", player)
 	af[#af+1] = LoadActor("./JudgmentOffsetTracking.lua", player)

--- a/Scripts/SL-Helpers.lua
+++ b/Scripts/SL-Helpers.lua
@@ -574,36 +574,6 @@ IsAutoplay = function(player)
 end
 
 -- -----------------------------------------------------------------------
-GetW0Count = function(player)
-	-- If the top window is disabled, then so is the W0 window.
-	-- Return 0 and move on.
-	if not SL.Global.ActiveModifiers.TimingWindows[1] then
-		return 0
-	end
-
-	local pn = ToEnumShortString(player)
-	local offsets = SL[pn].Stages.Stats[SL.Global.Stages.PlayedThisGame + 1].sequential_offsets
-	local W0_count = 0
-
-	for time_offset in ivalues(offsets) do
-		local offset = time_offset[2]
-
-		local prefs = SL.Preferences["FA+"]
-		local scale = PREFSMAN:GetPreference("TimingWindowScale")
-		local W0 = prefs["TimingWindowSecondsW1"] * scale + prefs["TimingWindowAdd"]
-
-		-- We found a judgment that fell within the W0 window (Fantastic+).
-		if offset ~= "Miss" then
-			offset = math.abs(offset)
-			if offset <= W0 then
-				W0_count = W0_count + 1
-			end
-		end
-	end
-	return W0_count
-end
-
--- -----------------------------------------------------------------------
 CalculateExScore = function(player)
 	-- No EX scores in Casual mode, just return some dummy number early.
 	if SL.Global.GameMode == "Casual" then return 0 end
@@ -620,12 +590,9 @@ CalculateExScore = function(player)
 	for index, window in ipairs(TNS) do
 		local number = stats:GetTapNoteScores( "TapNoteScore_"..window )
 
-		-- The W0 window needs to be emulated in ITG mode.
-		-- We already track note offsets so use that to compute the W0 count.
-		-- TODO(teejusb): Explicitly track this value instead of computing the count here
-		-- as it will be useful to display the count during gameplay.
+		-- The W0 window is emulated in ITG mode. Grab the value from stage stats.
 		if window == "W1" and SL.Global.GameMode == "ITG" then
-			local W0_count = GetW0Count(player)
+			local W0_count = SL[pn].Stages.Stats[SL.Global.Stages.PlayedThisGame + 1].W0_count
 			total_points = total_points + W0_count * SL.ExWeights["W0"]
 
 			-- Subtract the W0 note count from the actual W1 count and then fall through below

--- a/Scripts/SL_Init.lua
+++ b/Scripts/SL_Init.lua
@@ -390,7 +390,7 @@ SL = {
 		W5=0,
 		Miss=0,
 		LetGo=0,
-		Held=3.5,  -- Should be same as W0 as that is how SM handles it internally.
+		Held=1,
 		HitMine=-1
 	},
 	-- Fields used to determine the existence of the launcher and the


### PR DESCRIPTION
This way we can just reference the pre-computed value instead of looping `sequential_offsets` to compute it.
This speeds up the EX score calculation and we can later use this to display a live count in ScreenGameplay.
Also updated EX score weights, and used EX score for the ItlOverlay