### PR TITLE
Add JudgmentTIlt

### DIFF
--- a/Graphics/Player judgment.lua
+++ b/Graphics/Player judgment.lua
@@ -56,6 +56,20 @@ return Def.ActorFrame{
 		self:playcommand("Reset")
 
 		sprite:visible(true):setstate(frame)
+
+		if SL[ToEnumShortString(player)].ActiveModifiers.JudgmentTilt then
+			if param.TapNoteScore ~= "Miss" then
+				-- How much to rotate.
+				-- We cap it at 50ms (15px) since anything after likely to be too distracting.
+				local offset = math.min(math.abs(param.TapNoteOffset), 0.050) * 300
+				-- Which direction to rotate.
+				local direction = param.TapNoteOffset < 0 and -1 or 1
+				sprite:rotationz(direction * offset)
+			else
+				-- Reset rotations on misses so it doesn't use the previous note's offset.
+				sprite:rotationz(0)
+			end
+		end
 		-- this should match the custom JudgmentTween() from SL for 3.95
 		sprite:zoom(0.8):decelerate(0.1):zoom(0.75):sleep(0.6):accelerate(0.2):zoom(0)
 	end,

--- a/Languages/de.ini
+++ b/Languages/de.ini
@@ -933,8 +933,9 @@ Restart=Lied Neu Starten
 ColumnFlashOnMiss=Leuchte Spalte für Miss
 SubtractiveScoring=Subtraktive Wertung
 Pacemaker=Schrittmacher
-MissBecauseHeld=Track Held Misses
+MissBecauseHeld=Verfolge gehaltene Fehlschläge
 NPSGraphAtTop=Dichtediagramm oben
+JudgmentTilt=Urteil Neigung
 
 
 # MeasureCounterOptions

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -971,6 +971,7 @@ SubtractiveScoring=Subtractive Scoring
 Pacemaker=Pacemaker
 MissBecauseHeld=Track Held Misses
 NPSGraphAtTop=Density Graph at Top
+JudgmentTilt=Judgment Tilt
 
 # ErrorBar
 None=None

--- a/Languages/es.ini
+++ b/Languages/es.ini
@@ -216,6 +216,7 @@ SubtractiveScoring=Sustraer Puntuación
 Pacemaker=Marcapasos
 MissBecauseHeld=Contador de perdidas sostenidas
 NPSGraphAtTop=Gráfico de densidad
+JudgmentTilt=Inclinación del juicio
 
 # MeasureCounterPosition
 MeasureCounterLeft=Izquierda

--- a/Languages/fr.ini
+++ b/Languages/fr.ini
@@ -785,6 +785,7 @@ SubtractiveScoring=Score soustractif
 Pacemaker=Pacemaker
 MissBecauseHeld=Compter les Ratés maintenus
 NPSGraphAtTop=Graphique de densité en haut
+JudgmentTilt=Inclinaison du jugement
 
 # MeasureCounterPosition
 MeasureCounterLeft=Gauche

--- a/Languages/it.ini
+++ b/Languages/it.ini
@@ -261,11 +261,12 @@ Machine best=Record Locale
 Personal best=Record Personale
 
 # GameplayExtras
-MissBecauseHeld=Mostra pad miss
-NPSGraphAtTop=Grafico note per secondo
 ColumnFlashOnMiss=Flash su nota mancata
 SubtractiveScoring=Punteggio Sottrattivo
 Pacemaker=Pacemaker
+MissBecauseHeld=Mostra pad miss
+NPSGraphAtTop=Grafico note per secondo
+JudgmentTilt=Inclinazione del giudizio
 
 # MeasureCounterOptions
 MeasureCounterLeft=Sinistra

--- a/Languages/ja.ini
+++ b/Languages/ja.ini
@@ -738,6 +738,7 @@ SubtractiveScoring=Subtractive Scoring
 Pacemaker=Pacemaker
 MissBecauseHeld=Track Held Misses
 NPSGraphAtTop=Density Graph at Top
+JudgmentTilt=Judgment Tilt
 
 # MeasureCounterOptions
 MeasureCounterLeft=Move Left

--- a/Languages/pl.ini
+++ b/Languages/pl.ini
@@ -958,6 +958,7 @@ SubtractiveScoring=Punktacja Różnicowa
 Pacemaker=Pacemaker
 MissBecauseHeld=Zliczaj Przytrzymane Missy 
 NPSGraphAtTop=Wykres Zagęszczenia u Góry
+JudgmentTilt=Pochylenie osądu
 
 # Pasek Błędu
 None=Brak

--- a/Languages/pt-br.ini
+++ b/Languages/pt-br.ini
@@ -264,11 +264,12 @@ Machine best=Melhor da Maquina
 Personal best=Melhor "Pessoal"
 
 # GameplayExtras
-MissBecauseHeld=Trejetorias Perdidas
-NPSGraphAtTop=Grafico de Densidade no topo
 ColumnFlashOnMiss=Brilhar Colunas Perdidas
 SubtractiveScoring=Subtrair Pontuação
 Pacemaker=Marcapasso
+MissBecauseHeld=Trejetorias Perdidas
+NPSGraphAtTop=Grafico de Densidade no topo
+JudgmentTilt=Inclinação do Julgamento
 
 # MeasureCounterOptions
 MeasureCounterLeft=Esquerda

--- a/Scripts/SL-PlayerOptions.lua
+++ b/Scripts/SL-PlayerOptions.lua
@@ -472,11 +472,12 @@ local Overrides = {
 		SelectType = "SelectMultiple",
 		Values = function()
 			-- GameplayExtras will be presented as a single OptionRow when WideScreen
-			local vals = { "ColumnFlashOnMiss", "SubtractiveScoring", "Pacemaker", "MissBecauseHeld", "NPSGraphAtTop" }
+			local vals = { "ColumnFlashOnMiss", "SubtractiveScoring", "Pacemaker", "MissBecauseHeld", "NPSGraphAtTop", "JudgmentTilt" }
 
 			-- if not WideScreen (traditional DDR cabinets running at 640x480)
-			-- remove the last two choices and show an additional OptionRow with just those two
+			-- remove the last three choices and show an additional OptionRow with just those three
 			if not IsUsingWideScreen() then
+				table.remove(vals, 6)
 				table.remove(vals, 5)
 				table.remove(vals, 4)
 			end
@@ -487,7 +488,7 @@ local Overrides = {
 	-- this is defined in metrics.ini to only appear when not IsUsingWideScreen()
 	GameplayExtrasB = {
 		SelectType = "SelectMultiple",
-		Values = { "MissBecauseHeld", "NPSGraphAtTop" }
+		Values = { "MissBecauseHeld", "NPSGraphAtTop", "JudgmentTilt" }
 	},
 	ErrorBar = {
 		Values = { "None", "Colorful", "Monochrome", "Text" },

--- a/Scripts/SL-PlayerOptions.lua
+++ b/Scripts/SL-PlayerOptions.lua
@@ -472,23 +472,27 @@ local Overrides = {
 		SelectType = "SelectMultiple",
 		Values = function()
 			-- GameplayExtras will be presented as a single OptionRow when WideScreen
-			local vals = { "ColumnFlashOnMiss", "SubtractiveScoring", "Pacemaker", "MissBecauseHeld", "NPSGraphAtTop", "JudgmentTilt" }
+			local vals = { "ColumnFlashOnMiss", "SubtractiveScoring", "Pacemaker", "MissBecauseHeld", "NPSGraphAtTop" }
 
 			-- if not WideScreen (traditional DDR cabinets running at 640x480)
-			-- remove the last three choices and show an additional OptionRow with just those three
+			-- remove the last two choices to be appended an additional OptionRow (GameplayExtrasB below).
 			if not IsUsingWideScreen() then
-				table.remove(vals, 6)
 				table.remove(vals, 5)
 				table.remove(vals, 4)
 			end
 			return vals
 		end,
 	},
-
-	-- this is defined in metrics.ini to only appear when not IsUsingWideScreen()
 	GameplayExtrasB = {
 		SelectType = "SelectMultiple",
-		Values = { "MissBecauseHeld", "NPSGraphAtTop", "JudgmentTilt" }
+		Values = function()
+			if IsUsingWideScreen() then
+				return { "JudgmentTilt" }
+			else
+				-- Add in the two removed options if not in WideScreen.
+				return { "MissBecauseHeld", "NPSGraphAtTop", "JudgmentTilt" }
+			end
+		end
 	},
 	ErrorBar = {
 		Values = { "None", "Colorful", "Monochrome", "Text" },

--- a/Scripts/SL-PlayerProfiles.lua
+++ b/Scripts/SL-PlayerProfiles.lua
@@ -49,6 +49,7 @@ local permitted_profile_settings = {
 	Pacemaker            = "boolean",
 	MissBecauseHeld      = "boolean",
 	NPSGraphAtTop        = "boolean",
+	JudgmentTilt         = "boolean",
 	ErrorBar             = "string",
 	ErrorBarUp           = "boolean",
 	ErrorBarMultiTick    = "boolean",

--- a/Scripts/SL_Init.lua
+++ b/Scripts/SL_Init.lua
@@ -33,6 +33,7 @@ local PlayerDefaults = {
 				LifeMeterType = "Standard",
 				MissBecauseHeld = false,
 				NPSGraphAtTop = false,
+				JudgmentTilt = false,
 				ErrorBar = "None",
 				ErrorBarUp = false,
 				ErrorBarMultiTick = false,

--- a/metrics.ini
+++ b/metrics.ini
@@ -728,8 +728,7 @@ OptionRowNormalMetricsGroup="OptionRowExtendedPlayerOptions"
 # remember that removing OptionRows from the modifier menus is only one part of this
 # we need to perform additional checks in ./BGA/ScreenGameplay underlay/ to ensure that unwanted modifiers aren't brought into gameplay via player profile
 LineNames=(function() \
-	local lines = "Turn,Scroll,Hide,LifeMeterType,DataVisualizations,TargetScore,ActionOnMissedTarget,GameplayExtras,ErrorBar,ErrorBarOptions,MeasureCounter,MeasureCounterOptions,TimingWindows,ScreenAfterPlayerOptions2" \
-	if not IsUsingWideScreen() then lines = lines:gsub("GameplayExtras", "GameplayExtras,GameplayExtrasB") end \
+	local lines = "Turn,Scroll,Hide,LifeMeterType,DataVisualizations,TargetScore,ActionOnMissedTarget,GameplayExtras,GameplayExtrasB,ErrorBar,ErrorBarOptions,MeasureCounter,MeasureCounterOptions,TimingWindows,ScreenAfterPlayerOptions2" \
 	if not PREFSMAN:GetPreference("EventMode") then lines = lines:gsub("ActionOnMissedTarget,", "") end \
    return lines \
 end)()


### PR DESCRIPTION
Add's a player option to tilt the judgment based off of how off you are on each note.
Limits the max amount of tilt to 50ms/15px (excellent window a small bit of the great window) so that it doesn't get too distracting.