### PR TITLE
Add EX/FA+ Elements to ScreenGameplay

### DIFF
--- a/BGAnimations/ScreenEvaluation common/Panes/Pane1/JudgmentNumbers.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane1/JudgmentNumbers.lua
@@ -37,9 +37,7 @@ for i=1,#TapNoteScores.Types do
 		InitCommand=function(self)
 			self:zoom(0.5):horizalign(right)
 
-			if SL.Global.GameMode ~= "ITG" then
-				self:diffuse( SL.JudgmentColors[SL.Global.GameMode][i] )
-			end
+			self:diffuse( SL.JudgmentColors[SL.Global.GameMode][i] )
 
 			-- if some TimingWindows were turned off, the leading 0s should not
 			-- be colored any differently than the (lack of) JudgmentNumber,

--- a/BGAnimations/ScreenEvaluation common/Shared/EventOverlay.lua
+++ b/BGAnimations/ScreenEvaluation common/Shared/EventOverlay.lua
@@ -282,6 +282,7 @@ local GetRpgPaneFunctions = function(eventAf, rpgData, player)
 end
 
 local GetItlPaneFunctions = function(eventAf, itlData, player)
+	local pn = ToEnumShortString(player)
 	local score = CalculateExScore(player) * 100
 	local paneTexts = {}
 	local paneFunctions = {}

--- a/BGAnimations/ScreenGameplay overlay/JudgmentOffsetTracking.lua
+++ b/BGAnimations/ScreenGameplay overlay/JudgmentOffsetTracking.lua
@@ -24,21 +24,6 @@ return Def.Actor{
 			-- Store judgment offsets (including misses) in an indexed table as they occur.
 			-- Also store the CurMusicSeconds for Evaluation's scatter plot.
 			sequential_offsets[#sequential_offsets+1] = { GAMESTATE:GetCurMusicSeconds(), offset }
-
-			-- Only check/update FA+ count if we received a TNS in the top window.
-			if params.TapNoteScore == "TapNoteScore_W1" and SL.Global.GameMode == "ITG"  then
-				local prefs = SL.Preferences["FA+"]
-				local scale = PREFSMAN:GetPreference("TimingWindowScale")
-				local W0 = prefs["TimingWindowSecondsW1"] * scale + prefs["TimingWindowAdd"]
-
-				local storage = SL[ToEnumShortString(player)].Stages.Stats[SL.Global.Stages.PlayedThisGame + 1]
-
-				offset = math.abs(offset)
-				if offset <= W0 then
-					-- Initialized in ScreenGameplay overlay/default.lua
-					storage.W0_count = storage.W0_count + 1
-				end
-			end
 		end
 	end,
 	OffCommand=function(self)

--- a/BGAnimations/ScreenGameplay overlay/TrackExScoreJudgments.lua
+++ b/BGAnimations/ScreenGameplay overlay/TrackExScoreJudgments.lua
@@ -1,0 +1,121 @@
+-- In this file, we're keep track of judgment counts for calculating the EX score to display during
+-- ScreenGameplay and ScreeEvaluation.
+--
+-- Similar to PerColumnJudgmentTracking.lua, this file doesn't override or recreate the engine's
+-- judgment system in any way. It just allows transient judgment data to persist beyond ScreenGameplay.
+------------------------------------------------------------
+
+-- don't bother tracking for Casual gamemode
+if SL.Global.GameMode == "Casual" then return end
+
+local player = ...
+
+local stats = STATSMAN:GetCurStageStats():GetPlayerStageStats(player)
+local storage = SL[ToEnumShortString(player)].Stages.Stats[SL.Global.Stages.PlayedThisGame + 1]
+
+local valid_tns = {
+	W1 = true,
+	W2 = true,
+	W3 = true,
+	W4 = true,
+	W5 = true,
+	Miss = true,
+	HitMine = true
+}
+
+local valid_hns = {
+	LetGo = true,
+	Held = true
+}
+
+return Def.Actor{
+	OnCommand=function(self)
+		storage.ex_counts = {
+			-- These counts are only tracked while a player hasn't failed.
+			-- This is so that the EX score stops changing once they've failed.
+			W0 = 0,
+			W1 = 0,
+			W2 = 0,
+			W3 = 0,
+			W4 = 0,
+			W5 = 0,
+			Miss = 0,
+			HitMine = 0,
+			-- Hold and rolls are tracked together here since they're covered by
+			-- the HoldNoteScore.
+			Held = 0,
+			LetGo = 0,
+		
+			-- The W0 count displayed in the pane in ScreenEvaluation should
+			-- still display the total count (whether or not the player has failed).
+			-- Track that separately.
+			W0_total = 0
+		}
+	end,
+	JudgmentMessageCommand=function(self, params)
+		if params.Player ~= player then return end
+		
+		local count_updated = false
+		if params.HoldNoteScore then
+			local HNS = ToEnumShortString(params.HoldNoteScore)
+			-- Only track the HoldNoteScores we care about
+			if valid_hns[HNS] then
+				if not stats:GetFailed() then
+					storage.ex_counts[HNS] = storage.ex_counts[HNS] + 1
+					count_updated = true
+				end
+			end
+		end
+
+		if params.TapNoteScore then
+			local TNS = ToEnumShortString(params.TapNoteScore)
+
+			if SL.Global.GameMode == "ITG" then
+				if TNS == "W1" then
+					-- Check if this W1 is actually in the W0 window
+					local is_W0 = IsW0Judgment(params, player)
+					if is_W0 then
+						if not stats:GetFailed() then
+							storage.ex_counts.W0 = storage.ex_counts.W0 + 1
+							count_updated = true
+						end
+						storage.ex_counts.W0_total = storage.ex_counts.W0_total + 1
+					else
+						if not stats:GetFailed() then
+							storage.ex_counts.W1 = storage.ex_counts.W1 + 1
+							count_updated = true
+						end
+					end
+				else
+					-- Only track the TapNoteScores we care about
+					if valid_tns[TNS] then
+						if not stats:GetFailed() then
+							storage.ex_counts[TNS] = storage.ex_counts[TNS] + 1
+							count_updated = true
+						end
+					end
+				end
+			else
+				adjusted_TNS = TNS
+				-- In FA+ mode, we need to shift the windows up 1 so that the key we're using is accurate.
+				-- E.g. W1 window becomes W0, W2 becomes W1, etc.
+				if TNS ~= "Miss" then
+					adjusted_TNS = "W"..(tonumber(TNS:sub(-1))-1)
+				end
+				
+				-- Only track the TapNoteScores we care about
+				if valid_tns[adjusted_TNS] then
+					if not stats:GetFailed() then
+						storage.ex_counts[adjusted_TNS] = storage.ex_counts[adjusted_TNS] + 1
+						count_updated = true
+					end
+				end
+			end
+
+			if count_updated then
+				-- Broadcast so other elements on ScreenGameplay can process the updated count.
+				MESSAGEMAN:Broadcast("ExCountsChanged", { Player=player, ExScore=CalculateExScore(player) })
+			end
+		end
+	end,
+}

--- a/BGAnimations/ScreenGameplay overlay/WhoIsCurrentlyWinning.lua
+++ b/BGAnimations/ScreenGameplay overlay/WhoIsCurrentlyWinning.lua
@@ -5,9 +5,15 @@
 -- if there is only one player, don't bother
 if #GAMESTATE:GetHumanPlayers() < 2 then return end
 
-local p1_score, p2_score, p1_dp, p2_dp
+-- if displaying different scoring mechanisms, don't bother.
+if SL["P1"].ActiveModifiers.ShowEXScore ~= SL["P2"].ActiveModifiers.ShowEXScore then return end
+
+local p1_score, p2_score
+local p1_dp = 0
+local p2_dp = 0
 local p1_pss = STATSMAN:GetCurStageStats():GetPlayerStageStats(PLAYER_1)
 local p2_pss = STATSMAN:GetCurStageStats():GetPlayerStageStats(PLAYER_2)
+local IsEX = SL["P1"].ActiveModifiers.ShowEXScore
 
 -- allow for HideScore, which outright removes score actors
 local try_diffusealpha = function(af, alpha)
@@ -21,13 +27,29 @@ return Def.Actor{
 		p1_score = underlay:GetChild("P1Score")
 		p2_score = underlay:GetChild("P2Score")
 	end,
-	JudgmentMessageCommand=function(self) self:queuecommand("Winning") end,
+	JudgmentMessageCommand=function(self, params)
+		if not IsEX then
+			-- calculate the percentage DP manually rather than use GetPercentDancePoints.
+			-- That function rounds to the nearest .01%, which is inaccurate on long songs.
+			if params.Player == PLAYER_1 then
+				p1_dp = p1_pss:GetActualDancePoints() / p1_pss:GetPossibleDancePoints()
+			elseif params.Player == PLAYER_2 then
+				p2_dp = p2_pss:GetActualDancePoints() / p2_pss:GetPossibleDancePoints()
+			end
+			self:queuecommand("Winning")
+		end
+	end,
+	ExCountsChangedMessageCommand=function(self, params)
+		if IsEX then
+			if params.Player == PLAYER_1 then
+				p1_dp = params.ExScore
+			elseif params.Player == PLAYER_2 then
+				p2_dp = params.ExScore
+			end
+			self:queuecommand("Winning")
+		end
+	end,
 	WinningCommand=function(self)
-		-- calculate the percentage DP manually rather than use GetPercentDancePoints.
-		-- That function rounds to the nearest .01%, which is inaccurate on long songs.
-		p1_dp = p1_pss:GetActualDancePoints() / p1_pss:GetPossibleDancePoints()
-		p2_dp = p2_pss:GetActualDancePoints() / p2_pss:GetPossibleDancePoints()
-
 		if p1_dp == p2_dp then
 			try_diffusealpha(p1_score, 1)
 			try_diffusealpha(p2_score, 1)

--- a/BGAnimations/ScreenGameplay overlay/default.lua
+++ b/BGAnimations/ScreenGameplay overlay/default.lua
@@ -34,12 +34,11 @@ for player in ivalues( GAMESTATE:GetHumanPlayers() ) do
 	--
 	-- Sadly, the full details of this Stages.Stats[stage_index] data structure
 	-- is not documented anywhere. :(
-	SL[pn].Stages.Stats[SL.Global.Stages.PlayedThisGame+1] = {
-		W0_count = 0, -- Only really used to keep track of the FA Plus window in ITG mode.
-	}
+	SL[pn].Stages.Stats[SL.Global.Stages.PlayedThisGame+1] = {}
 
 	af[#af+1] = LoadActor("./TrackTimeSpentInGameplay.lua", player)
 	af[#af+1] = LoadActor("./JudgmentOffsetTracking.lua", player)
+	af[#af+1] = LoadActor("./TrackExScoreJudgments.lua", player)
 
 	-- FIXME: refactor PerColumnJudgmentTracking to not be inside this loop
 	--        the Lua input callback logic shouldn't be duplicated for each player

--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/StepStatistics/TapNoteJudgments.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/StepStatistics/TapNoteJudgments.lua
@@ -1,10 +1,14 @@
 local player, has_labels = unpack(...)
+local pn = ToEnumShortString(player)
 
 local IsUltraWide = (GetScreenAspectRatio() > 21/9)
 local NoteFieldIsCentered = (GetNotefieldX(player) == _screen.cx)
 
 local StepsOrTrail = (GAMESTATE:IsCourseMode() and GAMESTATE:GetCurrentTrail(player)) or GAMESTATE:GetCurrentSteps(player)
 local total_tapnotes = StepsOrTrail:GetRadarValues(player):GetValue( "RadarCategory_Notes" )
+
+-- Only add this in ITG mode.
+local ShowFaPlusWindow = SL[pn].ActiveModifiers.ShowFaPlusWindow and SL.Global.GameMode=="ITG"
 
 -- determine how many digits are needed to express the number of notes in base-10
 local digits = (math.floor(math.log10(total_tapnotes)) + 1)
@@ -19,18 +23,43 @@ local TNS = {
 	Types = { 'W1', 'W2', 'W3', 'W4', 'W5', 'Miss' },
 	Judgments = { W1=0, W2=0, W3=0, W4=0, W5=0, Miss=0 },
 	Names = {},
+	Colors = {},
 }
 
+-- Prepend "W0" if it's enabled.
+if ShowFaPlusWindow then
+	table.insert(TNS.Types, 1, 'W0')
+	TNS.Judgments["W0"] = 0
+end
+
 local tns_string = "TapNoteScore" .. (SL.Global.GameMode=="ITG" and "" or SL.Global.GameMode)
+
 -- get TNS names appropriate for the current GameMode, localized to the current language
 for i, judgment in ipairs(TNS.Types) do
-	TNS.Names[#TNS.Names+1] = THEME:GetString(tns_string, judgment)
+	if ShowFaPlusWindow then
+		-- Add the windows from FA+ (W0 is handled by FA+ W1).
+		if judgment ~= "W0" then
+			TNS.Names[#TNS.Names+1] = THEME:GetString("TapNoteScoreFA+", judgment)
+			TNS.Colors[#TNS.Colors+1] = SL.JudgmentColors["FA+"][i-1]
+		end
+		-- And then additionally add the Way Off window.
+		if judgment == "W5" then
+			TNS.Names[#TNS.Names+1] = THEME:GetString("TapNoteScore", judgment)
+			TNS.Colors[#TNS.Colors+1] = SL.JudgmentColors["ITG"][5]
+		end
+	else
+		TNS.Names[#TNS.Names+1] = THEME:GetString(tns_string, judgment)
+		TNS.Colors[#TNS.Colors+1] = SL.JudgmentColors[SL.Global.GameMode][i]
+	end
 end
 
 local leadingZeroAttr
-local row_height = 35
+local row_height = ShowFaPlusWindow and 29 or 35
 
 local windows = SL.Global.ActiveModifiers.TimingWindows
+if ShowFaPlusWindow then
+	table.insert(windows, 1, windows[1])
+end
 
 -- -----------------------------------------------------------------------
 
@@ -50,7 +79,6 @@ af.InitCommand=function(self)
 	end
 end
 
-
 for index, window in ipairs(TNS.Types) do
 
 	-- TNS value
@@ -67,8 +95,8 @@ for index, window in ipairs(TNS.Types) do
 				self:halign( PlayerNumber:Reverse()[OtherPlayer[player]] )
 			end
 
-			if SL.Global.ActiveModifiers.TimingWindows[index] or index==#TNS.Types then
-				self:diffuse( SL.JudgmentColors[SL.Global.GameMode][index] )
+			if windows[index] or index==#TNS.Types then
+				self:diffuse( TNS.Colors[index] )
 				leadingZeroAttr = { Length=(digits-1), Diffuse=Brightness(self:GetDiffuse(), 0.35) }
 				self:AddAttribute(0, leadingZeroAttr )
 			else
@@ -78,14 +106,33 @@ for index, window in ipairs(TNS.Types) do
 		JudgmentMessageCommand=function(self, params)
 			if params.Player ~= player then return end
 			if params.HoldNoteScore then return end
+			if not params.TapNoteScore then return end
 
-			if params.TapNoteScore and ToEnumShortString(params.TapNoteScore) == window then
+			local incremented = false
+
+			-- Check the top window case for ShowFaPlusWindow.
+			if ShowFaPlusWindow and ToEnumShortString(params.TapNoteScore) == "W1" then
+				local is_W0 = IsW0Judgment(params, player)
+				if is_W0 and window == "W0" then
+					TNS.Judgments[window] = TNS.Judgments[window] + 1
+					incremented = true
+				end
+
+				if not is_W0 and window == "W1" then
+					TNS.Judgments[window] = TNS.Judgments[window] + 1
+					incremented = true
+				end
+			elseif ToEnumShortString(params.TapNoteScore) == window then
 				TNS.Judgments[window] = TNS.Judgments[window] + 1
+				incremented = true
+			end
+
+			if incremented then
 				self:settext( (pattern):format(TNS.Judgments[window]) )
 
 				leadingZeroAttr = {
 					Length=(digits - (math.floor(math.log10(TNS.Judgments[window]))+1)),
-					Diffuse=Brightness(SL.JudgmentColors[SL.Global.GameMode][index], 0.35)
+					Diffuse=Brightness(TNS.Colors[index], 0.35)
 				}
 				self:AddAttribute(0, leadingZeroAttr )
 			end
@@ -108,7 +155,7 @@ for index, window in ipairs(TNS.Types) do
 						self:x(-80 - (digits-4)*16)
 					end
 					self:y((index-1) * row_height - 279)
-					self:diffuse( SL.JudgmentColors[SL.Global.GameMode][index] )
+					self:diffuse( TNS.Colors[index] )
 
 					-- flip alignment when ultrawide and both players joined
 					if IsUltraWide and #GAMESTATE:GetHumanPlayers() > 1 then

--- a/BGAnimations/ScreenGameplay underlay/Shared/VersusStepStatistics.lua
+++ b/BGAnimations/ScreenGameplay underlay/Shared/VersusStepStatistics.lua
@@ -76,6 +76,9 @@ for player in ivalues(Players) do
 
         -- Add a score to Step Stats if it's hidden by the NPS graph.
         if SL[ToEnumShortString(player)].ActiveModifiers.NPSGraphAtTop then
+            local pn = ToEnumShortString(player)
+            local IsEX = SL[pn].ActiveModifiers.ShowEXScore
+
             af[#af+1] = LoadFont("Wendy/_wendy monospace numbers")..{
                 Text="0.00",
                 InitCommand=function(self)
@@ -86,15 +89,30 @@ for player in ivalues(Players) do
                     else
                         self:xy(65, -150)
                     end
+
+                    if IsEX then
+                        -- If EX Score, let's diffuse it to be the same as the FA+ top window.
+                        -- This will make it consistent with the EX Score Pane.
+                        self:diffuse(SL.JudgmentColors["FA+"][1])
+                    end
                 end,
                 JudgmentMessageCommand=function(self, params)
                     if params.Player ~= player then return end
-
-                    local pss = STATSMAN:GetCurStageStats():GetPlayerStageStats(player)
-                    dance_points = pss:GetPercentDancePoints()
-                    percent = FormatPercentScore( dance_points ):sub(1,-2)
-                    self:settext(percent)
-                end
+            
+                    if not IsEX then
+                        local pss = STATSMAN:GetCurStageStats():GetPlayerStageStats(player)
+                        local dance_points = pss:GetPercentDancePoints()
+                        local percent = FormatPercentScore( dance_points ):sub(1,-2)
+                        self:settext(percent)
+                    end
+                end,
+                ExCountsChangedMessageCommand=function(self, params)
+                    if params.Player ~= player then return end
+            
+                    if IsEX then
+                        self:settext(("%.02f"):format(params.ExScore))
+                    end
+                end,
             }
         end
     end

--- a/Languages/de.ini
+++ b/Languages/de.ini
@@ -619,6 +619,7 @@ BackgroundFilter=Bildschirmabdeckung
 ComboFont=Combo Schriftart
 MusicRate=Musikrate
 Stepchart=Schwierigkeit
+FaPlus=FA+ Optionen
 ScreenAfterPlayerOptions=Was Kommt nächstes?
 
 
@@ -790,6 +791,7 @@ ComboFont=Wähl die Schriftart für Combo. Diese Schriftart wird auch für den M
 BackgroundFilter=Verstecke die Unterseite des Spielfeld.
 MusicRate=Ändern die Tempo der Musik.
 Stepchart=Wähle ein Schwierigkeit.
+FaPlus=Wähle, ob du das FA+-Fenster emulieren und/oder die EX-Wertung im Spiel anzeigen möchten.
 ScreenAfterPlayerOptions=Wähl ein anderes Lied ODER wähl mehrere Modifikationen.
 
 
@@ -901,6 +903,9 @@ Dark=Dunkel
 Darker=Dunkler
 Darkest=Dunkelsten
 
+# FaPlus
+ShowFaPlusWindow=FA+-Fenster anzeigen
+ShowEXScore=EX-Score anzeigen
 
 # Hide
 Targets=Ziele

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -634,6 +634,7 @@ ComboFont=Combo Font
 BackgroundFilter=Background Filter
 MusicRate=Music Rate
 Stepchart=Stepchart
+FaPlus=FA+ Options
 ScreenAfterPlayerOptions=What comes next?
 
 # ScreenPlayerOptions2
@@ -811,6 +812,7 @@ ComboFont=Choose the font to count your combo. This font will also be used for t
 BackgroundFilter=Darken the underside of the playing field.\nThis will partially obscure background art.
 MusicRate=Change the native speed of the music itself.
 Stepchart=Choose the stepchart you wish to play.
+FaPlus=Choose to emulate the FA+ window and/or display EX scoring in gameplay.
 ScreenAfterPlayerOptions=Go back and choose a different song or change additional modifiers.
 
 # ScreenPlayerOptions2
@@ -925,6 +927,10 @@ Off=Off
 Dark=Dark
 Darker=Darker
 Darkest=Darkest
+
+# FaPlus
+ShowFaPlusWindow=Display FA+ Window
+ShowEXScore=Display EX Score
 
 # Hide
 Targets=Targets

--- a/Languages/es.ini
+++ b/Languages/es.ini
@@ -187,6 +187,10 @@ Dark=Oscuro
 Darker=Más Oscuro
 Darkest=Hosco
 
+# FaPlus
+ShowFaPlusWindow=Mostrar ventana FA+
+ShowEXScore=Mostrar puntuación EX
+
 # Hide
 Targets=Receptores
 SongBG=Fondo
@@ -626,6 +630,7 @@ ComboFont=Fuente de Combo
 HoldJudgment=Juicio sostenido
 MusicRate=Vel. de Canción
 Stepchart=Dificultad
+FaPlus=Opciones FA+
 ScreenAfterPlayerOptions=Siguiente Pantalla
 
 # ScreenPlayerOptions2
@@ -784,6 +789,7 @@ HoldJudgment=Grafico para notas sostenidas.
 BackgroundFilter=Cubre el fondo del area de notas.
 MusicRate=Cambia la velocidad de la canción.
 Stepchart=Elige una dificultad.
+FaPlus=Elija emular la ventana FA+ y/o mostrar la puntuación EX en el juego.
 ScreenAfterPlayerOptions=Escoge otra canción, O selecciona mas modificadores.
 
 # ScreenPlayerOptions2

--- a/Languages/fr.ini
+++ b/Languages/fr.ini
@@ -511,6 +511,7 @@ BackgroundFilter=Filtre écran
 JudgmentGraphic=Police de jugement
 MusicRate=Vitesse de musique
 Stepchart=Stepchart
+FaPlus=Options FA+
 ScreenAfterPlayerOptions=Prochain écran
 
 # ScreenPlayerOptions2
@@ -661,6 +662,7 @@ ComboFont=Choisissez la police du compteur de combo. Cette police sera égalemen
 BackgroundFilter=Couvrir l'arrière du joueur.
 MusicRate=Changer la vitesse de lecture de la musique.
 Stepchart=Choisissez une difficulté.
+FaPlus=Choisissez d'émuler la fenêtre FA+ et/ou d'afficher le score EX dans le gameplay.
 ScreenAfterPlayerOptions=Choisir une chanson différente OU choisir plus d'options.
 
 # ScreenPlayerOptions2
@@ -756,6 +758,10 @@ Off=Désactiver
 Dark=Sombre
 Darker=Plus sombre
 Darkest=Noir
+
+# FaPlus
+ShowFaPlusWindow=Afficher la fenêtre FA+
+ShowEXScore=Afficher le score EX
 
 # Hide
 Targets=Récepteurs

--- a/Languages/it.ini
+++ b/Languages/it.ini
@@ -239,6 +239,10 @@ Dark=Leggero
 Darker=Medio
 Darkest=Scuro
 
+# FaPlus
+ShowFaPlusWindow=Visualizza finestra FA+
+ShowEXScore=Mostra il punteggio EX
+
 # Hide
 Targets=Recettori
 SongBG=Sfondo
@@ -1204,6 +1208,7 @@ Perspective=Prospettiva
 MusicRate=Velocità traccia audio
 Steps=Difficoltà
 Stepchart=Chart
+FaPlus=Opzioni FA+
 Turn=Chart
 Scroll=Scorrimento
 Insert=Inserisci
@@ -1506,6 +1511,7 @@ SpeedMod=Regola la velocità con cui le note si muovono verso i recettori.
 
 Steps=Scegli una difficoltà.
 Stepchart=Scegli una difficoltà.
+FaPlus=Scegli di emulare la finestra FA+ e/o visualizzare il punteggio EX durante il gioco.
 HoldJudgment=Modifica la grafica mostrata per le note hold
 BackgroundFilter=Scurisce lo sfondo al di sotto delle note per migliorare la leggibilità.
 Mini=Modifica la dimensione delle note. Più il numero è alto, più le note saranno piccole.

--- a/Languages/ja.ini
+++ b/Languages/ja.ini
@@ -613,6 +613,7 @@ BackgroundFilter=背景の暗さを調節します。
 ComboFont=Choose the font to count your combo. This font will also be used for the Measure Counter if that is enabled.
 MusicRate=曲自体の再生速度を変更します。
 Stepchart=譜面の難易度を選択します。
+FaPlus=FA +ウィンドウをエミュレートするか、ゲームプレイでEXスコアを表示するかを選択します。
 ScreenAfterPlayerOptions=他の曲を選択するか、更にオプションを設定することができます。
 
 # ScreenPlayerOptions2
@@ -704,10 +705,14 @@ CustomSongsMaxSeconds=アーケードで運用するなら、ArcadeOptionsの2-r
 ##############################################
 [SLPlayerOptions]
 # ScreenFilter
-Off=Off
-Dark=Dark
-Darker=Darker
-Darkest=Darkest
+Off=オフ
+Dark=暗い
+Darker=もっと暗い
+Darkest=モット暗い！
+
+# FaPlus
+ShowFaPlusWindow=FA+ウィンドウを見せて
+ShowEXScore=EXスコアを見せて
 
 # Hide
 Targets=Targets

--- a/Languages/pl.ini
+++ b/Languages/pl.ini
@@ -625,6 +625,7 @@ ComboFont=Czcionka Combo
 BackgroundFilter=Filtr Ekranu
 MusicRate=Prędkość Odtwarzania
 Stepchart=Układ
+FaPlus=FA+ Opcje
 ScreenAfterPlayerOptions=Co następne?
 
 # Opcje Gracza 2
@@ -799,6 +800,7 @@ ComboFont=Wybierz czcionkę używaną do zliczania combo. Licznik miar będzie k
 BackgroundFilter=Przyciemnij spód planszy, częściowo zasłaniając tło.
 MusicRate=Zmień prędkość utworu.
 Stepchart=Wybierz układ, w który chcesz zagrać.
+FaPlus=Wybierz emulację okna FA+ i/lub wyświetlanie punktacji EX w grze.
 ScreenAfterPlayerOptions=Wróć i wybierz inny utwór, lub zmień modyfikatory.
 
 # Opcje Gracza 2
@@ -912,6 +914,10 @@ Off=Wyłączony
 Dark=Ciemny
 Darker=Ciemniejszy
 Darkest=Najciemniejszy
+
+# FaPlus
+ShowFaPlusWindow=Wyświetl okno FA+
+ShowEXScore=Wyświetl wynik EX
 
 # Ukryj
 Targets=Cele

--- a/Languages/pt-br.ini
+++ b/Languages/pt-br.ini
@@ -242,6 +242,10 @@ Dark=Escuro
 Darker=Mais Escuro
 Darkest=Escuridão
 
+# FaPlus
+ShowFaPlusWindow=Exibir janela FA+
+ShowEXScore=Exibir pontuação EX
+
 # Hide
 Targets=Receptores
 SongBG=Fundo
@@ -1198,6 +1202,7 @@ Perspective=Perspectiva
 MusicRate=Vel. da música
 Steps=Setas
 Stepchart=Setas
+FaPlus=Opções de FA+
 Turn=Virar
 Scroll=Rolagem
 Insert=Inserir
@@ -1499,6 +1504,7 @@ SpeedMod=Ajusta a velocidade na qual as notas viajam para os receptores.
 
 Steps=Escolha uma dificuldade.
 Stepchart=Escolha uma dificuldade.
+FaPlus=Escolha emular a janela FA+ e/ou exibir a pontuação EX no jogo.
 BackgroundFilter=Cobre a parte inferior da área das notas.
 Mini=Altere o tamanho das notas.
 Perspective=Altere o ângulo de vista das notas.

--- a/Scripts/SL-PlayerOptions.lua
+++ b/Scripts/SL-PlayerOptions.lua
@@ -382,6 +382,37 @@ local Overrides = {
 			end
 		end
 	},
+	FaPlus = {
+		SelectType = "SelectMultiple",
+		Values = function()
+			if SL.Global.GameMode == "FA+" then
+				return { "ShowEXScore" }
+			end
+			return { "ShowFaPlusWindow", "ShowEXScore" }
+		end,
+		LoadSelections = function(self, list, pn)
+			local mods = SL[ToEnumShortString(pn)].ActiveModifiers
+			if SL.Global.GameMode == "FA+" then
+				list[1] = mods.ShowEXScore or false
+				return list
+			end
+
+			list[1] = mods.ShowFaPlusWindow or false
+			list[2] = mods.ShowEXScore or false
+			return list
+		end,
+		SaveSelections = function(self, list, pn)
+			local mods = SL[ToEnumShortString(pn)].ActiveModifiers
+			if SL.Global.GameMode == "FA+" then
+				 -- always disable in FA+ mode since it's handled engine side.
+				mods.ShowFaPlusWindow = false
+				mods.ShowEXScore   = list[1]
+				return
+			end
+			mods.ShowFaPlusWindow = list[1]
+			mods.ShowEXScore   = list[2]
+		end
+	},
 	-------------------------------------------------------------------------
 	Hide = {
 		SelectType = "SelectMultiple",

--- a/Scripts/SL-PlayerProfiles.lua
+++ b/Scripts/SL-PlayerProfiles.lua
@@ -21,6 +21,8 @@ local permitted_profile_settings = {
 	ComboFont        = "string",
 	HoldJudgment     = "string",
 	BackgroundFilter = "string",
+	ShowFaPlusWindow = "boolean",
+	ShowEXScore      = "boolean",
 
 	----------------------------------
 	-- "Advanced Modifiers"

--- a/Scripts/SL_Init.lua
+++ b/Scripts/SL_Init.lua
@@ -36,6 +36,9 @@ local PlayerDefaults = {
 				ErrorBar = "None",
 				ErrorBarUp = false,
 				ErrorBarMultiTick = false,
+
+				ShowFaPlusWindow = false,
+				ShowEXScore = false,
 			}
 			self.Streams = {
 				-- Chart identifiers for caching purposes.

--- a/metrics.ini
+++ b/metrics.ini
@@ -646,7 +646,7 @@ RowPositionTransformFunction=function(self,positionIndex,itemIndex,numItems) sel
 RepeatRate=30
 AllowRepeatingChangeValueInput=true
 LineNames=(function() \
-	local lines = "SpeedModType,SpeedMod,Mini,Perspective,NoteSkinSL,Judgment,ComboFont,HoldJudgment,BackgroundFilter,MusicRate,Stepchart,ScreenAfterPlayerOptions" \
+	local lines = "SpeedModType,SpeedMod,Mini,Perspective,NoteSkinSL,Judgment,ComboFont,HoldJudgment,BackgroundFilter,MusicRate,Stepchart,FaPlus,ScreenAfterPlayerOptions" \
 	if GAMESTATE:GetCurrentGame():GetName() == "pump" then lines = lines:gsub("HoldJudgment,","") end \
 	return lines \
 end)()
@@ -662,6 +662,7 @@ LineComboFont="lua,CustomOptionRow('ComboFont')"
 LineBackgroundFilter="lua,CustomOptionRow('BackgroundFilter')"
 LineMusicRate="lua,CustomOptionRow('MusicRate')"
 LineStepchart="lua,CustomOptionRow('Stepchart')"
+LineFaPlus="lua,CustomOptionRow('FaPlus')"
 LineScreenAfterPlayerOptions="lua,CustomOptionRow('ScreenAfterPlayerOptions')"
 
 LineHoldJudgment="lua,CustomOptionRow('HoldJudgment')"
@@ -677,14 +678,19 @@ LineGameplayExtras="lua,CustomOptionRow('GameplayExtras')"
 #    unclear from a usability standpoint.
 LineGameplayExtrasB="lua,CustomOptionRow('GameplayExtrasB')"
 
-LineErrorBar="lua,CustomOptionRow('ErrorBar')"
-LineErrorBarOptions="lua,CustomOptionRow('ErrorBarOptions')"
-LineMeasureCounterOptions="lua,CustomOptionRow('MeasureCounterOptions')"
-LineMeasureCounter="lua,CustomOptionRow('MeasureCounter')"
+## These OptionRows appear on [ScreenPlayerOptions2] and [ScreenAttackMenu],
+## define them here anyway so that each of those screens can fallback on this one
+LineTurn="list,Turn"
+LineScroll="list,Scroll"
+LineLifeMeterType="lua,CustomOptionRow('LifeMeterType')"
 LineDataVisualizations="lua,CustomOptionRow('DataVisualizations')"
 LineTargetScore="lua,CustomOptionRow('TargetScore')"
 LineActionOnMissedTarget="lua,CustomOptionRow('ActionOnMissedTarget')"
-LineLifeMeterType="lua,CustomOptionRow('LifeMeterType')"
+LineErrorBar="lua,CustomOptionRow('ErrorBar')"
+LineErrorBarOptions="lua,CustomOptionRow('ErrorBarOptions')"
+LineMeasureCounter="lua,CustomOptionRow('MeasureCounter')"
+LineMeasureCounterOptions="lua,CustomOptionRow('MeasureCounterOptions')"
+LineTimingWindows="lua,CustomOptionRow('TimingWindows')"
 
 # lists assembled by the engine
 LinePerspective="list,Perspective"
@@ -692,11 +698,6 @@ LinePerspective="list,Perspective"
 # LineNoteSkin is the engine-generated OptionRow
 # we use it in EditMode's PlayerOptions to avoid buggy behavior
 LineNoteSkin="list,NoteSkins"
-
-## These OptionRows appear on [ScreenPlayerOptions2] and [ScreenAttackMenu],
-## define them here anyway so that each of those screens can fallback on this one
-LineTurn="list,Turn"
-LineScroll="list,Scroll"
 
 ## effects
 Line11="list,Accel"
@@ -736,7 +737,6 @@ end)()
 
 # OptionRows assembled in ./Scripts/SL-PlayerOptions.lua
 LineScreenAfterPlayerOptions2="lua,CustomOptionRow('ScreenAfterPlayerOptions2')"
-LineTimingWindows="lua,CustomOptionRow('TimingWindows')"
 
 [ScreenPlayerOptions3]
 Class="ScreenPlayerOptions"


### PR DESCRIPTION
This PR does a couple of things which I will highlight below:
1) Adds an "FA+ Options" row in the first player options screen. In the FA+ game mode, only "Display EX Score" is shown:
These values are saved to a player's profile.
<img width="1111" alt="image" src="https://user-images.githubusercontent.com/5017202/159150847-ea74d66e-cccf-4cf4-9bb7-62ea92f359eb.png">

- "Enabled" Means that the white counts are displayed in step statistics. In the next PR I will make it so that the judgment font chosen will also show white count, but I need to create the graphics for that.
- "Display EX Score" replaces the ITG score with the EX score. This is made obvious by highlighting the score in blue.
<img width="732" alt="image" src="https://user-images.githubusercontent.com/5017202/159150870-717a68f9-a90e-418b-8a17-c33315dac217.png">
<img width="1151" alt="image" src="https://user-images.githubusercontent.com/5017202/159152920-6aabc022-d98e-44a6-a12c-929c073cec15.png">

-----
2) A lot of refactoring surrounding EX/White count calculations
- Added `BGAnimations/ScreenGameplay overlay/TrackExScoreJudgments.lua` - This is used specifically to keep track of the EX Score values/judgments so everything that depends on it will fetch values from there. This actor broadcasts whenever a change has happened and is consumed by `BGAnimations/ScreenGameplay overlay/WhoIsCurrentlyWinning.lua` and `BGAnimations/ScreenGameplay underlay/PerPlayer/Score.lua`

- Modified the helper function `CalculateExScore` to accept the table created from above. The "totals" (taps/holds/rolls) are now computer from `StepsOrTrail` instead of `PlayerStageStats` since it seems like the latter displayed 0s in gameplay. This still seems to work correctly on `ScreenEvaluation` which is evident from the EX scores displayed in `ScreenGameplay` matches up with what's displayed in `ScreenEvaluation`.

- Added a helper function `IsW0Judgment`. This function determines if a TNS falls within the W0 window. This just helps in making it so we didn't need to duplicate the logic.

------
Briefly tested in:
1) 1 Player ITG Mode
2) 1 Player Course Mode
3) 1 Player FA+ Mode
4) 2 Player ITG Mode
5) 2 Player FA+ Mode