### PR TITLE
Add Support for Column Cues

### DIFF
--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/ColumnCues.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/ColumnCues.lua
@@ -1,0 +1,79 @@
+local player = ...
+local pn = ToEnumShortString(player)
+local mods = SL[pn].ActiveModifiers
+
+if not mods.ColumnCues then return end
+
+local playerState = GAMESTATE:GetPlayerState(player)
+local columnCues = SL[pn].Streams.ColumnCues
+
+local numColumns = GAMESTATE:GetCurrentStyle():ColumnsPerPlayer()
+local style = GAMESTATE:GetCurrentStyle(player)
+local width = style:GetWidth(player)
+
+local yOffset = 80
+local fadeTime = 0.15
+local curIndex = 1
+
+local Update = function(self, delta)
+	if curIndex <= #columnCues then
+		local curTime = playerState:GetSongPosition():GetMusicSecondsVisible()
+		local columnCue = columnCues[curIndex]
+		if columnCue.startTime <= curTime then
+			-- Get the current music rate.
+			-- Note that Lua files might change the rate mode so this might not be accurate.
+			-- It's hard to handle that case since we don't exactly know when a file will apply a rate mod.
+			local rate = SL.Global.ActiveModifiers.MusicRate
+			local scaledDuration = columnCue.duration / rate
+			-- Make sure there's still something to display after any potential scaling.
+			if scaledDuration > 2 * fadeTime then
+				for col_mine in ivalues(columnCue.columns) do
+					local col = col_mine.colNum
+					local isMine = col_mine.isMine
+					self:GetChild("Column"..col):playcommand("Flash", {
+						duration=scaledDuration,
+						isMine=isMine
+					})
+				end
+			end
+			curIndex = curIndex + 1
+		end
+	end
+end
+
+local af = Def.ActorFrame{
+	InitCommand=function(self)
+		self:xy( GetNotefieldX(player), yOffset)
+		local zoom_factor = 1 - scale( mods.Mini:gsub("%%","")/100, 0, 2, 0, 1)
+		self:zoomx( zoom_factor )
+		self:queuecommand("SetUpdate")
+	end,
+	SetUpdateCommand=function(self)
+		self:SetUpdateFunction(Update)
+	end
+}
+
+for columnIndex=1,numColumns do
+	af[#af+1] = Def.Quad {
+		Name="Column"..columnIndex,
+		InitCommand=function(self)
+			self:diffuse(0,0,0,0)
+				:x((columnIndex - (numColumns/2 + 0.5)) * (width/numColumns))
+				:vertalign(top)
+				:setsize(width/numColumns, _screen.h - yOffset)
+				:fadebottom(0.333)
+		end,
+		FlashCommand=function(self, params)
+			local flashDuration = params.duration
+			local clr = params.isMine and color("1,0,0,0.12") or color("0.3,1,1,0.12")
+			self:stoptweening()
+				:decelerate(fadeTime)
+				:diffuse(clr)
+				:sleep(flashDuration - 2*fadeTime)
+				:accelerate(fadeTime)
+				:diffuse(0,0,0,0)
+		end
+	}
+end
+
+return af

--- a/BGAnimations/ScreenGameplay underlay/default.lua
+++ b/BGAnimations/ScreenGameplay underlay/default.lua
@@ -59,6 +59,7 @@ for player in ivalues(Players) do
 	t[#t+1] = LoadActor("./PerPlayer/MeasureCounter.lua", player, layout.MeasureCounter)
 	t[#t+1] = LoadActor("./PerPlayer/TargetScore/default.lua", player)
 	t[#t+1] = LoadActor("./PerPlayer/SubtractiveScoring.lua", player, layout.SubtractiveScoring)
+	t[#t+1] = LoadActor("./PerPlayer/ColumnCues.lua", player)
 end
 
 -- add to the ActorFrame last; overlapped by StepStatistics otherwise

--- a/Languages/de.ini
+++ b/Languages/de.ini
@@ -941,6 +941,7 @@ Pacemaker=Schrittmacher
 MissBecauseHeld=Verfolge gehaltene Fehlschläge
 NPSGraphAtTop=Dichtediagramm oben
 JudgmentTilt=Urteil Neigung
+ColumnCues=Spalten-Cues
 
 
 # MeasureCounterOptions

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -978,6 +978,7 @@ Pacemaker=Pacemaker
 MissBecauseHeld=Track Held Misses
 NPSGraphAtTop=Density Graph at Top
 JudgmentTilt=Judgment Tilt
+ColumnCues=Column Cues
 
 # ErrorBar
 None=None

--- a/Languages/es.ini
+++ b/Languages/es.ini
@@ -221,6 +221,7 @@ Pacemaker=Marcapasos
 MissBecauseHeld=Contador de perdidas sostenidas
 NPSGraphAtTop=Gráfico de densidad
 JudgmentTilt=Inclinación del juicio
+ColumnCues=Señales de columna
 
 # MeasureCounterPosition
 MeasureCounterLeft=Izquierda

--- a/Languages/fr.ini
+++ b/Languages/fr.ini
@@ -792,6 +792,7 @@ Pacemaker=Pacemaker
 MissBecauseHeld=Compter les Ratés maintenus
 NPSGraphAtTop=Graphique de densité en haut
 JudgmentTilt=Inclinaison du jugement
+ColumnCues=Repère de colonne
 
 # MeasureCounterPosition
 MeasureCounterLeft=Gauche

--- a/Languages/it.ini
+++ b/Languages/it.ini
@@ -1292,6 +1292,7 @@ Pacemaker=Pacemaker
 MissBecauseHeld=Traccia Miss Premuti
 NPSGraphAtTop=Grafico Note per Secondo
 JudgmentTilt=Inclinazione Judgment
+ColumnCues=Spunti di colonna
 
 # ErrorBar
 None=Nessuno

--- a/Languages/ja.ini
+++ b/Languages/ja.ini
@@ -749,6 +749,7 @@ Pacemaker=ペースメーカー
 MissBecauseHeld=押しっぱなしミスを記録
 NPSGraphAtTop=上に密度グラフ
 JudgmentTilt=判定を傾ける
+ColumnCues=列の手がかり
 
 # MeasureCounterOptions
 MeasureCounterLeft=Move Left

--- a/Languages/pl.ini
+++ b/Languages/pl.ini
@@ -965,6 +965,7 @@ Pacemaker=Pacemaker
 MissBecauseHeld=Zliczaj Przytrzymane Missy 
 NPSGraphAtTop=Wykres Zagęszczenia u Góry
 JudgmentTilt=Pochylenie osądu
+ColumnCues=wskazówki dotyczące kolumn
 
 # Pasek Błędu
 None=Brak

--- a/Languages/pt-br.ini
+++ b/Languages/pt-br.ini
@@ -274,6 +274,7 @@ Pacemaker=Marcapasso
 MissBecauseHeld=Trejetorias Perdidas
 NPSGraphAtTop=Grafico de Densidade no topo
 JudgmentTilt=Inclinação do Julgamento
+ColumnCues=Dicas de coluna
 
 # MeasureCounterOptions
 MeasureCounterLeft=Esquerda

--- a/Scripts/SL-PlayerOptions.lua
+++ b/Scripts/SL-PlayerOptions.lua
@@ -521,10 +521,10 @@ local Overrides = {
 		SelectType = "SelectMultiple",
 		Values = function()
 			if IsUsingWideScreen() then
-				return { "JudgmentTilt" }
+				return { "JudgmentTilt", "ColumnCues" }
 			else
 				-- Add in the two removed options if not in WideScreen.
-				return { "MissBecauseHeld", "NPSGraphAtTop", "JudgmentTilt" }
+				return { "MissBecauseHeld", "NPSGraphAtTop", "JudgmentTilt", "ColumnCues" }
 			end
 		end
 	},

--- a/Scripts/SL-PlayerProfiles.lua
+++ b/Scripts/SL-PlayerProfiles.lua
@@ -52,6 +52,7 @@ local permitted_profile_settings = {
 	MissBecauseHeld      = "boolean",
 	NPSGraphAtTop        = "boolean",
 	JudgmentTilt         = "boolean",
+	ColumnCues           = "boolean",
 	ErrorBar             = "string",
 	ErrorBarUp           = "boolean",
 	ErrorBarMultiTick    = "boolean",

--- a/Scripts/SL_Init.lua
+++ b/Scripts/SL_Init.lua
@@ -34,6 +34,7 @@ local PlayerDefaults = {
 				MissBecauseHeld = false,
 				NPSGraphAtTop = false,
 				JudgmentTilt = false,
+				ColumnCues = false,
 				ErrorBar = "None",
 				ErrorBarUp = false,
 				ErrorBarMultiTick = false,
@@ -41,6 +42,7 @@ local PlayerDefaults = {
 				ShowFaPlusWindow = false,
 				ShowEXScore = false,
 			}
+			-- TODO(teejusb): Rename "Streams" as the data contains more information than that.
 			self.Streams = {
 				-- Chart identifiers for caching purposes.
 				Filename = "",
@@ -52,6 +54,7 @@ local PlayerDefaults = {
 				NotesPerMeasure = {},
 				PeakNPS = 0,
 				NPSperMeasure = {},
+				columnCues = {},
 				Hash = '',
 
 				Crossovers = 0,
@@ -123,6 +126,8 @@ local GlobalDefaults = {
 			self.TimeAtSessionStart = nil
 
 			self.GameplayReloadCheck = false
+			-- How long to wait before displaying a "cue"
+			self.ColumnCueMinTime = 1.5
 		end,
 
 		-- These values outside initialize() won't be reset each game cycle,


### PR DESCRIPTION
Oftentimes after a long enough break (or at the start of a song), players can be caught offguard from either unexpected mines, or not knowing where the next note starts. This PR gives you an indicator of the column where these might occur after a sufficiently long break (currently 1.5s).

Context 1: [Jim](https://i.imgur.com/uEJ1QBf.mp4)
Context 2: https://clips.twitch.tv/SavageThankfulPanKlappa-0ycH5qvMEGMWlSTz
Context 3: https://clips.twitch.tv/BlightedAbstemiousElephantItsBoshyTime-J3Dhrf7-TNmx9v0Q 

If the column is teal, it's a tap note, and if it's red it's a mine.

No phones were harmed in the making of this PR.

Ported from Digital Dance.

![image](https://user-images.githubusercontent.com/5017202/163350113-f33ec783-35c6-4f5d-a839-b5b018f26488.png)
