### PR TITLE
Bugfix EvalPanePrimary when HideFaPlusPane is true

### DIFF
--- a/Scripts/SL-PlayerOptions.lua
+++ b/Scripts/SL-PlayerOptions.lua
@@ -416,7 +416,7 @@ local Overrides = {
 			mods.ShowEXScore = list[2]
 			mods.HideFaPlusPane = list[3]
 			-- Default to FA+ pane if either options are active.
-			sl_pn.EvalPanePrimary = (list[1] or list[2]) and 2 or 1
+			sl_pn.EvalPanePrimary = ((list[1] or list[2]) and not list[3]) and 2 or 1
 		end
 	},
 	-------------------------------------------------------------------------


### PR DESCRIPTION
Silver Fox, who decided to be my personal beta tester (and he's also good! 😲😱) found an interesting bug after combining the activation of HideFaPlusPane with ShowFaPlusWindow and/or ShowEXScore for the first Screen Evaluation Pane.

As is, after set FA+ Options in this way:
![FaOptions](https://user-images.githubusercontent.com/10159143/166111668-1a18a8d4-ab98-462f-b7a4-cbd36100edf4.png)

The result is the following:
![07 _Disco_2022-04-30_164140](https://user-images.githubusercontent.com/10159143/166110766-0196bb54-a8cf-4d55-a50d-af285c07e126.png)

For fixing this I added the HideFaPlusPane value check, which must be false, otherwise the EvalPanePrimary will still be 1.

Tested on Stepmania 5.1.0-b2 and Simply Love 5.1.2 beta.
Viper