### PR TITLE
Column Cues in Casual Mode

### DIFF
--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/ColumnCues.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/ColumnCues.lua
@@ -1,7 +1,7 @@
 local player = ...
 local pn = ToEnumShortString(player)
 local mods = SL[pn].ActiveModifiers
-
+if SL.Global.GameMode == "Casual" then return end
 if not mods.ColumnCues then return end
 
 local playerState = GAMESTATE:GetPlayerState(player)

--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/ColumnCues.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/ColumnCues.lua
@@ -2,7 +2,9 @@ local player = ...
 local pn = ToEnumShortString(player)
 local mods = SL[pn].ActiveModifiers
 
-if not mods.ColumnCues then return end
+if SL.Global.GameMode ~= "Casual" then
+	if not mods.ColumnCues then return end
+end
 
 local playerState = GAMESTATE:GetPlayerState(player)
 local columnCues = SL[pn].Streams.ColumnCues

--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/ColumnCues.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/ColumnCues.lua
@@ -2,9 +2,7 @@ local player = ...
 local pn = ToEnumShortString(player)
 local mods = SL[pn].ActiveModifiers
 
-if SL.Global.GameMode ~= "Casual" then
-	if not mods.ColumnCues then return end
-end
+if not mods.ColumnCues then return end
 
 local playerState = GAMESTATE:GetPlayerState(player)
 local columnCues = SL[pn].Streams.ColumnCues

--- a/BGAnimations/ScreenSelectMusicCasual overlay/SongWheelShared.lua
+++ b/BGAnimations/ScreenSelectMusicCasual overlay/SongWheelShared.lua
@@ -87,6 +87,38 @@ af[#af+1] = Def.ActorFrame{
 		}
 	}
 }
+for player in ivalues( PlayerNumber ) do
+	local pn = ToEnumShortString(player)
+	af[#af+1] = Def.ActorFrame{
+		Name="ChartParser",
+		-- Hide when scrolling through the wheel. This also handles the case of
+		-- going from song -> folder. It will get unhidden after a chart is parsed
+		-- below.
+		CurrentSongChangedMessageCommand=function(self)
+			self:queuecommand("Hide")
+		end,
+		["CurrentSteps"..pn.."ChangedMessageCommand"]=function(self)
+			self:queuecommand("Hide")
+			self:stoptweening()
+			self:sleep(0.4)
+			self:queuecommand("ParseChart")
+		end,
+		ParseChartCommand=function(self)
+			local steps = GAMESTATE:GetCurrentSteps(player)
+			if steps then
+				MESSAGEMAN:Broadcast(pn.."ChartParsing")
+				ParseChartInfo(steps, pn)
+				self:queuecommand("Show")
+			end
+		end,
+		ShowCommand=function(self)
+			if GAMESTATE:GetCurrentSong() and
+					GAMESTATE:GetCurrentSteps(player) then
+				MESSAGEMAN:Broadcast(pn.."ChartParsed")
+			end
+		end
+	}
+end
 -----------------------------------------------------------------
 -- text
 

--- a/BGAnimations/ScreenSelectMusicCasual overlay/SongWheelShared.lua
+++ b/BGAnimations/ScreenSelectMusicCasual overlay/SongWheelShared.lua
@@ -87,38 +87,6 @@ af[#af+1] = Def.ActorFrame{
 		}
 	}
 }
-for player in ivalues( PlayerNumber ) do
-	local pn = ToEnumShortString(player)
-	af[#af+1] = Def.ActorFrame{
-		Name="ChartParser",
-		-- Hide when scrolling through the wheel. This also handles the case of
-		-- going from song -> folder. It will get unhidden after a chart is parsed
-		-- below.
-		CurrentSongChangedMessageCommand=function(self)
-			self:queuecommand("Hide")
-		end,
-		["CurrentSteps"..pn.."ChangedMessageCommand"]=function(self)
-			self:queuecommand("Hide")
-			self:stoptweening()
-			self:sleep(0.4)
-			self:queuecommand("ParseChart")
-		end,
-		ParseChartCommand=function(self)
-			local steps = GAMESTATE:GetCurrentSteps(player)
-			if steps then
-				MESSAGEMAN:Broadcast(pn.."ChartParsing")
-				ParseChartInfo(steps, pn)
-				self:queuecommand("Show")
-			end
-		end,
-		ShowCommand=function(self)
-			if GAMESTATE:GetCurrentSong() and
-					GAMESTATE:GetCurrentSteps(player) then
-				MESSAGEMAN:Broadcast(pn.."ChartParsed")
-			end
-		end
-	}
-end
 -----------------------------------------------------------------
 -- text
 


### PR DESCRIPTION
Column Cues cause a screen of errors when entering casual mode.

![image](https://user-images.githubusercontent.com/30600688/167437572-43910d39-d52d-41de-95ad-5f6fc137c2b1.png)

If the player attempts to play a song in Casual Mode while using a profile with Column Cues enabled, you're greeted with a flood of errors. This PR fixes it by adding Chart Parsing to casual mode. 

The Column Cue feature is pretty cool and pretty helpful, so this PR also always enables Column Cues in Casual Mode to help new and casual players.
