### PR TITLE
Allow the player to switch to Casual mode from ITG/FA+ mode

### DIFF
--- a/BGAnimations/ScreenSelectMusic overlay/SortMenu/SortMenu_InputHandler.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SortMenu/SortMenu_InputHandler.lua
@@ -33,7 +33,11 @@ local input = function(event)
 				-- Reload the SortMenu's available options and queue "DirectInputToEngine"
 				-- to return input from Lua back to the engine and hide the SortMenu from view
 				sortmenu:playcommand("AssessAvailableChoices"):queuecommand("DirectInputToEngine")
-
+				-- the player is switching to casual mode which uses a different SelectMusic screen
+				if focus.change == "Casual" then
+					screen:SetNextScreenName("ScreenSelectMusicCasual")
+					screen:StartTransitioningScreen("SM_GoToNextScreen")
+				end
 			-- the player wants to change styles, for example from single to double
 			elseif focus.kind == "ChangeStyle" then
 				-- If the MenuTimer is in effect, make sure to grab its current

--- a/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
@@ -308,6 +308,12 @@ local t = Def.ActorFrame {
 		if SL.Global.Stages.PlayedThisGame == 0 then
 			if SL.Global.GameMode ~= "ITG"      then table.insert(wheel_options, {"ChangeMode", "ITG"}) end
 			if SL.Global.GameMode ~= "FA+"      then table.insert(wheel_options, {"ChangeMode", "FA+"}) end
+			-- Casual players often choose the wrong mode and an experienced player in the area may notice this
+			-- and offer to switch them back to casual mode. This allows them to do so again.
+			-- It's technically not possible to reach the sort menu in Casual Mode, but juuust in case let's still
+			-- include the check.
+			if SL.Global.GameMode ~= "Casual"   then table.insert(wheel_options, {"ChangeMode", "Casual"}) end
+
 		end
 		-- allow players to switch to a TestInput overlay if the current game has visual assets to support it
 		-- and if we're in EventMode (public arcades probably don't want random players attempting to diagnose the pads...)


### PR DESCRIPTION
Allow the player to switch to Casual mode from ITG/FA+ mode if no stages have been played.

Casual/New players often choose the wrong mode, this allows them to switch to Casual mode as long as no songs have been played yet.
![image](https://user-images.githubusercontent.com/30600688/167444098-718dbb6a-6a98-49f7-a765-77088cb50018.png)
