### PR TITLE
bug fix: always reset song subtitle in Casual Mode

### DIFF
--- a/BGAnimations/ScreenSelectMusicCasual overlay/SongMT.lua
+++ b/BGAnimations/ScreenSelectMusicCasual overlay/SongMT.lua
@@ -238,6 +238,7 @@ local song_mt = {
 			if type(song) == "string" then
 				self.song = song
 				self.title_bmt:settext( THEME:GetString("ScreenSelectMusicCasual", "CloseThisFolder") )
+				self.subtitle_bmt:settext( "" )
 				self.img_path = THEME:GetPathB("ScreenSelectMusicCasual", "overlay/img/CloseThisFolder.png")
 
 				if CloseFolderTexture ~= nil then


### PR DESCRIPTION
baa9386fd5e84f0b35f76c323cb134c1b27d7b99 added song subtitles to ScreenSelectMusicCasual and introduced a dormant bug where the `"Close This Folder"` item could pick up neighboring song's subtitle if the pack was closed then re-opened.

Here's a demo of the bug:
https://user-images.githubusercontent.com/1253483/167541024-d40dd7c5-cc6f-4304-b445-71e7a1260c05.mp4

### Fix
This fixes that by setting the subtitle BitmapText's text on every sick_wheel event:

  * to an empty string if this is the "Close This Folder" item
  * to the song's subtitle if it is a song
