### PR TITLE
Remove AllowW1 and PercentageScoring from operator menu

### DIFF
--- a/Languages/de.ini
+++ b/Languages/de.ini
@@ -767,9 +767,7 @@ ScreenNameEntryMenuTimer=Set the MenuTimer value for ScreenNameEntry.
 
 
 # Advanced Options
-AllowW1=Enable or disable fantastic judgments.\n\n• Never - No fantastics, at all, ever.\n\n• Courses Only - Fantastics are only possible during courses (nonstop, oni, etc.).\n\n• Always - Fantastics are possible in normal gameplay as well as in courses.
 DefaultFailType=• Immediate - Ends gameplay when all players run out of life.\n\n• ImmediateContinue - Fails players when they run out of life, but allows gameplay to continue.\n\n• EndOfSong - Evaluates whether a player passes or fails at the end of the song.\n\n• Off - Disables fail.
-PercentageScoring=In other themes, this may impact whether dance points or percent scores are displayed.\n\nIn Simply Love, percent scores are always shown, but this setting still impacts how high scores get ranked relative to one another.\n\nYou want this setting 'On'.
 UseUnlockSystem=Enable or disable StepMania's unlock system.\n\nSimply Love does not support the unlock system, and I don't know of any other theme that does.
 AllowExtraStage=When enabled (and Event Mode is off), this allows players to earn extra stages after completing certain requirements.\n\nThis presumably impacts other themes, but has no bearing on Simply Love.
 HiddenSongs=Simfiles with #SELECTABLE:NO; will not appear in the MusicWheel, but might be accessible via specific courses.\n\nLeave this 'Off' to always display all songs.
@@ -878,9 +876,6 @@ MaxHighScoresPerListForMachine=10
 MaxHighScoresPerListForPlayer=3
 Premium=Doppelspieler werden dich lieben, wenn du mindestens ‘Double for 1 Credit’ aktivierst.
 # Advanced Options
-AllowW1=Immer
-PercentageScoring=Stelle es einfach auf “An”. Ich verstehe es auch nicht.\n(ノ°□°)ノ  ┻━┻
-#'
 AutogenSteps=Aus
 DefaultFailType=ImmediateContinue
 TimingWindowScale=4

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -789,9 +789,7 @@ ScreenEvaluationSummaryMenuTimer=Set the MenuTimer value for ScreenEvaluationSum
 ScreenNameEntryMenuTimer=Set the MenuTimer value for ScreenNameEntry.
 
 # Advanced Options
-AllowW1=Enable or disable fantastic judgments.\n\n• Never - No fantastics, at all, ever.\n\n• Courses Only - Fantastics are only possible during courses (nonstop, oni, etc.).\n\n• Always - Fantastics are possible in normal gameplay as well as in courses.
 DefaultFailType=• Immediate - Ends gameplay when all players run out of life.\n\n• ImmediateContinue - Fails players when they run out of life, but allows gameplay to continue.\n\n• EndOfSong - Evaluates whether a player passes or fails at the end of the song.\n\n• Off - Disables fail.
-PercentageScoring=In other themes, this may impact whether dance points or percent scores are displayed.\n\nIn Simply Love, percent scores are always shown, but this setting still impacts how high scores get ranked relative to one another.\n\nYou want this setting 'On'.
 UseUnlockSystem=Enable or disable StepMania's unlock system.\n\nSimply Love does not support the unlock system, and I don't know of any other theme that does.
 AllowExtraStage=When enabled (and Event Mode is off), this allows players to earn extra stages after completing certain requirements.\n\nThis presumably impacts other themes, but has no bearing on Simply Love.
 HiddenSongs=Simfiles with #SELECTABLE:NO; will not appear in the MusicWheel, but might be accessible via specific courses.\n\nLeave this 'Off' to always display all songs.
@@ -900,9 +898,6 @@ MaxHighScoresPerListForMachine=10
 MaxHighScoresPerListForPlayer=3
 Premium=Doubles players will love you if you set 'Double for 1 Credit'. 😍
 # Advanced Options
-AllowW1=Always
-PercentageScoring=Just set it to 'On'. I don't really understand it either.\n(ノ°□°)ノ  ┻━┻
-#'
 AutogenSteps=Off
 DefaultFailType=ImmediateContinue
 TimingWindowScale=4

--- a/Languages/es.ini
+++ b/Languages/es.ini
@@ -770,9 +770,7 @@ ScreenEvaluationSummaryMenuTimer=Ajusta el limite de tiempo para ScreenEvaluatio
 ScreenNameEntryMenuTimer=Ajusta el limite de tiempo para ScreenNameEntry.
 
 # Advanced Options
-AllowW1=Habilita o deshabilita la sincronización fantástica.\n\n• Nunca - No hay fantásticos. Nunca.\n\n• Solo Cursos - Los fantásticos son solo posibles durante cursos (maratón, oni, etc.)\n\n• Siempre - Los fantásticos son posibles en partidas normales y en los cursos.
 DefaultFailType=• Immediate - Finaliza el juego cuando todos los jugadores se quedan sin vida.\n\n• ImmediateContinue - Marca Perdida a los jugadores que se queden sin vida, pero permite continuar el juego.\n\n• EndOfSong - Evalua si algún jugador para o falla al final de la canción.\n\n• Off - Deshabilita la perdida de la partida.
-PercentageScoring=En otros temas, esto impactará si los puntos de baile ó el porcentaje son mostrados.\n\nEn Simply Love, el porcentaje siempre es mostrado, pero este ajuste afecta como las altas puntuaciones son calculadas relativas de cada una.\n\nDesearás esta opcion "Activada".
 UseUnlockSystem=Enciende o deshabilita el sistema de desbloqueos de StepMania.\n\nSimply Love no soporta el sistema, y no sé otro tema que lo utilize.
 AllowExtraStage=Cuando está habilitado (Y el modo Evento está apagado), esto permite a los jugadores obtener rondas extra despues de completar ciertos requisitos.\n\nEsto mayormente afecta otros temas, pero no tiene mucho efecto en Simply Love.
 HiddenSongs=Los Simfiles con #SELECTABLE:NO; no aparecerán en el MusicWheel, pero pueden ser accesibles en cursos especiales.\n\nDeja esto "Apagado" para mostrar todas las canciones.
@@ -876,9 +874,6 @@ MaxHighScoresPerListForMachine=10
 MaxHighScoresPerListForPlayer=3
 Premium=Los que juegan Dobles te amarán si al menos enciendes 'Dobles por 1 crédito'.
 # Advanced Options
-AllowW1=Siempre
-PercentageScoring=Solo dejalo 'Activado'. Yo tampoco lo entiendo. (ノ°□°)ノ  ┻━┻
-#'
 AutogenSteps=Off
 DefaultFailType=ImmediateContinue
 TimingWindowScale=4

--- a/Languages/fr.ini
+++ b/Languages/fr.ini
@@ -641,9 +641,7 @@ ScreenEvaluationSummaryMenuTimer=Définir le temps sur l'écran de sommaire d'é
 ScreenNameEntryMenuTimer=Définir le temps pour saisir un nom.
 
 # Advanced Options
-AllowW1=Activer ou non les jugements "Fantastiques".\n\n• Jamais - Pas de fantastiques, du tout.\n\n• Courses seulement - Les fantastiques ne seront disponibles que durant les courses (nonstop, oni, etc.).\n\n• Toujours - Les fantastiques seront disponibles tout aussi bien en jeu normal que durant les courses.
 DefaultFailType=• Immediate - Termine le jeu quand tous les joueurs n'ont plus de vie.\n\n• ImmediateContinue - Termine le jeu quand tous les joueurs n'ont plus de vie, mais permet de continuer à jouer.\n\n• Fin de chanson – Détermine si un joueur rate à la fin de la chanson.\n\n• Off - Désactive le fait de rater.
-PercentageScoring=Dans les autres thèmes, ce paramètre impacte si les points de dances ou des scores sous forme de pourcentages sont affichés.\n\nDans Simply Love, les scores pourcentages sont toujours affichés, mais ce réglage impacte toujours l'ordre des meilleurs scores.
 UseUnlockSystem=Activer ou non le système de débloquage de chansons de StepMania.\n\nSimply Love ne supporte pas ce système, et je ne connais aucun autre thème le supportant.
 AllowExtraStage=Quand activé (en dehors du mode évènement), permet aux joueurs de gagner des manches supplémentaires selon certaines actions.\n\nCeci impacte probablement les autres thèmes, mais n'a aucun effet sur Simply Love.
 HiddenSongs=Les chansons avec #SELECTABLE:NO; ne vont pas apparaître dans l'écran de choix de musique, mais peuvent être accessibles via des courses.\n\nDésactivez ceci pour toujours afficher toutes les chansons.
@@ -736,9 +734,6 @@ MaxHighScoresPerListForMachine=10
 MaxHighScoresPerListForPlayer=3
 Premium=Les joueurs 'Doubles' vont vous aimer si vous activez 'Double pour 1 Jeton'.
 # Advanced Options
-AllowW1=Toujours
-PercentageScoring=Contentez-vous d'activer ceci. Je ne comprends pas non plus ce paramètre.\n(ノ°□°)ノ  ┻━┻
-#'
 AutogenSteps=Désactivé
 DefaultFailType=ImmediateContinue
 TimingWindowScale=4

--- a/Languages/it.ini
+++ b/Languages/it.ini
@@ -819,14 +819,12 @@ CustomSongsMaxMegabytes=Limite di dimensione\ndelle canzoni
 # Advanced Options
 DefaultFailType=Tipo di Fallimento
 LifeDifficulty=Difficoltà Vita
-AllowW1=Timing Perfetto
 HiddenSongs=Canzoni Segrete
 AllowExtraStage=Permetti Extra Stage
 UseUnlockSystem=Sblocca Sistema
 AutogenSteps=Autogenera passi
 AutogenGroupCourses=Autogenera maratone
 FastLoad=Caricamento Rapido
-PercentageScoring=Punteggio Percentuale
 AllowSongDeletion=Abilita Cancellazione\nCanzone
 
 # Arcade Options
@@ -1097,9 +1095,7 @@ ScreenEvaluationSummaryMenuTimer=Regola il limite di tempo per la schermata di r
 ScreenNameEntryMenuTimer=Regola il limite di tempo per la schermata di immissione del nome.
 
 # Advanced Options
-AllowW1=Abilita o disabilita la valutazione 'Fantastic'.\n\n• Mai - I 'Fantastic' sono disabilitati.\n\n• Solo maratone - I 'Fantastic' sono attivi solo durante la modalità maratona\n\n• Sempre - I 'Fantastic' sono attivi in tutte le modalità.
 DefaultFailType=• Immediato: termina il gioco quando tutti i giocatori sono senza vita.\n\n• Immediato Continua: I giocatori che sono senza vita perdono il round, ma possono completare la canzone.\n\n• Fine del brano: valuta se un giocatore passa o fallisce la canzone alla fine del brano.\n\n• Disabilitato: Non si perde mai.
-PercentageScoring=In altri temi, questa opzione influenzerà il modo in cui verrà visualizzato il tuo punteggio.\n\nIn Simply Love la percentuale verrà sempre mostrata, ma questa impostazione influenza il modo in cui vengono calcolati i punteggi.\n\nLascia sempre questa opzione attiva per un corretto calcolo della tua percentuale.
 UseUnlockSystem=Attiva o disattiva il sistema di sblocco StepMania.\n\nPuoi ignorare questa impostazione perchè non viene usata da Simply Love nè da nessun altro dei temi più conosciuti.
 AllowExtraStage==Se abilitato (e con la Event Mode disabilitata), consente ai giocatori di ricevere un round extra dopo aver completato determinati requisiti.\n\nQuesto riguarda principalmente altri temi, ma non influenza Simply Love.
 HiddenSongs=I simfile con la stringa #SELECTABLE: NO; non verranno visualizzati nella selezione delle canzoni, ma sarà possibile accedervi se sono all'interno di una maratona.\n\nLascialo 'Disattivato' per accedere a tutti i brani, compresi quelli segreti.
@@ -1214,9 +1210,6 @@ MaxHighScoresPerListForPlayer=3
 Premium=I player Double ti ameranno se imposterai 'Double per 1 credito'. 😍
 
 # Advanced Options
-AllowW1=Sempre
-PercentageScoring=Imposta semplicemente su 'Attivato'. Nemmeno io lo capisco bene.\n(ノ°□°)ノ  ┻━┻
-#'
 AutogenSteps=Disattivato
 DefaultFailType=Immediato continua
 TimingWindowScale=4

--- a/Languages/ja.ini
+++ b/Languages/ja.ini
@@ -595,9 +595,7 @@ ScreenEvaluationSummaryMenuTimer=総合リザルト画面の制限時間を指�
 ScreenNameEntryMenuTimer=名前入力画面の制限時間を指定します。
 
 # Advanced Options
-AllowW1=Fantastic判定を有効化・無効化します。\n\n• Never - Fantastic判定をオフにします。\n\n• Courses Only - Fantastic判定はコース（nonstopやoniなど）の場合のみ有効化されます。\n\n• Always - Fantastic判定をゲームモードに関わらず有効化します。
 DefaultFailType=• Immediate - ライフが無くなった時点でFailedとなり、曲を終了します。\n\n• ImmediateContinue - ライフが無くなった時点でFailedとなりますが、ゲームプレイは曲が終了するまで継続します。\n\n• EndOfSong - 曲が終わった時点でライフが少しでも残っていればクリアとなります。\n\n• Off - Failを無効化します。
-PercentageScoring=他のテーマではDance PointとPercentageのどちらを表示するかに影響する項目ですが、Simply Loveでは、Percentageがいずれにせよ表示されます。\n\nただ、Simply Loveでもこの設定は、ランクがどのように評価されるかには影響します。\n\n'On'のままにしておくのが良いでしょう。
 UseUnlockSystem=StepManiaのアンロックシステムを有効化・無効化します。\n\nただ、Simply Loveではアンロックシステムをサポートしていませんし、他のテーマで実装されているのを見たこともありません。
 AllowExtraStage='On'にすると、プレイヤーがある特定の条件を達成したときにエクストラステージに進めるようになります。\n\n他のテーマでは特殊な演出が用意されていたりしますが、Simply Loveには特にありません。\n\nこの設定はEventモードでは無視されます。
 HiddenSongs='On'にすると、 #SELECTABLE:NO; と記述されたSimfileがゲーム内に表示されなくなります。この場合も、コースによってその曲が選択されていれば、そのコースでは遊ぶことができます。\n\n'Off'にすると、この設定に関係なくすべての曲が選曲画面から選択できるようになります。
@@ -693,8 +691,6 @@ MaxHighScoresPerListForMachine=10
 MaxHighScoresPerListForPlayer=3
 Premium='Double for 1 Credit'以上にするとダブルプレイをする人はうれしいです。
 # Advanced Options
-AllowW1=Always
-PercentageScoring=よくわかんないけど'On'にしておきましょう。\n(ノ°□°)ノ  ┻━┻
 AutogenSteps=Off
 DefaultFailType=ImmediateContinue
 TimingWindowScale=4

--- a/Languages/pl.ini
+++ b/Languages/pl.ini
@@ -777,9 +777,7 @@ ScreenEvaluationSummaryMenuTimer=Wybierz wartość licznika menu dla ekranu pods
 ScreenNameEntryMenuTimer=Wybierz wartość licznika menu dla ekranu wpisu imienia.
 
 # Opcje Zaawansowane
-AllowW1=Włącz lub wyłącz ocenę fantastic.\n\n• Nigdy - Nie ma oceny fantastic. Nigdy.\n\n• Tylko Zestawy - Uzyskanie oceny fantastic jest możliwe podczas grania w zestawy (nonstop, oni, itp.).\n\n• Zawsze - Uzyskanie oceny fantastic jest możliwe wszędzie.
 DefaultFailType=• Natychmiast - Kończy rozgrywkę, gdy wszystkim graczom skończy się życie.\n\n• Z opóźnieniem - Po opróżnieniu paska życia utwór zakończy się porażką, ale można go dokończyć.\n\n• Koniec Utworu - Porażka graczy rozstrzygana jest pod koniec utworu.\n\n• Wyłącz - Wyłącza możliwość porażki.
-PercentageScoring=W innych motywach ta opcja decyduje, czy punktacja wyświetlana jest w punktach, czy procentach.\n\nW Simply Love procenty są zawsze widoczne, ale to ustawienie wpływa na sposób klasyfikowania najlepszych wyników.\n\nTa opcja powinna być włączona.
 UseUnlockSystem=Włącz lub wyłącz system odblokowywania StepManii.\n\nSimply Love go nie wspiera, i nie znam żadnego innego motywu, który by to zrobił.
 AllowExtraStage=Gdy włączony (z wyłączonym trybem imprezy) po spełnieniu pewnych wymogów gracze będą mieli możliwość rozegrania dodatkowych utworów.\n\nTa opcja nie wpływa na na Simply Love, ale może mieć na inne motywy.
 HiddenSongs=Simfile z tagiem #SELECTABLE:NO; nie będą pokazywane w kole, ale mogą być dostępne w konkretnych zestawach.\n\nPozostaw włączone, aby zawsze dostępne były wszystkie utwory.
@@ -887,9 +885,6 @@ MaxHighScoresPerListForMachine=10
 MaxHighScoresPerListForPlayer=3
 Premium=Gracze Doubles pokochają cię jak ustawisz 'Double za 1 Żeton'.
 # Opcje Zaawansowane
-AllowW1=Zawsze
-PercentageScoring=Po prostu zostaw włączone. Sam nie wiem o co chodzi.\n(ノ°□°)ノ  ┻━┻
-#'
 AutogenSteps=Wyłącz
 DefaultFailType=Z opóźnieniem
 TimingWindowScale=4

--- a/Languages/pt-br.ini
+++ b/Languages/pt-br.ini
@@ -1018,8 +1018,6 @@ LifeDifficulty=Difículdade de vida
 
 HiddenSongs=Sons escondidos
 
-AllowW1=Timing Fantastico
-
 AllowExtraStage=Permitir estagio extra
 
 UseUnlockSystem=Destravar sistema
@@ -1027,8 +1025,6 @@ UseUnlockSystem=Destravar sistema
 AutogenSteps=Auto-gerar Setas
 
 AutogenGroupCourses=Auto-gerar grupo\nde maratonas
-
-PercentageScoring=Porcentagem de pontuação
 
 DefaultFailType=Modo padrão de perda
 
@@ -1490,9 +1486,7 @@ ScreenEvaluationSummaryMenuTimer=Ajuste o limite de tempo para a tela dos result
 ScreenNameEntryMenuTimer=Ajuste o limite de tempo para a tela de entrada de nome.
 
 # Advanced Options
-AllowW1=Ativar ou desativar a sincronização "fantástica".\n\n• Nunca - Não há "fantásticos". Nunca\n\n• Somente maratonas - Os "fantásticos" só são possíveis durante as maratonas (maratona, oni, etc.)\n\n• Sempre - O "fantastico" é possível em jogos e maratonas normais.
 DefaultFailType=• Imediato - Termina o jogo quando todos os jogadores ficam sem vida.\n\n• Continuação Imediata - fundo escurecido para jogadores que ficam sem vida, mas permite que o jogo continue.\n\n• Final da música - Avalia se um jogador para ou falha no final da música.\n\n• Desativado - Desativa a perda do jogo.
-PercentageScoring=Em outros assuntos, isso impactara como sua pontuação será mostrada ; Pontos de dança ou porcentagem.\n\nEm Simply Love, a porcentagem é sempre mostrada, mas esse ajuste afeta a forma como as pontuações altas são calculadas em relação a cada uma delas.\n\nVocê vai querer essa opção "Ativada".
 UseUnlockSystem=Ligue ou desative o sistema de desbloqueio StepMania.\n\nO Simply Love não suporta o sistema e eu não conheço outro tema que o use.
 AllowExtraStage=Quando habilitado (e o modo Evento está desativado), isso permite que os jogadores recebam rodadas extras após completar certos requisitos.\n\nIsso afeta principalmente outros temas, mas não afeta muito o Simply Love.
 HiddenSongs=Os Simfiles com #SELECTABLE: NO; não aparecerão na seleção de música, mas podem ser acessados ​​em maratonas especiais.\n\nDeixe isso "Desativado" para mostrar todas as músicas.
@@ -1593,9 +1587,6 @@ MaxHighScoresPerListForMachine=10
 MaxHighScoresPerListForPlayer=3
 Premium=Aqueles que jogarem dupla vão amá-lo se pelo menos você escolher a segunda opção.
 # Advanced Options
-AllowW1=Sempre
-PercentageScoring=Apenas deixe "Ativado". Eu não entendo também.\n(ノ ° □ °) ノ ┻━┻
-#'
 AutogenSteps=Desativado
 DefaultFailType=Continuação Imediata
 TimingWindowScale=4

--- a/metrics.ini
+++ b/metrics.ini
@@ -1159,11 +1159,10 @@ LineCustomSongsMaxMegabytes="lua,OperatorMenuOptionRows.CustomSongsMaxMegabytes(
 
 [ScreenAdvancedOptions]
 Fallback="ScreenOptionsServiceChild"
-LineNames="DefaultFailType,TimingWindowScale,LifeDifficulty,AllowW1,HiddenSongs,EasterEggs,AllowExtraStage,UseUnlockSystem,AutogenSteps,AutogenGroupCourses,FastLoad,PercentageScoring,SongDeletion"
+LineNames="DefaultFailType,TimingWindowScale,LifeDifficulty,HiddenSongs,EasterEggs,AllowExtraStage,UseUnlockSystem,AutogenSteps,AutogenGroupCourses,FastLoad,SongDeletion"
 LineDefaultFailType="conf,DefaultFailType"
 LineTimingWindowScale="conf,TimingWindowScale"
 LineLifeDifficulty="conf,LifeDifficulty"
-LineAllowW1="conf,AllowW1"
 LineHiddenSongs="conf,HiddenSongs"
 LineEasterEggs="conf,EasterEggs"
 LineAllowExtraStage="conf,AllowExtraStage"
@@ -1171,7 +1170,6 @@ LineUseUnlockSystem="conf,UseUnlockSystem"
 LineAutogenSteps="conf,AutogenSteps"
 LineAutogenGroupCourses="conf,AutogenGroupCourses"
 LineFastLoad="conf,FastLoad"
-LinePercentageScoring="conf,PercentageScoring"
 LineSongDeletion="conf,AllowSongDeletion"
 
 


### PR DESCRIPTION
Both settings are hardcoded for all three game modes, so changing them in the operator menu doesn't do anything.