### PR TITLE
Fix Autoplay Judgment Count/EX Score display

### DIFF
--- a/BGAnimations/ScreenGameplay overlay/TrackExScoreJudgments.lua
+++ b/BGAnimations/ScreenGameplay overlay/TrackExScoreJudgments.lua
@@ -58,6 +58,8 @@ return Def.Actor{
 	end,
 	JudgmentMessageCommand=function(self, params)
 		if params.Player ~= player then return end
+
+		if IsAutoplay(player) then return end
 		
 		local count_updated = false
 		if params.HoldNoteScore then

--- a/BGAnimations/ScreenGameplay overlay/TrackExScoreJudgments.lua
+++ b/BGAnimations/ScreenGameplay overlay/TrackExScoreJudgments.lua
@@ -58,7 +58,6 @@ return Def.Actor{
 	end,
 	JudgmentMessageCommand=function(self, params)
 		if params.Player ~= player then return end
-
 		if IsAutoplay(player) then return end
 		
 		local count_updated = false

--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/StepStatistics/TapNoteJudgments.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/StepStatistics/TapNoteJudgments.lua
@@ -111,6 +111,7 @@ for index, window in ipairs(TNS.Types) do
 			if params.Player ~= player then return end
 			if params.HoldNoteScore then return end
 			if not params.TapNoteScore then return end
+			if IsAutoplay(player) then return end
 
 			local incremented = false
 

--- a/Graphics/Player judgment.lua
+++ b/Graphics/Player judgment.lua
@@ -50,7 +50,11 @@ return Def.ActorFrame{
 			if ToEnumShortString(param.TapNoteScore) == "W1" then
 				if mods.ShowFaPlusWindow then
 					-- If this W1 judgment fell outside of the FA+ window, show the white window
-					if not IsW0Judgment(param, player) then
+					--
+					-- Treat Autoplay specially. The TNS might be out of the range, but
+					-- it's a nicer experience to always just display the top window graphic regardless.
+					-- This technically causes a discrepency on the histogram, but it's likely okay.
+					if not IsW0Judgment(param, player) and not IsAutoplay(player) then
 						frame = 1
 					end
 				end

--- a/Graphics/Player judgment.lua
+++ b/Graphics/Player judgment.lua
@@ -60,8 +60,12 @@ return Def.ActorFrame{
 				end
 				-- We don't need to adjust the top window otherwise.
 			else
-				-- Everything outside of W1 needs to be shifted down a row.
-				frame = frame + 1
+				-- Everything outside of W1 needs to be shifted down a row if not in FA+ mode.
+				-- Some people might be using 2x7s in FA+ mode (by copying ITG graphics to FA+).
+				-- Don't need to shift in that case.
+				if mode ~= "FA+" then
+					frame = frame + 1
+				end
 			end
 		end
 

--- a/Scripts/SL-CustomScores.lua
+++ b/Scripts/SL-CustomScores.lua
@@ -155,7 +155,7 @@ function WriteScores()
 		end
 
 		-- Don't store scores for guest profiles or autoplay
-		if PROFILEMAN:IsPersistentProfile(player) and GAMESTATE:IsSideJoined(player) and not IsAutoplay(player) then
+		if PROFILEMAN:IsPersistentProfile(player) and GAMESTATE:IsSideJoined(player) and IsHumanPlayer(player) then
 			local profileSlot = {
 				[PLAYER_1] = "ProfileSlot_Player1",
 				[PLAYER_2] = "ProfileSlot_Player2"

--- a/Scripts/SL-Helpers-GrooveStats.lua
+++ b/Scripts/SL-Helpers-GrooveStats.lua
@@ -423,8 +423,8 @@ ValidForGrooveStats = function(player)
 	-- only FailTypes "Immediate" and "ImmediateContinue" are valid for GrooveStats
 	valid[11] = (po:FailSetting() == "FailType_Immediate" or po:FailSetting() == "FailType_ImmediateContinue")
 
-	-- AutoPlay is not allowed
-	valid[12] = not IsAutoplay(player)
+	-- AutoPlay/AutoplayCPU is not allowed
+	valid[12] = IsHumanPlayer(player)
 
 	-- ------------------------------------------
 	-- return the entire table so that we can let the player know which settings,

--- a/Scripts/SL-Helpers.lua
+++ b/Scripts/SL-Helpers.lua
@@ -565,8 +565,13 @@ end
 
 
 -- -----------------------------------------------------------------------
+IsHumanPlayer = function(player)
+	return GAMESTATE:GetPlayerState(player):GetPlayerController() == "PlayerController_Human"
+end
+
+-- -----------------------------------------------------------------------
 IsAutoplay = function(player)
-	return GAMESTATE:GetPlayerState(player):GetPlayerController() ~= "PlayerController_Human"
+	return GAMESTATE:GetPlayerState(player):GetPlayerController() == "PlayerController_Autoplay"
 end
 
 -- -----------------------------------------------------------------------


### PR DESCRIPTION
Prior to this PR, there was a discrepancy between the judgment count shown in ScreenEval and that which was displayed in StepStats. This PR fixes this discrepancy by not incrementing the counts for StepStats if Autoplay is enabled to match up with the count/score reported by the engine.

We implement the same change for the EX Score tracking so that the EX Score doesn't increment with Autoplay enabled.

Note that the AutoplayCPU behavior is different in that it increments both the judgment counts and the score. This PR still preserves that by only specifically taking Autoplay (and not AutoplayCPU) into consideration.

Also adds a QoL feature to always display the top window judgment graphic with Autoplay.
