### PR TITLE
Fix scatter plot and timing graph coloring

### DIFF
--- a/Scripts/SL-Helpers.lua
+++ b/Scripts/SL-Helpers.lua
@@ -52,7 +52,7 @@ end
 
 DetermineTimingWindow = function(offset)
 	for i=1,NumJudgmentsAvailable() do
-		if math.abs(offset) < GetTimingWindow(i) then
+		if math.abs(offset) <= GetTimingWindow(i) then
 			return i
 		end
 	end


### PR DESCRIPTION
Visible in autoplay: Judgments right at the edge of the window were displayed in the wrong color.