### PR TITLE
Fix avatar not updating after fast switching

### DIFF
--- a/BGAnimations/ScreenSystemLayer overlay.lua
+++ b/BGAnimations/ScreenSystemLayer overlay.lua
@@ -83,8 +83,8 @@ for player in ivalues(PlayerNumber) do
 				return
 			end
 
-			-- only read from disk if not currently set
-			if self:GetTexture() == nil then
+			-- only read from disk if not currently set or if the path has changed
+			if self:GetTexture() == nil or path ~= self:GetTexture():GetPath() then
 				self:Load(path):finishtweening():linear(0.075):diffusealpha(1)
 
 				local dim = 32


### PR DESCRIPTION
If you use the fast profile switcher to change between two local profiles which both have an avatar set, the avatar in the footer doesn't get updated and will still show the avatar of the original player. This PR forces the avatar to update.