### PR TITLE
Fix player mods not being respected in some cases

### DIFF
--- a/BGAnimations/ScreenSelectMusic overlay/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/default.lua
@@ -18,6 +18,7 @@ local af = Def.ActorFrame{
 			GAMESTATE:ResetPlayerOptions(params.Player)
 			SL[ToEnumShortString(params.Player)]:initialize()
 		end
+		ApplyMods(params.Player)
 	end,
 
 	PlayerJoinedMessageCommand=function(self, params)
@@ -25,6 +26,7 @@ local af = Def.ActorFrame{
 			GAMESTATE:ResetPlayerOptions(params.Player)
 			SL[ToEnumShortString(params.Player)]:initialize()
 		end
+		ApplyMods(params.Player)
 	end,
 
 	-- ---------------------------------------------------


### PR DESCRIPTION
This PR fixes an issue with some player mods not being applied correctly when using the fast profile switcher.

To reproduce the issue, set up two local profiles, one (A) with the ddr-rainbow noteskin and the other one (B) with cel. Make sure the mods have been saved correctly. Start the game with A as P1, then immediately switch P1 to B on SSM using the fast switcher. Play a song as B (make sure to not enter the options screen). The noteskin used in the gameplay screen will be wrong.

Only some mods are affected (e.g. noteskin and speedmod). The issue can currently be mitigated by entering options on song start.