### PR TITLE
Fix ShowFaPlusWindow applied on FA+ Game Mode

### DIFF
--- a/BGAnimations/ScreenSelectMusic overlay/SortMenu/SortMenu_InputHandler.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SortMenu/SortMenu_InputHandler.lua
@@ -19,12 +19,15 @@ local input = function(event)
 			sortmenu:GetChild("start_sound"):play()
 			local focus = sort_wheel:get_actor_item_at_focus_pos()
 			if focus.kind == "SortBy" then
-				MESSAGEMAN:Broadcast('Sort',{order=focus.sort_by})
+				MESSAGEMAN:Broadcast('Sort', { order = focus.sort_by })
 				overlay:queuecommand("DirectInputToEngine")
 
-			-- the player wants to change modes, for example from ITG to FA+
+				-- the player wants to change modes, for example from ITG to FA+
 			elseif focus.kind == "ChangeMode" then
 				SL.Global.GameMode = focus.change
+				for player in ivalues(GAMESTATE:GetHumanPlayers()) do
+					ApplyMods(player)
+				end
 				SetGameModePreferences()
 				THEME:ReloadMetrics()
 				-- Broadcast that the SL GameMode has changed
@@ -38,7 +41,7 @@ local input = function(event)
 					screen:SetNextScreenName("ScreenSelectMusicCasual")
 					screen:StartTransitioningScreen("SM_GoToNextScreen")
 				end
-			-- the player wants to change styles, for example from single to double
+				-- the player wants to change styles, for example from single to double
 			elseif focus.kind == "ChangeStyle" then
 				-- If the MenuTimer is in effect, make sure to grab its current
 				-- value before reloading the screen.
@@ -48,7 +51,7 @@ local input = function(event)
 				-- Get the style we want to change to
 				local new_style = focus.change:lower()
 				-- accommodate techno game
-				if GAMESTATE:GetCurrentGame():GetName()=="techno" then new_style = new_style.."8" end
+				if GAMESTATE:GetCurrentGame():GetName() == "techno" then new_style = new_style .. "8" end
 				-- set it in the engine
 				GAMESTATE:SetCurrentStyle(new_style)
 				-- finally, reload the screen

--- a/Graphics/Player judgment.lua
+++ b/Graphics/Player judgment.lua
@@ -9,10 +9,12 @@ local sprite
 -- If that fails too, fail gracefully and do nothing
 local available_judgments = GetJudgmentGraphics()
 
-local file_to_load = (FindInTable(mods.JudgmentGraphic, available_judgments) ~= nil and mods.JudgmentGraphic or available_judgments[1]) or "None"
+local file_to_load = (
+	FindInTable(mods.JudgmentGraphic, available_judgments) ~= nil and mods.JudgmentGraphic or available_judgments[1]) or
+	"None"
 
 if file_to_load == "None" then
-	return Def.Actor{ InitCommand=function(self) self:visible(false) end }
+	return Def.Actor { InitCommand = function(self) self:visible(false) end }
 end
 
 ------------------------------------------------------------
@@ -26,13 +28,13 @@ local TNSFrames = {
 	TapNoteScore_Miss = 5
 }
 
-return Def.ActorFrame{
-	Name="Player Judgment",
-	InitCommand=function(self)
+return Def.ActorFrame {
+	Name = "Player Judgment",
+	InitCommand = function(self)
 		local kids = self:GetChildren()
 		sprite = kids.JudgmentWithOffsets
 	end,
-	JudgmentMessageCommand=function(self, param)
+	JudgmentMessageCommand = function(self, param)
 		if param.Player ~= player then return end
 		if not param.TapNoteScore then return end
 		if param.HoldNoteScore then return end
@@ -40,14 +42,14 @@ return Def.ActorFrame{
 		-- "frame" is the number we'll use to display the proper portion of the judgment sprite sheet
 		-- Sprite actors expect frames to be 0-indexed when using setstate() (not 1-indexed as is more common in Lua)
 		-- an early W1 judgment would be frame 0, a late W2 judgment would be frame 3, and so on
-		local frame = TNSFrames[ param.TapNoteScore ]
+		local frame = TNSFrames[param.TapNoteScore]
 		if not frame then return end
 		local tns = ToEnumShortString(param.TapNoteScore)
 
 		-- If the judgment font contains a graphic for the additional white fantastic window...
 		if sprite:GetNumStates() == 7 or sprite:GetNumStates() == 14 then
 			if tns == "W1" then
-				if mods.ShowFaPlusWindow then
+				if mods.ShowFaPlusWindow and SL.Global.GameMode == "ITG" then
 					-- If this W1 judgment fell outside of the FA+ window, show the white window
 					--
 					-- Treat Autoplay specially. The TNS might be out of the range, but
@@ -98,9 +100,9 @@ return Def.ActorFrame{
 		sprite:zoom(0.8):decelerate(0.1):zoom(0.75):sleep(0.6):accelerate(0.2):zoom(0)
 	end,
 
-	Def.Sprite{
-		Name="JudgmentWithOffsets",
-		InitCommand=function(self)
+	Def.Sprite {
+		Name = "JudgmentWithOffsets",
+		InitCommand = function(self)
 			-- animate(false) is needed so that this Sprite does not automatically
 			-- animate its way through all available frames; we want to control which
 			-- frame displays based on what judgment the player earns
@@ -109,12 +111,12 @@ return Def.ActorFrame{
 			-- if we are on ScreenEdit, judgment graphic is always "Love"
 			-- because ScreenEdit is a mess and not worth bothering with.
 			if string.match(tostring(SCREENMAN:GetTopScreen()), "ScreenEdit") then
-				self:Load( THEME:GetPathG("", "_judgments/Love") )
+				self:Load(THEME:GetPathG("", "_judgments/Love"))
 
 			else
-				self:Load( THEME:GetPathG("", "_judgments/" .. file_to_load) )
+				self:Load(THEME:GetPathG("", "_judgments/" .. file_to_load))
 			end
 		end,
-		ResetCommand=function(self) self:finishtweening():stopeffect():visible(false) end
+		ResetCommand = function(self) self:finishtweening():stopeffect():visible(false) end
 	}
 }

--- a/Graphics/Player judgment.lua
+++ b/Graphics/Player judgment.lua
@@ -9,12 +9,10 @@ local sprite
 -- If that fails too, fail gracefully and do nothing
 local available_judgments = GetJudgmentGraphics()
 
-local file_to_load = (
-	FindInTable(mods.JudgmentGraphic, available_judgments) ~= nil and mods.JudgmentGraphic or available_judgments[1]) or
-	"None"
+local file_to_load = (FindInTable(mods.JudgmentGraphic, available_judgments) ~= nil and mods.JudgmentGraphic or available_judgments[1]) or "None"
 
 if file_to_load == "None" then
-	return Def.Actor { InitCommand = function(self) self:visible(false) end }
+	return Def.Actor{ InitCommand=function(self) self:visible(false) end }
 end
 
 ------------------------------------------------------------
@@ -28,13 +26,13 @@ local TNSFrames = {
 	TapNoteScore_Miss = 5
 }
 
-return Def.ActorFrame {
-	Name = "Player Judgment",
-	InitCommand = function(self)
+return Def.ActorFrame{
+	Name="Player Judgment",
+	InitCommand=function(self)
 		local kids = self:GetChildren()
 		sprite = kids.JudgmentWithOffsets
 	end,
-	JudgmentMessageCommand = function(self, param)
+	JudgmentMessageCommand=function(self, param)
 		if param.Player ~= player then return end
 		if not param.TapNoteScore then return end
 		if param.HoldNoteScore then return end
@@ -42,14 +40,14 @@ return Def.ActorFrame {
 		-- "frame" is the number we'll use to display the proper portion of the judgment sprite sheet
 		-- Sprite actors expect frames to be 0-indexed when using setstate() (not 1-indexed as is more common in Lua)
 		-- an early W1 judgment would be frame 0, a late W2 judgment would be frame 3, and so on
-		local frame = TNSFrames[param.TapNoteScore]
+		local frame = TNSFrames[ param.TapNoteScore ]
 		if not frame then return end
 		local tns = ToEnumShortString(param.TapNoteScore)
 
 		-- If the judgment font contains a graphic for the additional white fantastic window...
 		if sprite:GetNumStates() == 7 or sprite:GetNumStates() == 14 then
 			if tns == "W1" then
-				if mods.ShowFaPlusWindow and SL.Global.GameMode == "ITG" then
+				if mods.ShowFaPlusWindow then
 					-- If this W1 judgment fell outside of the FA+ window, show the white window
 					--
 					-- Treat Autoplay specially. The TNS might be out of the range, but
@@ -100,9 +98,9 @@ return Def.ActorFrame {
 		sprite:zoom(0.8):decelerate(0.1):zoom(0.75):sleep(0.6):accelerate(0.2):zoom(0)
 	end,
 
-	Def.Sprite {
-		Name = "JudgmentWithOffsets",
-		InitCommand = function(self)
+	Def.Sprite{
+		Name="JudgmentWithOffsets",
+		InitCommand=function(self)
 			-- animate(false) is needed so that this Sprite does not automatically
 			-- animate its way through all available frames; we want to control which
 			-- frame displays based on what judgment the player earns
@@ -111,12 +109,12 @@ return Def.ActorFrame {
 			-- if we are on ScreenEdit, judgment graphic is always "Love"
 			-- because ScreenEdit is a mess and not worth bothering with.
 			if string.match(tostring(SCREENMAN:GetTopScreen()), "ScreenEdit") then
-				self:Load(THEME:GetPathG("", "_judgments/Love"))
+				self:Load( THEME:GetPathG("", "_judgments/Love") )
 
 			else
-				self:Load(THEME:GetPathG("", "_judgments/" .. file_to_load))
+				self:Load( THEME:GetPathG("", "_judgments/" .. file_to_load) )
 			end
 		end,
-		ResetCommand = function(self) self:finishtweening():stopeffect():visible(false) end
+		ResetCommand=function(self) self:finishtweening():stopeffect():visible(false) end
 	}
 }


### PR DESCRIPTION
**Silver Fox strikes again!** He found another **buried** bug (idk how, he is like a hound) 🦊


**_Preconditions_**:
- The profile you are using have the _Display FA+ Window_ (_ShowFaPlusWindow_) mod **active**
- You start the game with the ITG GameMode but before do the first song, you change to FA+ GameMode

**_As Is_**:
During the Gameplay the Blue Fantastic with any type of judgement, never show up. It's always shown the White Fantastic.

I leave here some screenshots:
![ChangeModeITGToFAPlus](https://user-images.githubusercontent.com/10159143/174647540-e0bbe043-f9fb-4746-b576-7714263897c7.png)
![GameplayWhiteFantastic](https://user-images.githubusercontent.com/10159143/174647555-0129df77-c8f5-4bf0-ab45-9e017d534bc9.png)

_**What I've done**_:
Add check of the current GameMode along with the check of ShowFaPlusWindow

PS
I've also thought to call [ApplyMods()](https://github.com/Simply-Love/Simply-Love-SM5/blob/f362d57636e2a2f458184ce10cbeafa0bf70a1fc/Scripts/SL-PlayerOptions.lua#L798-L819) when change GameMode [here](https://github.com/Simply-Love/Simply-Love-SM5/blob/f362d57636e2a2f458184ce10cbeafa0bf70a1fc/BGAnimations/ScreenSelectMusic%20overlay/SortMenu/SortMenu_InputHandler.lua#L26-L40) but maybe can cause much more issues than benefits.

Viper 🐍
