### PR TITLE
Fix ScreenEvaluationSummary

### DIFF
--- a/BGAnimations/ScreenEvaluation common/PerPlayer/Storage.lua
+++ b/BGAnimations/ScreenEvaluation common/PerPlayer/Storage.lua
@@ -20,9 +20,15 @@ return Def.Actor{
 		-- so that we can more easily display it on ScreenEvaluationSummary when this game cycle ends.
 		local storage = SL[pn].Stages.Stats[SL.Global.Stages.PlayedThisGame + 1]
 
-		-- a PLayerStageStats object from the engine
+		-- a PlayerStageStats object from the engine
 		-- see: http://quietly-turning.github.io/Lua-For-SM5/LuaAPI#Actors-PlayerStageStats
 		local pss = STATSMAN:GetCurStageStats():GetPlayerStageStats(player)
+
+		if PROFILEMAN:IsPersistentProfile(pn) then
+			storage.profile = PROFILEMAN:GetProfile(player):GetDisplayName()
+		else
+			storage.profile = '[GUEST]'
+		end
 
 		storage.grade = pss:GetGrade()
 		storage.score = pss:GetPercentDancePoints()
@@ -47,6 +53,6 @@ return Def.Actor{
 			storage.stepartist = pss:GetPlayedSteps()[1]:GetAuthorCredit()
 		end
 
-		storage.timingwindows =SL[pn].ActiveModifiers.TimingWindows
+		storage.timingwindows = SL[pn].ActiveModifiers.TimingWindows
 	end
 }

--- a/BGAnimations/ScreenEvaluationSummary overlay/PlayerStageStats.lua
+++ b/BGAnimations/ScreenEvaluationSummary overlay/PlayerStageStats.lua
@@ -1,4 +1,4 @@
-local player = ...
+local player, displayProfileNames = unpack(...)
 
 local LetterGradesAF
 local playerStats
@@ -17,7 +17,7 @@ elseif player == PLAYER_2 then
 	col1x = 90
 	col2x = _screen.w/2.5
 	gradex = _screen.w/3.33
-	align1= left
+	align1 = left
 	align2 = right
 end
 
@@ -30,6 +30,7 @@ local af = Def.ActorFrame{
 		playerStats = SL[ToEnumShortString(player)].Stages.Stats[params.StageNum]
 
 		if playerStats then
+			profile = playerStats.profile
 			steps = playerStats.steps
 	 		meter = playerStats.meter
 	 		difficulty = playerStats.difficulty
@@ -40,7 +41,21 @@ local af = Def.ActorFrame{
 	end
 }
 
---percent score
+-- profile name (only if there were any profile switches happening this session)
+if displayProfileNames then
+	af[#af+1] = LoadFont("Common Normal")..{
+		InitCommand=function(self) self:zoom(0.5):horizalign(align1):x(col1x):y(-43) end,
+		DrawStageCommand=function(self)
+			if playerStats and profile then
+				self:settext(profile)
+			else
+				self:settext("")
+			end
+		end
+	}
+end
+
+-- percent score
 af[#af+1] = LoadFont("Common Bold")..{
 	InitCommand=function(self) self:zoom(0.5):horizalign(align1):x(col1x):y(-24) end,
 	DrawStageCommand=function(self)

--- a/BGAnimations/ScreenEvaluationSummary overlay/Row.lua
+++ b/BGAnimations/ScreenEvaluationSummary overlay/Row.lua
@@ -95,13 +95,33 @@ t[#t+1] = LoadFont("Common Normal")..{
 -- and that is what we want here.
 --
 -- We shouldn't use something like GAMESTATE:GetHumanPlayers() because players
--- can late-join (and maybe late-unjoin someday soon) and GetHumanPlayers()
--- would return whichever players were currently joined at the time of ScreenEvalSummary.
+-- can late-join (and late-unjoin, and switch) and GetHumanPlayers() would return
+-- whichever players were currently joined at the time of ScreenEvalSummary.
 
+
+-- Before we get to actually populating the per-player stats, check whether we
+-- should also display the name of the profile that was used to play a specific
+-- song.
+--
+-- The rationale is that this should only be done if it helps avoid confusion.
+-- If P1 and P2 were each consistently using a single profile the whole time,
+-- there is no added value in displaying it. On the other hand, if either P1 or
+-- P2 switched profiles over the course of the session, let's make it clear who
+-- obtained which score.
+local displayProfileNames = false
+for player in ivalues( PlayerNumber ) do
+	if #uniqueProfilesUsedForPlayer(ToEnumShortString(player)) > 1 then
+		displayProfileNames = true
+		break
+	end
+end
+
+
+-- Finally, load the actors that will populate the actual player-specific stats.
 for player in ivalues( PlayerNumber ) do
 	-- PlayerStageStats.lua handles player-specific things
 	-- like stepchart difficulty, stepartist, letter grade, and judgment breakdown
-	t[#t+1] = LoadActor("./PlayerStageStats.lua", player)
+	t[#t+1] = LoadActor("./PlayerStageStats.lua", {player, displayProfileNames})
 end
 
 return t

--- a/BGAnimations/ScreenEvaluationSummary overlay/default.lua
+++ b/BGAnimations/ScreenEvaluationSummary overlay/default.lua
@@ -30,6 +30,20 @@ local page_text = THEME:GetString("ScreenEvaluationSummary", "Page")
 
 -- -----------------------------------------------------------------------
 
+
+-- Utility function to collect the names of all unique profiles that played at least one song
+-- as player pn this session.
+uniqueProfilesUsedForPlayer = function(pn)
+	local extractProfile = function(stats)
+		return stats.profile
+	end
+	local profilesUsed = map(extractProfile, SL[pn].Stages.Stats)
+	return deduplicate(profilesUsed)
+end
+
+
+-- -----------------------------------------------------------------------
+
 local t = Def.ActorFrame{
 	-- this CodeMessage is defined in metrics.ini under [ScreenEvaluationSummary]
 	-- it handles both page navigation and screenshot requests

--- a/BGAnimations/ScreenSelectMusic overlay/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/default.lua
@@ -15,16 +15,14 @@ local af = Def.ActorFrame{
 
 	PlayerProfileSetMessageCommand=function(self, params)
 		if not PROFILEMAN:IsPersistentProfile(params.Player) then
-			GAMESTATE:ResetPlayerOptions(params.Player)
-			SL[ToEnumShortString(params.Player)]:initialize()
+			LoadGuest(params.Player)
 		end
 		ApplyMods(params.Player)
 	end,
 
 	PlayerJoinedMessageCommand=function(self, params)
 		if not PROFILEMAN:IsPersistentProfile(params.Player) then
-			GAMESTATE:ResetPlayerOptions(params.Player)
-			SL[ToEnumShortString(params.Player)]:initialize()
+			LoadGuest(params.Player)
 		end
 		ApplyMods(params.Player)
 	end,

--- a/Scripts/06 SL-Utilities.lua
+++ b/Scripts/06 SL-Utilities.lua
@@ -169,3 +169,20 @@ function map(func, array)
 	end
 	return new_array
 end
+
+
+-- Create a new table with each unique element from the input present exactly once,
+-- e.g. {1, 2, 3, 2, 1} -> {1, 2, 3}
+function deduplicate(array)
+	local hash = {}
+	local res = {}
+
+	for _, v in ipairs(array) do
+		if not hash[v] then
+			res[#res+1] = v
+			hash[v] = true
+		end
+	end
+
+	return res
+end

--- a/Scripts/SL-PlayerProfiles.lua
+++ b/Scripts/SL-PlayerProfiles.lua
@@ -77,6 +77,22 @@ local permitted_profile_settings = {
 local theme_name = THEME:GetThemeDisplayName()
 local filename =  theme_name .. " UserPrefs.ini"
 
+
+-- Function called when a [GUEST] joins during SSM, either by late joining or via the fast
+-- profile switcher. It does two things:
+-- 1) properly reset profile state (e.g. modifiers), and
+-- 2) persist any state that should survive a profile switch (e.g., session history
+--    in SL[pn].Stages with songs played for displaying on ScreenEvaluationSummary).
+-- LoadProfileCustom takes care of this for persistent profiles.
+LoadGuest = function(player)
+	GAMESTATE:ResetPlayerOptions(player)
+	local pn = ToEnumShortString(player)
+	local stages = SL[pn].Stages
+	SL[pn]:initialize()
+	SL[pn].Stages = stages
+end
+
+
 -- function assigned to "CustomLoadFunction" under [Profile] in metrics.ini
 LoadProfileCustom = function(profile, dir)
 
@@ -94,8 +110,13 @@ LoadProfileCustom = function(profile, dir)
 	end
 
 	if pn then
+		-- Remember and persist stats about songs played across profile switches
+		local stages = SL[pn].Stages
+
 		SL[pn]:initialize()
 		ParseGrooveStatsIni(player)
+
+		SL[pn].Stages = stages
 	end
 
 	if pn and FILEMAN:DoesFileExist(path) then


### PR DESCRIPTION
The screen was broken after introducing the profile switcher: https://github.com/Simply-Love/Simply-Love-SM5/issues/396

The fix consists of two parts:

1. Making sure the current session history survives any profile switches.
2. Tweaking the screen to be less confusing when multiple profiles are involved. In case of no profile switches (i.e., both P1 and P2 only used up to one unique profile each), the screen behaves as usual. If either P1 or P2 (or both) used more than one profile (including guest) over the course of the session, we now show the display name of the profile that obtained a specific score.

Tested hopefully all possible scenarios (late joining, completely unjoining a player for a song, switching after every song, using [GUEST]).

I also sneaked in some tiny quality of life improvements like a LoadProfileCustom counterpart for [GUEST] and some utility functions.