### PR TITLE
Fix typos in logic for FA+ windows and pane

### DIFF
--- a/Scripts/SL-PlayerOptions.lua
+++ b/Scripts/SL-PlayerOptions.lua
@@ -411,7 +411,7 @@ local Overrides = {
 			if SL.Global.GameMode == "FA+" then
 				 -- always disable in FA+ mode since it's handled engine side.
 				mods.ShowFaPlusWindow = false
-				mods.ShowEXScore = list[1]
+				mods.ShowEXScore = list[2]
 				mods.ShowFaPlusPane = list[3]
 				return
 			end
@@ -419,7 +419,7 @@ local Overrides = {
 			mods.ShowEXScore = list[2]
 			mods.ShowFaPlusPane = list[3]
 			-- Default to FA+ pane if either options are active.
-			sl_pn.EvalPanePrimary = ((list[1] or list[2]) and not list[3]) and 2 or 1
+			sl_pn.EvalPanePrimary = ((list[1] or list[2]) and list[3]) and 2 or 1
 		end
 	},
 	-------------------------------------------------------------------------


### PR DESCRIPTION
- Show EX Score option was on list[1] instead of list[2] for translating options to FA+ mode.
- Logic for primary evaluation pane had a "not" that was causing it to default to a disabled pane in cases where FA+ or EX Score were enabled but the FA+ pane was not, as well as defaulting to the normal pane when FA+ was enabled.