### PR TITLE
Add 'today' to Calories Burned

### DIFF
--- a/Languages/de.ini
+++ b/Languages/de.ini
@@ -302,7 +302,7 @@ FormatStages=%i Stages
 
 [ScreenGameOver]
 LastUsedHighScoreName=Highscore Name
-CaloriesBurned=Kalorien Verbrannt
+CaloriesBurned=Kalorienverbrauch Heute
 TotalSongsPlayed=Insgesamt Gespielte Lieder
 SongsPlayedThisGame=Lieder Dieses Spiel Gespielt
 NotesHitThisGame=Noten Dieses Spiel Getroffen

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -302,7 +302,7 @@ OutOfRanking=Out of Ranking
 ##############################################
 [ScreenGameOver]
 LastUsedHighScoreName=High Score Name
-CaloriesBurned=Calories Burned
+CaloriesBurned=Calories Burned Today
 TotalSongsPlayed=Total Songs Played
 SongsPlayedThisGame=Songs Played This Game
 NotesHitThisGame=Notes Hit This Game

--- a/Languages/es.ini
+++ b/Languages/es.ini
@@ -355,7 +355,7 @@ FormatStages=%i Canciones
 
 [ScreenGameOver]
 LastUsedHighScoreName=Nombre de Puntuación
-CaloriesBurned=Calorias Quemadas
+CaloriesBurned=Calorias Quemadas Hoy
 TotalSongsPlayed=Total de Canciones\nJugadas
 SongsPlayedThisGame=Canciones Jugadas\nen Sesión
 NotesHitThisGame=Flechas marcadas

--- a/Languages/fr.ini
+++ b/Languages/fr.ini
@@ -239,7 +239,7 @@ FormatStages=%i Stages
 
 [ScreenGameOver]
 LastUsedHighScoreName=Nom du joueur
-CaloriesBurned=Calories brûlées
+CaloriesBurned=Calories dépensées aujourd'hui
 CurrentCombo=Combo actuel
 NotesHitThisGame=Flèches tapées
 TotalSongsPlayed=Chansons jouées au total

--- a/Languages/it.ini
+++ b/Languages/it.ini
@@ -309,7 +309,7 @@ OutOfRanking=Non Classificabile
 ##############################################
 [ScreenGameOver]
 LastUsedHighScoreName=Nome Punteggi
-CaloriesBurned=Calorie Bruciate
+CaloriesBurned=Calorie bruciate oggi
 CurrentCombo=Combo attuale
 TotalSongsPlayed=Totale Canzoni giocate \n
 SongsPlayedThisGame=Canzioni giocate\nin questa sessione

--- a/Languages/ja.ini
+++ b/Languages/ja.ini
@@ -215,7 +215,7 @@ FormatStages=%i Stages
 
 [ScreenGameOver]
 LastUsedHighScoreName=High Score Name
-CaloriesBurned=Calories Burned
+CaloriesBurned=Calories Burned Today
 TotalSongsPlayed=Total Songs Played
 SongsPlayedThisGame=Songs Played This Game
 NotesHitThisGame=Notes Hit This Game

--- a/Languages/pl.ini
+++ b/Languages/pl.ini
@@ -301,7 +301,7 @@ OutOfRanking=Poza Rankingiem
 ##############################################
 [ScreenGameOver]
 LastUsedHighScoreName=Nazwa rekordu
-CaloriesBurned=Spalonych kalorii
+CaloriesBurned=Spalonych kalorii dzisiaj
 TotalSongsPlayed=Rozegranych utworów łącznie
 SongsPlayedThisGame=Rozegranych utworów w tej grze
 NotesHitThisGame=Trafionych note'ów w tej grze

--- a/Languages/pt-br.ini
+++ b/Languages/pt-br.ini
@@ -398,7 +398,7 @@ FormatStages=%i Músicas
 
 [ScreenGameOver]
 LastUsedHighScoreName=Nome da pontuação
-CaloriesBurned=Calorias Queimadas
+CaloriesBurned=Calorias queimadas hoje
 CurrentCombo=Combo Atual
 TotalSongsPlayed=Total de Músicas\nJogadas
 NotesHitThisGame=Notas acertadas


### PR DESCRIPTION
Changes "Calories Burned" to "Calories Burned Today" to make it apparent that the calorie count resets every day. Used a combination of DeepL and Google Translate for the other languages.

<img width="1392" alt="Screen Shot 2022-10-03 at 4 48 48 PM" src="https://user-images.githubusercontent.com/266170/193705870-93c592ba-8112-43bc-b552-7df3ece152b1.png">

<img width="1392" alt="Screen Shot 2022-10-03 at 4 51 16 PM" src="https://user-images.githubusercontent.com/266170/193705873-254c7689-f7f9-40af-bb26-136a232d72dc.png">
