### PR TITLE
Add a Theme Preference to Hide Density Graph and Tech Display in SelectMusic

### DIFF
--- a/BGAnimations/ScreenSelectMusic overlay/PerPlayer/Cursor-Classic.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/PerPlayer/Cursor-Classic.lua
@@ -1,0 +1,93 @@
+-- the difficulty grid and per-player bouncing cursors don't support CourseMode
+-- CourseContentsList.lua should be used instead
+if GAMESTATE:IsCourseMode() then return end
+-- ----------------------------------------------
+
+local player = ...
+local pn = ToEnumShortString(player)
+local p = PlayerNumber:Reverse()[player]
+
+local GetStepsToDisplay = LoadActor("../StepsDisplayList/StepsToDisplay.lua")
+-- I feel like this surely must be the wrong way to do this...
+local GlobalOffsetSeconds = PREFSMAN:GetPreference("GlobalOffsetSeconds")
+
+local RowIndex = 1
+
+return Def.Sprite{
+	Texture=THEME:GetPathB("ScreenSelectMusic", "overlay/PerPlayer/arrow.png"),
+	Name="Cursor"..pn,
+	InitCommand=function(self)
+		self:visible( GAMESTATE:IsHumanPlayer(player) )
+		self:halign( p ):zoom(0.575)
+
+		-- FIXME: SM5.1-beta's EffectClock enum includes constants for
+		--   CLOCK_BGM_BEAT_PLAYER1 and CLOCK_BGM_BEAT_PLAYER2 but
+		--   but effectclock(), the only method currently available via
+		--   the Lua API, doesn't appear to have any way to use them.
+		--
+		--   effectclock in Lua maps to Actor::SetEffectClockString() in C++
+		--   which handles a limited set of hardcoded english strings:
+		--   "timer", "timerglobal", "beat", "music", "musicnooffset", and "beatnooffset"
+		--   as well as some limited cabinet light handling.
+		--
+		--   Notably, there is not anything like "beatp1" or "beatp2" or "stepsbeat" or etc.
+		--   The takeaway here is that these bouncing cursors will sync with song timing.
+	 	--   If the current song uses steps timing, it will not be used in the bounce() effect.
+		--
+		--   One example of this is ACE FOR ACES, where some step timing is a steady 200bpm,
+		--   while others are 50-400bpm, but the song timing is 200.  This song timing is what
+		--   will be used to animate both players' bouncing cursors here, regardless of whether
+		--   one or both are joined.  This would need to be fixed in the engine.
+		self:bounce():effectclock("beatnooffset")
+
+		if player == PLAYER_1 then
+			self:x( IsUsingWideScreen() and _screen.cx-330 or 0)
+			self:effectmagnitude(-3,0,0)
+
+		elseif player == PLAYER_2 then
+			self:rotationz(180)
+			self:x(IsUsingWideScreen() and _screen.cx-28 or 276)
+			self:effectmagnitude(3,0,0)
+		end
+
+		self:effectperiod(1):effectoffset( -10 * GlobalOffsetSeconds)
+	end,
+
+	PlayerJoinedMessageCommand=function(self, params)
+		if params.Player == player then self:visible(true) end
+	end,
+	PlayerUnjoinedMessageCommand=function(self, params)
+		if params.Player == player then self:visible(false) end
+	end,
+
+	OnCommand=function(self) self:queuecommand("Set") end,
+	CurrentSongChangedMessageCommand=function(self) self:queuecommand("Set") end,
+	CurrentStepsP1ChangedMessageCommand=function(self) self:queuecommand("Set") end,
+	CurrentStepsP2ChangedMessageCommand=function(self) self:queuecommand("Set") end,
+
+	SetCommand=function(self)
+		local song = GAMESTATE:GetCurrentSong()
+
+		if song then
+			local playable_steps = SongUtil.GetPlayableSteps( song )
+			local current_steps = GAMESTATE:GetCurrentSteps(player)
+
+			for i,chart in pairs( GetStepsToDisplay(playable_steps) ) do
+				if chart == current_steps then
+					RowIndex = i
+					break
+				end
+			end
+		end
+
+		-- keep within reasonable limits because Edit charts are a thing
+		RowIndex = clamp(RowIndex, 1, 5)
+
+		-- update cursor y position
+		local sdl = self:GetParent():GetParent():GetChild("StepsDisplayList")
+		if sdl then
+			local grid = sdl:GetChild("Grid")
+			self:y(sdl:GetY() + grid:GetY() + grid:GetChild("Blocks_"..RowIndex):GetY() + 1 )
+		end
+	end
+}

--- a/BGAnimations/ScreenSelectMusic overlay/PerPlayer/StepArtist-Classic.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/PerPlayer/StepArtist-Classic.lua
@@ -1,0 +1,160 @@
+local player = ...
+local pn = ToEnumShortString(player)
+local p = PlayerNumber:Reverse()[player]
+
+local text_table, marquee_index
+
+return Def.ActorFrame{
+	Name="StepArtistAF_" .. pn,
+
+	-- song and course changes
+	OnCommand=function(self) self:queuecommand("Reset") end,
+	["CurrentSteps"..pn.."ChangedMessageCommand"]=function(self) self:queuecommand("Reset") end,
+	CurrentSongChangedMessageCommand=function(self) self:queuecommand("Reset") end,
+	CurrentCourseChangedMessageCommand=function(self) self:queuecommand("Reset") end,
+
+	PlayerJoinedMessageCommand=function(self, params)
+		if params.Player == player then
+			self:queuecommand("Appear" .. pn)
+		end
+	end,
+
+	-- Simply Love doesn't support player unjoining (that I'm aware of!) but this
+	-- animation is left here as a reminder to a future me to maybe look into it.
+	PlayerUnjoinedMessageCommand=function(self, params)
+		if params.Player == player then
+			self:ease(0.5, 275):addy(scale(p,0,1,1,-1) * 30):diffusealpha(0)
+		end
+	end,
+
+	-- depending on the value of pn, this will either become
+	-- an AppearP1Command or an AppearP2Command when the screen initializes
+	["Appear"..pn.."Command"]=function(self) self:visible(true):ease(0.5, 275):addy(scale(p,0,1,-1,1) * 30) end,
+
+	InitCommand=function(self)
+		self:visible( false ):halign( p )
+
+		if player == PLAYER_1 then
+
+			if GAMESTATE:IsCourseMode() then
+				self:x( _screen.cx - (IsUsingWideScreen() and 356 or 346))
+				self:y(_screen.cy + 32)
+			else
+				self:y(_screen.cy + 44)
+				self:x( _screen.cx - (IsUsingWideScreen() and 356 or 346))
+			end
+
+		elseif player == PLAYER_2 then
+
+			if GAMESTATE:IsCourseMode() then
+				self:x( _screen.cx - 210)
+				self:y(_screen.cy + 85)
+			else
+				self:y(_screen.cy + 97)
+				self:x( _screen.cx - 210)
+			end
+		end
+
+		if GAMESTATE:IsHumanPlayer(player) then
+			self:queuecommand("Appear" .. pn)
+		end
+	end,
+
+	-- colored background quad
+	Def.Quad{
+		Name="BackgroundQuad",
+		InitCommand=function(self) self:zoomto(175, _screen.h/28):x(113) end,
+		ResetCommand=function(self)
+			local StepsOrTrail = GAMESTATE:IsCourseMode() and GAMESTATE:GetCurrentTrail(player) or GAMESTATE:GetCurrentSteps(player)
+
+			if StepsOrTrail then
+				local difficulty = StepsOrTrail:GetDifficulty()
+				self:diffuse( DifficultyColor(difficulty) )
+			else
+				self:diffuse( PlayerColor(player) )
+			end
+		end
+	},
+
+	--STEPS label
+	LoadFont("Common Normal")..{
+		Text=GAMESTATE:IsCourseMode() and Screen.String("SongNumber"):format(1) or Screen.String("STEPS"),
+		InitCommand=function(self)
+			self:diffuse(0,0,0,1):horizalign(left):x(30):maxwidth(40)
+		end,
+		UpdateTrailTextMessageCommand=function(self, params)
+			self:settext( THEME:GetString("ScreenSelectCourse", "SongNumber"):format(params.index) )
+		end
+	},
+
+	--stepartist text
+	LoadFont("Common Normal")..{
+		InitCommand=function(self)
+			self:diffuse(color("#1e282f")):horizalign(left)
+
+			if GAMESTATE:IsCourseMode() then
+				self:x(60):maxwidth(138)
+			else
+				self:x(75):maxwidth(124)
+			end
+		end,
+		ResetCommand=function(self)
+
+			local SongOrCourse = GAMESTATE:IsCourseMode() and GAMESTATE:GetCurrentCourse() or GAMESTATE:GetCurrentSong()
+			local StepsOrTrail = GAMESTATE:IsCourseMode() and GAMESTATE:GetCurrentTrail(player) or GAMESTATE:GetCurrentSteps(player)
+
+			-- always stop tweening when steps change in case a MarqueeCommand is queued
+			self:stoptweening()
+
+			if SongOrCourse and StepsOrTrail then
+
+				text_table = GetStepsCredit(player)
+				marquee_index = 0
+
+				-- don't queue a Marquee in CourseMode
+				-- each TrailEntry text change will be broadcast from CourseContentsList.lua
+				-- to ensure it stays synced with the scrolling list of songs
+				if not GAMESTATE:IsCourseMode() then
+					-- only queue a Marquee if there are things in the text_table to display
+					if #text_table > 0 then
+						self:queuecommand("Marquee")
+					else
+						-- no credit information was specified in the simfile for this stepchart, so just set to an empty string
+						self:settext("")
+					end
+				end
+			else
+				-- there wasn't a song/course or a steps object, so the MusicWheel is probably hovering
+				-- on a group title, which means we want to set the stepartist text to an empty string for now
+				self:settext("")
+			end
+		end,
+		MarqueeCommand=function(self)
+			-- increment the marquee_index, and keep it in bounds
+			marquee_index = (marquee_index % #text_table) + 1
+			-- retrieve the text we want to display
+			local text = text_table[marquee_index]
+
+			-- set this BitmapText actor to display that text
+			self:settext( text )
+
+			-- check for emojis; they shouldn't be diffused to Color.Black
+			DiffuseEmojis(self, text)
+
+			if not GAMESTATE:IsCourseMode() then
+				-- sleep 2 seconds before queueing the next Marquee command to do this again
+				if #text_table > 1 then
+					self:sleep(2):queuecommand("Marquee")
+				end
+			else
+				self:sleep(0.5):queuecommand("m")
+			end
+		end,
+		UpdateTrailTextMessageCommand=function(self, params)
+			if text_table then
+				self:settext( text_table[params.index] or "" )
+			end
+		end,
+		OffCommand=function(self) self:stoptweening() end
+	}
+}

--- a/BGAnimations/ScreenSelectMusic overlay/PerPlayer/StepArtist-Classic.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/PerPlayer/StepArtist-Classic.lua
@@ -35,24 +35,11 @@ return Def.ActorFrame{
 		self:visible( false ):halign( p )
 
 		if player == PLAYER_1 then
-
-			if GAMESTATE:IsCourseMode() then
-				self:x( _screen.cx - (IsUsingWideScreen() and 356 or 346))
-				self:y(_screen.cy + 32)
-			else
-				self:y(_screen.cy + 44)
-				self:x( _screen.cx - (IsUsingWideScreen() and 356 or 346))
-			end
-
+			self:y(_screen.cy + 44)
+			self:x( _screen.cx - (IsUsingWideScreen() and 356 or 346))
 		elseif player == PLAYER_2 then
-
-			if GAMESTATE:IsCourseMode() then
-				self:x( _screen.cx - 210)
-				self:y(_screen.cy + 85)
-			else
-				self:y(_screen.cy + 97)
-				self:x( _screen.cx - 210)
-			end
+			self:y(_screen.cy + 97)
+			self:x( _screen.cx - 210)
 		end
 
 		if GAMESTATE:IsHumanPlayer(player) then

--- a/BGAnimations/ScreenSelectMusic overlay/PerPlayer/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/PerPlayer/default.lua
@@ -4,14 +4,26 @@ local t = Def.ActorFrame{}
 -- If the other player suddenly latejoins, we can't dynamically add more actors to the screen
 -- We can only unhide hidden actors that were there all along
 for player in ivalues( PlayerNumber ) do
-	t[#t+1] = LoadActor("./DensityGraph.lua", player)
-	-- AuthorCredit, Description, and ChartName associated with the current stepchart
-	t[#t+1] = LoadActor("./StepArtist.lua", player)
+	-- Density Graph is only loaded when DisplayStyle is set to ITG+
+	if ThemePrefs.Get("SelectMusicDisplayStyle") == "ITG+" and GAMESTATE:GetCurrentGame():GetName() == "dance"  then
+		t[#t+1] = LoadActor("./DensityGraph.lua", player)
+		-- AuthorCredit, Description, and ChartName associated with the current stepchart
+		t[#t+1] = LoadActor("./StepArtist.lua", player)
+	else
+		-- AuthorCredit, Description, and ChartName associated with the current stepchart
+		t[#t+1] = LoadActor("./StepArtist-Classic.lua", player)
+
+	end
 end
 
 -- Bouncing cursor inside the grid of difficulty blocks. These should be on top of both of the other elements.
 for player in ivalues( PlayerNumber ) do
-	t[#t+1] = LoadActor("./Cursor.lua", player)
+	-- The cursor appears differently depending on the DisplayStyle
+	if ThemePrefs.Get("SelectMusicDisplayStyle") == "ITG+" and GAMESTATE:GetCurrentGame():GetName() == "dance" then
+		t[#t+1] = LoadActor("./Cursor.lua", player)
+	else
+		t[#t+1] = LoadActor("./Cursor-Classic.lua", player)
+	end
 end
 
 return t

--- a/BGAnimations/ScreenSelectMusic overlay/PerPlayer/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/PerPlayer/default.lua
@@ -5,7 +5,7 @@ local t = Def.ActorFrame{}
 -- We can only unhide hidden actors that were there all along
 for player in ivalues( PlayerNumber ) do
 	-- Density Graph is only loaded when DisplayStyle is set to ITG+
-	if ThemePrefs.Get("SelectMusicDisplayStyle") == "ITG+" and GAMESTATE:GetCurrentGame():GetName() == "dance"  then
+	if ThemePrefs.Get("SelectMusicDisplayStyle") == "ITG+" and GAMESTATE:GetCurrentGame():GetName() == "dance" and not GAMESTATE:IsCourseMode() then
 		t[#t+1] = LoadActor("./DensityGraph.lua", player)
 		-- AuthorCredit, Description, and ChartName associated with the current stepchart
 		t[#t+1] = LoadActor("./StepArtist.lua", player)

--- a/BGAnimations/ScreenSelectMusic overlay/SongDescription/SongDescription.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SongDescription/SongDescription.lua
@@ -6,7 +6,7 @@ local _w = IsUsingWideScreen() and 320 or 310
 
 local af = Def.ActorFrame{
 	OnCommand=function(self)
-		if ThemePrefs.Get("SelectMusicDisplayStyle") == "ITG+" and GAMESTATE:GetCurrentGame():GetName() == "dance" then
+		if ThemePrefs.Get("SelectMusicDisplayStyle") == "ITG+" and GAMESTATE:GetCurrentGame():GetName() == "dance" and not GAMESTATE:IsCourseMode() then
 			self:xy(_screen.cx - (IsUsingWideScreen() and 170 or 165), _screen.cy - 55)
 		else
 			self:xy(_screen.cx - (IsUsingWideScreen() and 170 or 165), _screen.cy - 28)

--- a/BGAnimations/ScreenSelectMusic overlay/SongDescription/SongDescription.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SongDescription/SongDescription.lua
@@ -6,7 +6,12 @@ local _w = IsUsingWideScreen() and 320 or 310
 
 local af = Def.ActorFrame{
 	OnCommand=function(self)
-		self:xy(_screen.cx - (IsUsingWideScreen() and 170 or 165), _screen.cy - 55)
+		if ThemePrefs.Get("SelectMusicDisplayStyle") == "ITG+" and GAMESTATE:GetCurrentGame():GetName() == "dance" then
+			self:xy(_screen.cx - (IsUsingWideScreen() and 170 or 165), _screen.cy - 55)
+		else
+			self:xy(_screen.cx - (IsUsingWideScreen() and 170 or 165), _screen.cy - 28)
+
+		end
 	end,
 
 	CurrentSongChangedMessageCommand=function(self)    self:playcommand("Set") end,

--- a/BGAnimations/ScreenSelectMusic overlay/StepsDisplayList/CourseContentsList.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/StepsDisplayList/CourseContentsList.lua
@@ -36,7 +36,7 @@ end
 
 local af = Def.ActorFrame{
 	InitCommand=function(self)
-		self:xy(_screen.cx-170, _screen.cy + 28)
+		self:xy(_screen.cx-170, _screen.cy + 40)
 	end,
 
 	---------------------------------------------------------------------

--- a/BGAnimations/ScreenSelectMusic overlay/StepsDisplayList/Grid-Classic.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/StepsDisplayList/Grid-Classic.lua
@@ -1,0 +1,135 @@
+-- this difficulty grid doesn't support CourseMode
+-- CourseContentsList.lua should be used instead
+if GAMESTATE:IsCourseMode() then return end
+-- ----------------------------------------------
+
+local num_rows    = 5
+local num_columns = 20
+
+local GridZoomX = IsUsingWideScreen() and 0.435 or 0.39
+local BlockZoomY = 0.275
+
+local GetStepsToDisplay = LoadActor("./StepsToDisplay.lua")
+
+local t = Def.ActorFrame{
+	Name="StepsDisplayList",
+	InitCommand=function(self) self:vertalign(top):xy(_screen.cx-170, _screen.cy + 70) end,
+
+	OnCommand=function(self)                           self:queuecommand("RedrawStepsDisplay") end,
+	CurrentSongChangedMessageCommand=function(self)    self:queuecommand("RedrawStepsDisplay") end,
+	CurrentStepsP1ChangedMessageCommand=function(self) self:queuecommand("RedrawStepsDisplay") end,
+	CurrentStepsP2ChangedMessageCommand=function(self) self:queuecommand("RedrawStepsDisplay") end,
+
+	RedrawStepsDisplayCommand=function(self)
+
+		local song = GAMESTATE:GetCurrentSong()
+
+		if song then
+			local steps = SongUtil.GetPlayableSteps( song )
+
+			if steps then
+				local StepsToDisplay = GetStepsToDisplay(steps)
+
+				for i=1,num_rows do
+					if StepsToDisplay[i] then
+						-- if this particular song has a stepchart for this row, update the Meter
+						-- and BlockRow coloring appropriately
+						local meter = StepsToDisplay[i]:GetMeter()
+						local difficulty = StepsToDisplay[i]:GetDifficulty()
+						self:GetChild("Grid"):GetChild("Meter_"..i):playcommand("Set",  {Meter=meter, Difficulty=difficulty})
+						self:GetChild("Grid"):GetChild("Blocks_"..i):playcommand("Set", {Meter=meter, Difficulty=difficulty})
+					else
+						-- otherwise, set the meter to an empty string and hide this particular colored BlockRow
+						self:GetChild("Grid"):GetChild("Meter_"..i):playcommand("Unset")
+						self:GetChild("Grid"):GetChild("Blocks_"..i):playcommand("Unset")
+					end
+				end
+			end
+		else
+			self:playcommand("Unset")
+		end
+	end,
+
+	-- - - - - - - - - - - - - -
+
+	-- background
+	Def.Quad{
+		Name="Background",
+		InitCommand=function(self)
+			self:diffuse(color("#1e282f")):zoomto(320, 96)
+			if ThemePrefs.Get("RainbowMode") then
+				self:diffusealpha(0.9)
+			end
+		end
+	},
+}
+
+
+local Grid = Def.ActorFrame{
+	Name="Grid",
+	InitCommand=function(self) self:horizalign(left):vertalign(top):xy(8, -52 ) end,
+}
+
+
+-- A grid of decorative faux-blocks that will exist
+-- behind the changing difficulty blocks.
+Grid[#Grid+1] = Def.Sprite{
+	Name="BackgroundBlocks",
+	Texture=THEME:GetPathB("ScreenSelectMusic", "overlay/StepsDisplayList/_block.png"),
+
+	InitCommand=function(self) self:diffuse(color("#182025")) end,
+	OnCommand=function(self)
+		local width = self:GetWidth()
+		local height= self:GetHeight()
+		self:zoomto(width * num_columns * GridZoomX, height * num_rows * BlockZoomY)
+		self:y( 3 * height * BlockZoomY )
+		self:customtexturerect(0, 0, num_columns, num_rows)
+	end
+}
+
+for RowNumber=1,num_rows do
+
+	Grid[#Grid+1] =	Def.Sprite{
+		Name="Blocks_"..RowNumber,
+		Texture=THEME:GetPathB("ScreenSelectMusic", "overlay/StepsDisplayList/_block.png"),
+
+		InitCommand=function(self) self:diffusealpha(0) end,
+		OnCommand=function(self)
+			local width = self:GetWidth()
+			local height= self:GetHeight()
+			self:y( RowNumber * height * BlockZoomY)
+			self:zoomto(width * num_columns * GridZoomX, height * BlockZoomY)
+		end,
+		SetCommand=function(self, params)
+			-- the engine's Steps::TidyUpData() method ensures that difficulty meters are positive
+			-- (and does not seem to enforce any upper bound that I can see)
+			self:customtexturerect(0, 0, num_columns, 1)
+			self:cropright( 1 - (params.Meter * (1/num_columns)) )
+			self:diffuse( DifficultyColor(params.Difficulty, true) )
+		end,
+		UnsetCommand=function(self)
+			self:customtexturerect(0,0,0,0)
+		end
+	}
+
+	Grid[#Grid+1] = LoadFont("Common Bold")..{
+		Name="Meter_"..RowNumber,
+		InitCommand=function(self)
+			local height = self:GetParent():GetChild("Blocks_"..RowNumber):GetHeight()
+			self:horizalign(right)
+			self:y(RowNumber * height * BlockZoomY)
+			self:x( IsUsingWideScreen() and -140 or -126 )
+			self:zoom(0.3)
+		end,
+		SetCommand=function(self, params)
+			-- diffuse and set each chart's difficulty meter
+			self:diffuse( DifficultyColor(params.Difficulty) )
+			self:settext(params.Meter)
+		end,
+		UnsetCommand=function(self) self:settext(""):diffuse(color("#182025")) end,
+	}
+end
+
+t[#t+1] = Grid
+
+return t

--- a/BGAnimations/ScreenSelectMusic overlay/StepsDisplayList/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/StepsDisplayList/default.lua
@@ -2,8 +2,11 @@ local file
 
 if GAMESTATE:IsCourseMode() then
 	file = LoadActor("./CourseContentsList.lua")
-else
+elseif ThemePrefs.Get("SelectMusicDisplayStyle") == "ITG+" and GAMESTATE:GetCurrentGame():GetName() == "dance"  then
 	file = LoadActor("./Grid.lua")
+else
+	file = LoadActor("./Grid-Classic.lua")
+
 end
 
 return file

--- a/BGAnimations/ScreenSelectMusic overlay/banner.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/banner.lua
@@ -5,7 +5,7 @@ local SongOrCourse, banner
 
 local t = Def.ActorFrame{
 	OnCommand=function(self)
-		if ThemePrefs.Get("SelectMusicDisplayStyle") == "ITG+" and GAMESTATE:GetCurrentGame():GetName() ~= "dance"  then
+		if ThemePrefs.Get("SelectMusicDisplayStyle") == "ITG+" and GAMESTATE:GetCurrentGame():GetName() == "dance" and not GAMESTATE:IsCourseMode() then
 			if IsUsingWideScreen() then
 				self:zoom(0.7655)
 				self:xy(_screen.cx - 170, 96)

--- a/BGAnimations/ScreenSelectMusic overlay/banner.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/banner.lua
@@ -5,13 +5,18 @@ local SongOrCourse, banner
 
 local t = Def.ActorFrame{
 	OnCommand=function(self)
-		if IsUsingWideScreen() then
-			self:zoom(0.7655)
-			self:xy(_screen.cx - 170, 96)
+		if ThemePrefs.Get("SelectMusicDisplayStyle") == "ITG+" and GAMESTATE:GetCurrentGame():GetName() ~= "dance"  then
+			if IsUsingWideScreen() then
+				self:zoom(0.7655)
+				self:xy(_screen.cx - 170, 96)
+			end
 		else
-			self:zoom(0.75)
-			self:xy(_screen.cx - 166, 96)
+			if IsUsingWideScreen() then
+				self:zoom(0.75)
+				self:xy(_screen.cx - 166, 112)
+			end
 		end
+
 	end
 }
 

--- a/BGAnimations/ScreenSelectMusic overlay/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/default.lua
@@ -46,12 +46,12 @@ local af = Def.ActorFrame{
 	-- number of steps, jumps, holds, etc., and high scores associated with the current stepchart
 	LoadActor("./PaneDisplay.lua"),
 
+	-- The grid for the difficulty picker (normal) or CourseContentsList (CourseMode)
+	LoadActor("./StepsDisplayList/default.lua"),
 	-- elements we need two of (one for each player) that draw underneath the StepsDisplayList
 	-- this includes the stepartist boxes, the density graph, and the cursors.
 	LoadActor("./PerPlayer/default.lua"),
-	-- The grid for the difficulty picker (normal) or CourseContentsList (CourseMode)
-	LoadActor("./StepsDisplayList/default.lua"),
-
+	
 	-- Banner Art
 	LoadActor("./Banner.lua"),
 	-- Song's Musical Artist, BPM, Duration

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -790,7 +790,7 @@ AllowScreenNameEntry=Set this to 'No' if you want to skip the Name Entry screen.
 AllowScreenGameOver=Set this to 'No' if you want to skip the Game Over screen.
 
 MusicWheelStyle=Set this to 'IIDX' if you want the MusicWheel to hide other, inactive song groups when actively browsing one.
-SelectMusicDisplayStyle=Set this to 'ITG+' if you want to see the Density Graph and Tech in the SelectMusic.\n\nSet this to 'Classic' to only show the steps grid and their difficulty.\n\nBoth options will show song and step descriptions and the meter level\n\nNote:'ITG+' was designed for 4-Panel Singles.
+SelectMusicDisplayStyle=Set this to 'ITG+' if you want to see information gained from the Chart Parser in ScreenSelectMusic. This includes the Density Graph and Tech in each chart.\n\nSet this to 'Classic' to hide this and restore classic behavior, only showing the steps grid & difficulty.\n\n\n\nThis only impacts 'Dance' game mode
 AllowDanceSolo=Set this to 'Yes' if you want to enable Solo as a choice so you can play the handful of ⬅↖⬇⬆↗➡ stepcharts in:\n\n• Solo Bass Mix\n• Solo 2000\n• Solo 4th Mix\n• foonmix\n• Solo Doubles 🤫\n\nThis only impacts 'Dance' game mode.
 HideStockNoteSkins=Set this to 'Hide' if you want to hide all NoteSkins that come with SM5 from the modifier menu.
 

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -599,6 +599,7 @@ AllowScreenEvalSummary=Allow Screen\nEval Summary
 AllowScreenNameEntry=Allow Screen\nName Entry
 AllowScreenGameOver=Allow Screen\nGame Over
 MusicWheelStyle=MusicWheel Style
+SelectMusicDisplayStyle=SelectMusic Style
 AllowDanceSolo=Allow Dance Solo
 HideStockNoteSkins=Stock NoteSkins
 ShowGradesInMusicWheel=Show Grades\nIn MusicWheel
@@ -789,6 +790,7 @@ AllowScreenNameEntry=Set this to 'No' if you want to skip the Name Entry screen.
 AllowScreenGameOver=Set this to 'No' if you want to skip the Game Over screen.
 
 MusicWheelStyle=Set this to 'IIDX' if you want the MusicWheel to hide other, inactive song groups when actively browsing one.
+SelectMusicDisplayStyle=Set this to 'ITG+' if you want to see the Density Graph and Tech in the SelectMusic.\n\nSet this to 'Classic' to only show the steps grid and their difficulty.\n\nBoth options will show song and step descriptions and the meter level\n\nNote:'ITG+' was designed for 4-Panel Singles.
 AllowDanceSolo=Set this to 'Yes' if you want to enable Solo as a choice so you can play the handful of ⬅↖⬇⬆↗➡ stepcharts in:\n\n• Solo Bass Mix\n• Solo 2000\n• Solo 4th Mix\n• foonmix\n• Solo Doubles 🤫\n\nThis only impacts 'Dance' game mode.
 HideStockNoteSkins=Set this to 'Hide' if you want to hide all NoteSkins that come with SM5 from the modifier menu.
 
@@ -900,6 +902,7 @@ AutoStyle='None' is best for public machines.
 DefaultGameMode='Casual' is best for public machines.
 AllowFailingOutOfSet=This should be 'No' unless you are a mean dude that wants to cycle people through games as quickly as possible.
 MusicWheelStyle='IIDX' allows faster navigation of the MusicWheel.
+SelectMusicDisplayStyle='Classic' is best for public machines or for running SRTs
 MusicWheelSpeed='Plaid' is as fast as the MusicWheel will scroll.
 
 AllowScreenSelectColor=This screen often confuses novice players, so you may wish to disable it for public machines.

--- a/Scripts/99 SL-ThemePrefs.lua
+++ b/Scripts/99 SL-ThemePrefs.lua
@@ -88,6 +88,11 @@ SL_CustomPrefs.Get = function()
 			},
 			Values = { "none", "single", "versus", "double" }
 		},
+		SelectMusicDisplayStyle =
+		{
+			Default = "Classic",
+			Choices = { "Classic", "ITG+" }
+		},
 		VisualStyle =
 		{
 			Default = "Hearts",

--- a/metrics.ini
+++ b/metrics.ini
@@ -1115,7 +1115,7 @@ OptionRowNormalMetricsGroup="OptionRowSimplyLoveOptions"
 LineNames=(function() \
 	local lines = "VisualStyle" \
 	if ThemePrefs.Get("VisualStyle") ~= "SRPG6" then lines = lines .. ",RainbowMode" end \
-	lines = lines.. ",,MusicWheelSpeed,,MusicWheelStyle,AutoStyle,DefaultGameMode,AllowFailingOutOfSet,NumberOfContinuesAllowed,CasualMaxMeter,SelectProfile,SelectColor,EvalSummary,NameEntry,GameOver,HideStockNoteSksins,DanceSolo,Nice,WriteCustomScores,KeyboardFeatures" \
+	lines = lines.. ",,MusicWheelSpeed,,MusicWheelStyle,SelectMusicDisplayStyle,AutoStyle,DefaultGameMode,AllowFailingOutOfSet,NumberOfContinuesAllowed,CasualMaxMeter,SelectProfile,SelectColor,EvalSummary,NameEntry,GameOver,HideStockNoteSksins,DanceSolo,Nice,WriteCustomScores,KeyboardFeatures" \
 	if Sprite.LoadFromCached ~= nil then lines = lines .. ",UseImageCache" end \
 	return lines \
 end)()
@@ -1127,6 +1127,8 @@ LineDefaultGameMode="lua,ThemePrefsRows.GetRow('DefaultGameMode')"
 LineAllowFailingOutOfSet="lua,ThemePrefsRows.GetRow('AllowFailingOutOfSet')"
 LineNumberOfContinuesAllowed="lua,ThemePrefsRows.GetRow('NumberOfContinuesAllowed')"
 LineMusicWheelStyle="lua,ThemePrefsRows.GetRow('MusicWheelStyle')"
+LineSelectMusicDisplayStyle="lua,ThemePrefsRows.GetRow('SelectMusicDisplayStyle')"
+
 LineMusicWheelSpeed="lua,OperatorMenuOptionRows.MusicWheelSpeed()"
 
 LineSelectProfile="lua,ThemePrefsRows.GetRow('AllowScreenSelectProfile')"


### PR DESCRIPTION
### This PR adds a new Theme Preference known as **SelectMusicDisplayStyle** with two options: "Classic" or "ITG+". 

![image](https://user-images.githubusercontent.com/30600688/196521031-2a55f862-9b17-432f-9244-3e8e8057b8c5.png)

Setting the preference to ITG+ maintains the current upstream's display for SelectMusic. This includes showing the DensityGraph and counting how much of each tech appears in each chart and displaying it. Setting the preference to Classic restores classic behavior where this information is not shown. 

Why?

I've found a couple of use cases for not showing the information from the chart parser. 

1. In my experience, this information was a bit intimidating for new players. This often discouraged them from playing multiple charts and overall made the interface _more scary looking_.

2. Sometimes the parser isn't 100% accurate. I'm not entirely sure about how far it supports (i.e. does it support Doubles?, Pump? Pump Doubles? etc.). 

3. This information kind of diminishes the sight reading experience. When I pick a chart, I now know the exact tech that is present in it and I know when and where the streams will occur. No more surprises. I found that this is especially significant for a sight reading tournament. 

Ex: This is the final mission of the UPSRT2.5 shown in SelectMusic with the SelectMusicDisplayStyle set to "ITG+"
![image](https://user-images.githubusercontent.com/30600688/196523012-b0bf7658-e5ca-47c1-a61c-1800697fd2e8.png)

Ideally I want to make sure players don't really know what to expect when they go in. Especially since this is the final mission of an SRT. I think having this as an option allows people who want to disable the extra display to be able to do so just by changing a setting. Otherwise anyone who wants to remove the graph and tech display has to modify SL code (which is not viable for everyone). 

The below image shows what the song would look like with SelectDisplayMusicStyle set to "Classic"

![image](https://user-images.githubusercontent.com/30600688/196522901-3ccfb86c-8fe5-4780-a7ef-04ee456eb3df.png)

I also noticed that we see this information displayed in other game-types such as Pump.

![image](https://user-images.githubusercontent.com/30600688/196529757-a63b6d76-45fc-4020-871d-6981a2961239.png)

 My current understanding is that the parsing was mainly geared for 4-Panel singles. Our cab is temporarily using pump and well....the meta is different on pump so the tech counts displayed were more or less just _there_.  This PR also ensures that when using a game-type that is not 'dance,' Classic behavior is used by default.

I just think having this as a toggleable option can be useful for a lot of people using the theme. I like seeing the tech and what not in a chart, I just personally want the ability to turn it off. Especially for running or participating in SRTs. On my current Fork, I didn't have this as a toggleable option, I instead moved the new display into FA+ only and ITG mode using the "classic." My reasonings were mainly for new players.

The Preference name and value options are tentative and I'm open to suggestions on alternatives. Another idea was something like 'ClassicMode' {On, Off}. Idk