### PR TITLE
respect SELECTABLE:NO in Casual Mode

### DIFF
--- a/BGAnimations/ScreenSelectMusicCasual overlay/Input.lua
+++ b/BGAnimations/ScreenSelectMusicCasual overlay/Input.lua
@@ -204,7 +204,7 @@ t.Handler = function(event)
 
 		--------------------------------------------------------------
 		--------------------------------------------------------------
-		-- handle SSMCasual's custom PlayerPptions menu input
+		-- handle SSMCasual's custom PlayerOptions menu input
 
 		else
 			-- get the index of the active optionrow for this player

--- a/BGAnimations/ScreenSelectMusicCasual overlay/Setup.lua
+++ b/BGAnimations/ScreenSelectMusicCasual overlay/Setup.lua
@@ -4,8 +4,9 @@
 -- The idea is basically to just throw setup-related stuff
 -- in here that we don't want cluttering up default.lua
 ---------------------------------------------------------------------------
+
 -- because no one wants "Invalid PlayMode 7"
-GAMESTATE:SetCurrentPlayMode(0)
+GAMESTATE:SetCurrentPlayMode('PlayMode_Regular')
 
 ---------------------------------------------------------------------------
 -- local junk
@@ -112,7 +113,10 @@ local PruneSongsFromGroup = function(group)
 		-- this should be guaranteed by this point, but better safe than segfault
 		if song:HasStepsType(steps_type)
 		-- respect StepMania's cutoff for 1-round songs
-		and song:MusicLengthSeconds() < PREFSMAN:GetPreference("LongVerSongSeconds") then
+		and song:MusicLengthSeconds() < PREFSMAN:GetPreference("LongVerSongSeconds")
+		-- respect the #SELECTABLE tag in this song's simfile
+		and UNLOCKMAN:IsSongLocked(song) == 0
+		then
 			-- ensure that at least one stepchart has a meter ≤ CasualMaxMeter (10, by default)
 			for steps in ivalues(song:GetStepsByStepsType(steps_type)) do
 				if steps:GetMeter() <= ThemePrefs.Get("CasualMaxMeter") then


### PR DESCRIPTION
This fixes Casual Mode to not show songs that are considered "locked" by StepMania.  This includes one or more of:

  * `#SELECTABLE:NO` is set in the simfile and StepMania's HiddenSongs preference is enabled.
  * the song is locked using `UNLOCKMAN`
  * the song is disabled via *ScreenOptionsToggleSongs*

`UNLOCKMAN:SongIsLocked(song)` will return an int between 0 to 15 inclusive, the result of bitwise ORing powers-of-2 representing reasons a song could be locked, defined in UnlockManager.h.

references:
* reasons a song could be locked: https://github.com/stepmania/stepmania/blob/d10f433de0a82d6df89d6f6cc860680de28bb4a9/src/UnlockManager.h#L102-L113
* bitwise OR in `UNLOCKMAN:SongIsLocked` https://github.com/stepmania/stepmania/blob/d10f433de0a82d6df89d6f6cc860680de28bb4a9/src/UnlockManager.cpp#L142-L162


`0` will be returned if song is not locked for any reason, so let's ensure `UNLOCKMAN:SongIsLocked(song)` returns 0 in ScreenSelectMusicCasual.  If not, prune the song.

---

While I was in SSMC's setup.lua, I replaced `GAMESTATE:SetCurrentPlayMode(0)` with `GAMESTATE:SetCurrentPlayMode('PlayMode_Regular')`, as I understand enums better now and think using the string value in Lua conveys what it is doing more clearly.

https://quietly-turning.github.io/Lua-For-SM5/LuaAPI#Enums-PlayMode

---

This resolves #428.