### PR TITLE
PeakNPS AND DateTime are hard to see during HolidayCheer()

### DIFF
--- a/BGAnimations/ScreenEvaluation decorations.lua
+++ b/BGAnimations/ScreenEvaluation decorations.lua
@@ -51,7 +51,7 @@ af[#af+1] = LoadFont("Wendy/_wendy monospace numbers")..{
 		end
 
 		local textColor = Color.White
-		if ThemePrefs.Get("RainbowMode") then
+		if ThemePrefs.Get("RainbowMode") and not HolidayCheer() then
 			textColor = Color.Black
 		end
 

--- a/BGAnimations/ScreenSelectMusic overlay/PerPlayer/DensityGraph.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/PerPlayer/DensityGraph.lua
@@ -107,9 +107,8 @@ af2[#af2+1] = LoadFont("Common Normal")..{
 		else
 			self:addx(-136):addy(-41)
 		end
-
-		-- We want black text in Rainbow mode, white otherwise.
-		self:diffuse(ThemePrefs.Get("RainbowMode") and {0, 0, 0, 1} or {1, 1, 1, 1})
+		-- We want black text in Rainbow mode except during HolidayCheer(), white otherwise.
+		self:diffuse((ThemePrefs.Get("RainbowMode") and not HolidayCheer()) and {0, 0, 0, 1} or {1, 1, 1, 1})
 	end,
 	HideCommand=function(self)
 		self:settext("Peak NPS: ")


### PR DESCRIPTION
Peak NPS and the Date on the Evaluation screen are pretty hard to see during December when in Rainbow mode. Due to the background and the text changing to black because of rainbow mode. I've included a few screenshots to show:

![image](https://user-images.githubusercontent.com/30600688/209739154-1efcd8e4-b029-4374-be6f-92e4f438c484.png)
![image](https://user-images.githubusercontent.com/30600688/209739231-fbbe3f71-9c16-42f5-9b82-8ce32a5e8391.png)

This PR is pretty small but it just makes it so they don't change to black when RainbowMode is active during HolidayCheer(). Following shows what it would look like

![image](https://user-images.githubusercontent.com/30600688/209739263-f63d84cc-c8d4-4374-b687-7a147cc88e6c.png)
