### PR TITLE
Toggle between DensityGraph and PatternInfo in ScreenSelectMusic

### DIFF
--- a/BGAnimations/ScreenSelectMusic overlay/PerPlayer/DensityGraph.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/PerPlayer/DensityGraph.lua
@@ -272,7 +272,7 @@ for i, row in ipairs(layout) do
 				if col == "Total Stream" then
 					self:maxwidth(100)
 				end
-				self:xy(-width/2 + 40, -height/2 + 10)
+				self:xy(-width/2 + 40, -height/2 + 13)
 				self:addx((j-1)*colSpacing)
 				self:addy((i-1)*rowSpacing)
 			end,
@@ -305,7 +305,7 @@ for i, row in ipairs(layout) do
 				local textHeight = 17
 				local textZoom = 0.8
 				self:maxwidth(width/textZoom):zoom(textZoom):horizalign(left)
-				self:xy(-width/2 + 50, -height/2 + 10)
+				self:xy(-width/2 + 50, -height/2 + 13)
 				self:addx((j-1)*colSpacing)
 				self:addy((i-1)*rowSpacing)
 			end,

--- a/BGAnimations/ScreenSelectMusic overlay/PerPlayer/DensityGraph.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/PerPlayer/DensityGraph.lua
@@ -5,9 +5,6 @@ if GAMESTATE:IsCourseMode() then return end
 local player = ...
 local pn = ToEnumShortString(player)
 
--- In 2-players mode, whether the DensityGraph or PatternInfo is shown
--- Can be toggled by the code "ToggleChartInfo" in metrics.ini
-local showPatternInfo = false
 -- Height and width of the density graph.
 local height = 64
 local width = IsUsingWideScreen() and 286 or 276
@@ -42,14 +39,11 @@ local af = Def.ActorFrame{
 	end,
 	CodeMessageCommand=function(self, params)
 		-- Toggle between the density graph and the pattern info
-		if params.Name == "ToggleChartInfo" and params.PlayerNumber == player then
-			-- Only do so if there are 2 players joined
-			if GAMESTATE:GetNumSidesJoined() ~= 1 then
-				if showPatternInfo then
-					self:queuecommand("ShowInfo")
-				else
-					self:queuecommand("HideInfo")
-				end
+		if params.Name == "TogglePatternInfo" and params.PlayerNumber == player then
+			-- Only need to toggle in versus since in single player modes, both
+			-- panes are already displayed.
+			if GAMESTATE:GetNumSidesJoined() == 2 then
+				self:queuecommand("TogglePatternInfo")
 			end
 		end
 	end,
@@ -112,13 +106,8 @@ af2[#af2+1] = NPS_Histogram(player, width, height)..{
 	RedrawCommand=function(self)
 		self:visible(true)
 	end,
-	ShowInfoCommand=function(self)
-		self:queuecommand("Hide")
-		showPatternInfo = false
-	end,
-	HideInfoCommand=function(self)
-		self:queuecommand("Redraw")
-		showPatternInfo = true
+	TogglePatternInfoCommand=function(self)
+		self:visible(not self:GetVisible())
 	end
 }
 -- Don't let the density graph parse the chart.
@@ -150,11 +139,8 @@ af2[#af2+1] = LoadFont("Common Normal")..{
 			self:visible(true)
 		end
 	end,
-	ShowInfoCommand=function(self)
-		self:queuecommand("Hide")
-	end,
-	HideInfoCommand=function(self)
-		self:queuecommand("Redraw")
+	TogglePatternInfoCommand=function(self)
+		self:visible(not self:GetVisible())
 	end
 }
 
@@ -171,11 +157,8 @@ af2[#af2+1] = Def.ActorFrame{
 	RedrawCommand=function(self)
 		self:visible(true)
 	end,
-	ShowInfoCommand=function(self)
-		self:queuecommand("Hide")
-	end,
-	HideInfoCommand=function(self)
-		self:queuecommand("Redraw")
+	TogglePatternInfoCommand=function(self)
+		self:visible(not self:GetVisible())
 	end,
 	Def.Quad{
 		InitCommand=function(self)
@@ -210,7 +193,7 @@ af2[#af2+1] = Def.ActorFrame{
 af2[#af2+1] = Def.ActorFrame{
 	Name="PatternInfo",
 	InitCommand=function(self)
-		if GAMESTATE:GetNumSidesJoined() ~= 1 then
+		if GAMESTATE:GetNumSidesJoined() == 2 then
 			self:y(0)
 		else
 			self:y(88)
@@ -219,7 +202,7 @@ af2[#af2+1] = Def.ActorFrame{
 	end,
 	PlayerJoinedMessageCommand=function(self, params)
 		self:visible(GAMESTATE:GetNumSidesJoined() == 1)
-		if GAMESTATE:GetNumSidesJoined() ~= 1 then
+		if GAMESTATE:GetNumSidesJoined() == 2 then
 			self:y(0)
 		else
 			self:y(88)
@@ -227,17 +210,14 @@ af2[#af2+1] = Def.ActorFrame{
 	end,
 	PlayerUnjoinedMessageCommand=function(self, params)
 		self:visible(GAMESTATE:GetNumSidesJoined() == 1)
-		if GAMESTATE:GetNumSidesJoined() ~= 1 then
+		if GAMESTATE:GetNumSidesJoined() == 2 then
 			self:y(0)
 		else
 			self:y(88)
 		end
 	end,
-	ShowInfoCommand=function(self)
-		self:visible(true)
-	end,
-	HideInfoCommand=function(self)
-		self:visible(false)
+	TogglePatternInfoCommand=function(self)
+		self:visible(not self:GetVisible())
 	end,
 	
 	-- Background for the additional chart info.

--- a/metrics.ini
+++ b/metrics.ini
@@ -1532,10 +1532,11 @@ TimerSeconds=SL.Global.MenuTimer.ScreenSelectMusicCasual
 PrevScreen=Branch.SSMCancel()
 NextScreen=Branch.AfterSelectMusic()
 
-CodeNames="SortList,SortList2,SortList3,EscapeFromEventMode"
+CodeNames="SortList,SortList2,SortList3,EscapeFromEventMode,ToggleChartInfo"
 CodeSortList="@Select-Start"
 CodeSortList2=PREFSMAN:GetPreference("OnlyDedicatedMenuButtons") and "MenuLeft-MenuRight" or GAMESTATE:GetCurrentGame():GetName() == "pump" and "DownLeft-DownRight"
 CodeSortList3=not PREFSMAN:GetPreference("OnlyDedicatedMenuButtons") and "Left-Right" or ""
+CodeToggleChartInfo="Select,Select"
 CodeEscapeFromEventMode=PREFSMAN:GetPreference("EventMode") and "MenuLeft,MenuLeft,MenuRight,MenuRight,MenuLeft,MenuLeft,MenuRight,MenuRight" or ""
 
 # this allows us to override the normal sort select command

--- a/metrics.ini
+++ b/metrics.ini
@@ -1532,11 +1532,11 @@ TimerSeconds=SL.Global.MenuTimer.ScreenSelectMusicCasual
 PrevScreen=Branch.SSMCancel()
 NextScreen=Branch.AfterSelectMusic()
 
-CodeNames="SortList,SortList2,SortList3,EscapeFromEventMode,ToggleChartInfo"
+CodeNames="SortList,SortList2,SortList3,EscapeFromEventMode,TogglePatternInfo"
 CodeSortList="@Select-Start"
 CodeSortList2=PREFSMAN:GetPreference("OnlyDedicatedMenuButtons") and "MenuLeft-MenuRight" or GAMESTATE:GetCurrentGame():GetName() == "pump" and "DownLeft-DownRight"
 CodeSortList3=not PREFSMAN:GetPreference("OnlyDedicatedMenuButtons") and "Left-Right" or ""
-CodeToggleChartInfo="Select,Select"
+CodeTogglePatternInfo="Select,Select"
 CodeEscapeFromEventMode=PREFSMAN:GetPreference("EventMode") and "MenuLeft,MenuLeft,MenuRight,MenuRight,MenuLeft,MenuLeft,MenuRight,MenuRight" or ""
 
 # this allows us to override the normal sort select command


### PR DESCRIPTION
This adds a toggle between the densitygraph and the tech display on the selectmusic screen when in two player mode. 

Open to any changes with this, but rn you double tap Select and it will switch between them. Previous behavior was that in Two player mode you were locked into only seeing the DensityGraph.