### PR TITLE
4:3 aspect ratio tidy-up

### DIFF
--- a/BGAnimations/ScreenSelectMusic overlay/PaneDisplay.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/PaneDisplay.lua
@@ -8,7 +8,7 @@ local footer_height = 32
 -- height of the PaneDisplay in pixels
 local pane_height = 60
 
-local text_zoom = WideScale(0.8, 0.9)
+local text_zoom = IsUsingWideScreen() and WideScale(0.8, 0.9) or WideScale(0.7, 0.8)
 
 -- -----------------------------------------------------------------------
 -- Convenience function to return the SongOrCourse and StepsOrTrail for a
@@ -189,12 +189,20 @@ end
 
 -- -----------------------------------------------------------------------
 -- define the x positions of four columns, and the y positions of three rows of PaneItems
-local pos = {
-	col = { WideScale(-104,-133), WideScale(-36,-38), WideScale(54,76), WideScale(150, 190) },
-	row = { 13, 31, 49 }
-}
 
-local num_rows = 3
+local pos = {}
+pos.row = { 13, 31, 49 }
+
+if IsUsingWideScreen() then
+	-- five columns
+	pos.col = { WideScale(-104,-133), WideScale(-36,-38), WideScale(54,76), WideScale(150, 190) }
+
+else
+	-- four columns
+	pos.col = { WideScale(-104,-133), WideScale(-36,-38), WideScale(54,76), WideScale(150, 190)   }
+end
+
+
 local num_cols = 2
 
 -- HighScores handled as special cases for now until further refactoring
@@ -218,7 +226,7 @@ local PaneItems = {
 -- -----------------------------------------------------------------------
 local af = Def.ActorFrame{ Name="PaneDisplayMaster" }
 
-af[#af+1] = RequestResponseActor("GetScores", 10, 17, 50)..{
+af[#af+1] = RequestResponseActor("GetScores", 10, IsUsingWideScreen() and 17 or _screen.cx+10, 50)..{
 	OnCommand=function(self)
 		-- Create variables for both players, even if they're not currently active.
 		self.IsParsing = {false, false}

--- a/BGAnimations/ScreenSelectMusic overlay/PerPlayer/DensityGraph.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/PerPlayer/DensityGraph.lua
@@ -7,12 +7,12 @@ local pn = ToEnumShortString(player)
 
 -- Height and width of the density graph.
 local height = 64
-local width = IsUsingWideScreen() and 286 or 276
+local width = IsUsingWideScreen() and 286 or 268
 
 local af = Def.ActorFrame{
 	InitCommand=function(self)
-		self:visible( GAMESTATE:IsHumanPlayer(player) )
-		self:xy(_screen.cx-182, _screen.cy+23)
+		self:visible(GAMESTATE:IsHumanPlayer(player))
+		self:xy(IsUsingWideScreen() and  _screen.cx-182 or  _screen.cx-176, _screen.cy+23)
 
 		if player == PLAYER_2 then
 			self:addy(height+24)
@@ -30,6 +30,7 @@ local af = Def.ActorFrame{
 	PlayerUnjoinedMessageCommand=function(self, params)
 		if params.Player == player then
 			self:visible(false)
+
 		end
 	end,
 }
@@ -211,7 +212,7 @@ for i, row in ipairs(layout) do
 			Name=col .. "Value",
 			InitCommand=function(self)
 				local textHeight = 17
-				local textZoom = 0.8
+				local textZoom = IsUsingWideScreen() and 0.8 or 0.75 
 				self:zoom(textZoom):horizalign(right)
 				if col == "Total Stream" then
 					self:maxwidth(100)
@@ -247,7 +248,7 @@ for i, row in ipairs(layout) do
 			Name=col,
 			InitCommand=function(self)
 				local textHeight = 17
-				local textZoom = 0.8
+				local textZoom = IsUsingWideScreen() and 0.8 or 0.75 
 				self:maxwidth(width/textZoom):zoom(textZoom):horizalign(left)
 				self:xy(-width/2 + 50, -height/2 + 10)
 				self:addx((j-1)*colSpacing)

--- a/BGAnimations/ScreenSelectMusic overlay/PerPlayer/StepArtist.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/PerPlayer/StepArtist.lua
@@ -37,20 +37,20 @@ return Def.ActorFrame{
 		if player == PLAYER_1 then
 
 			if GAMESTATE:IsCourseMode() then
-				self:x( _screen.cx - (IsUsingWideScreen() and 356 or 346))
+				self:x( _screen.cx - (IsUsingWideScreen() and 356 or 337))
 				self:y(_screen.cy + 32)
 			else
-				self:x( _screen.cx - (IsUsingWideScreen() and 356 or 346))
+				self:x( _screen.cx - (IsUsingWideScreen() and 356 or 337))
 				self:y(_screen.cy + 12)
 			end
 
 		elseif player == PLAYER_2 then
 
 			if GAMESTATE:IsCourseMode() then
-				self:x( _screen.cx - 210)
+				self:x( _screen.cx - (IsUsingWideScreen() and 210 or 208))
 				self:y(_screen.cy + 85)
 			else
-				self:x( _screen.cx - 244)
+				self:x( _screen.cx - (IsUsingWideScreen() and 244 or 242))
 				self:y(_screen.cy + 40)
 			end
 		end

--- a/BGAnimations/ScreenSelectMusic overlay/SongDescription/SongDescription.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SongDescription/SongDescription.lua
@@ -2,11 +2,11 @@ local MusicWheel, SelectedType
 local group_durations = LoadActor("./GroupDurations.lua")
 
 -- width of background quad
-local _w = IsUsingWideScreen() and 320 or 310
+local _w = IsUsingWideScreen() and 320 or 303
 
 local af = Def.ActorFrame{
 	OnCommand=function(self)
-		self:xy(_screen.cx - (IsUsingWideScreen() and 170 or 165), _screen.cy - 55)
+		self:xy(_screen.cx - (IsUsingWideScreen() and 170 or 160), _screen.cy - 55)
 	end,
 
 	CurrentSongChangedMessageCommand=function(self)    self:playcommand("Set") end,
@@ -29,7 +29,7 @@ af[#af+1] = Def.Quad{
 
 -- ActorFrame for Artist, BPM, and Song length
 af[#af+1] = Def.ActorFrame{
-	InitCommand=function(self) self:xy(-110,-6) end,
+	InitCommand=function(self) self:xy(IsUsingWideScreen() and -110 or -95,-6) end,
 
 	-- ----------------------------------------
 	-- Artist Label

--- a/BGAnimations/ScreenSelectMusic overlay/StepsDisplayList/CourseContentsList.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/StepsDisplayList/CourseContentsList.lua
@@ -36,7 +36,7 @@ end
 
 local af = Def.ActorFrame{
 	InitCommand=function(self)
-		self:xy(_screen.cx-170, _screen.cy + 28)
+		self:xy(_screen.cx- (IsUsingWideScreen() and 170 or 160), _screen.cy + 28)
 	end,
 
 	---------------------------------------------------------------------
@@ -52,7 +52,7 @@ local af = Def.ActorFrame{
 	-- lower mask
 	Def.Quad{
 		InitCommand=function(self)
-			self:xy(IsUsingWideScreen() and -44 or 0,98)
+			self:xy(IsUsingWideScreen() and -44 or 90,98)
 				:zoomto(_screen.w/2, 40)
 				:MaskSource()
 		end
@@ -72,7 +72,8 @@ local af = Def.ActorFrame{
 	-- gray background Quad
 	Def.Quad{
 		InitCommand=function(self)
-			self:diffuse(color("#1e282f")):zoomto(320, 96)
+			
+			self:diffuse(color("#1e282f")):zoomto(IsUsingWideScreen() and 320 or 303, 96)
 				:xy(0, 30)
 
 			if ThemePrefs.Get("RainbowMode") then
@@ -91,8 +92,8 @@ af[#af+1] = Def.CourseContentsList {
 	NumItemsToDraw=numItemsToDraw,
 
 	InitCommand=function(self)
-		self:xy(40,-4)
-			:SetUpdateFunction( update )
+		self:xy(IsUsingWideScreen() and 40 or 40,-4)
+			:SetUpdateFunction( update ):zoom(IsUsingWideScreen() and 1 or 0.95)
 	end,
 
 	CurrentTrailP1ChangedMessageCommand=function(self) self:playcommand("Set") end,

--- a/BGAnimations/ScreenSelectMusic overlay/StepsDisplayList/Grid.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/StepsDisplayList/Grid.lua
@@ -7,7 +7,7 @@ local GetStepsToDisplay = LoadActor("./StepsToDisplay.lua")
 
 local t = Def.ActorFrame{
 	Name="StepsDisplayList",
-	InitCommand=function(self) self:xy(_screen.cx-26, _screen.cy + 67) end,
+	InitCommand=function(self) self:xy(IsUsingWideScreen() and _screen.cx-26 or _screen.cx-24 , _screen.cy + 67) end,
 
 	OnCommand=function(self)                           self:queuecommand("RedrawStepsDisplay") end,
 	CurrentSongChangedMessageCommand=function(self)    self:queuecommand("RedrawStepsDisplay") end,

--- a/BGAnimations/ScreenSelectMusic overlay/banner.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/banner.lua
@@ -9,8 +9,8 @@ local t = Def.ActorFrame{
 			self:zoom(0.7655)
 			self:xy(_screen.cx - 170, 96)
 		else
-			self:zoom(0.75)
-			self:xy(_screen.cx - 166, 96)
+			self:zoom(0.72)
+			self:xy(_screen.cx - 160, 96)
 		end
 	end
 }


### PR DESCRIPTION
4:3 was a bit cluttered together, both in Regular and Marathon mode. This commit aims to tidy it up a bit.

### Before:
![4-3Before](https://user-images.githubusercontent.com/30600688/209750370-5d392488-13fc-4642-be07-e1ad75356d17.png)
![image](https://user-images.githubusercontent.com/30600688/209750629-b5764ea2-6b7e-4f08-a278-9ec243b875c5.png)

<br><br>

### After:
![4-3After](https://user-images.githubusercontent.com/30600688/209750392-e3939c29-8830-4634-b01a-00caa9e763db.png)
![image](https://user-images.githubusercontent.com/30600688/209750685-968f3f4d-2813-4c85-9a89-02eade0dbd08.png)
