### PR TITLE
Move course mode check from IsServiceAllowed to AutoSubmitScore

### DIFF
--- a/BGAnimations/ScreenEvaluation common/Shared/AutoSubmitScore.lua
+++ b/BGAnimations/ScreenEvaluation common/Shared/AutoSubmitScore.lua
@@ -1,4 +1,4 @@
-if not IsServiceAllowed(SL.GrooveStats.AutoSubmit) then return end
+if not IsServiceAllowed(SL.GrooveStats.AutoSubmit) or GAMESTATE:IsCourseMode() then return end
 
 local NumEntries = 10
 

--- a/Scripts/SL-Helpers-GrooveStats.lua
+++ b/Scripts/SL-Helpers-GrooveStats.lua
@@ -224,13 +224,12 @@ end
 --  - We must be in the "dance" game mode (not "pump", etc)
 --  - We must be in either ITG or FA+ mode.
 --  - At least one Api Key must be available (this condition may be relaxed in the future)
---  - We must not be in course mode.
+--  - We must not be in course mode (ZANKOKU: moving this specific check to autosubmitscore instead, since otherwise it blocks scorebox when playing course mode).
 IsServiceAllowed = function(condition)
 	return (condition and
 		GAMESTATE:GetCurrentGame():GetName()=="dance" and
 		(SL.Global.GameMode == "ITG" or SL.Global.GameMode == "FA+") and
-		(SL.P1.ApiKey ~= "" or SL.P2.ApiKey ~= "") and
-		not GAMESTATE:IsCourseMode())
+		(SL.P1.ApiKey ~= "" or SL.P2.ApiKey ~= ""))
 end
 
 -- -----------------------------------------------------------------------


### PR DESCRIPTION
Performing the check for course mode blocks the GrooveStats scorebox from appearing during individual songs being played in courses, so this conditional should just be moved to AutoSubmitScore, which is the only place where that check matters.