### PR TITLE
use IsAction attr on ActorSounds more consistently

### DIFF
--- a/BGAnimations/ScreenNameEntryTraditional underlay/default.lua
+++ b/BGAnimations/ScreenNameEntryTraditional underlay/default.lua
@@ -202,10 +202,10 @@ for player in ivalues(Players) do
 end
 
 -- ActorSounds
-t[#t+1] = LoadActor( THEME:GetPathS("", "_change value"))..{ Name="delete", SupportPan = true }
-t[#t+1] = LoadActor( THEME:GetPathS("Common", "start"))..{ Name="enter", SupportPan = true }
-t[#t+1] = LoadActor( THEME:GetPathS("MusicWheel", "change"))..{ Name="move", SupportPan = true }
-t[#t+1] = LoadActor( THEME:GetPathS("common", "invalid"))..{ Name="invalid", SupportPan = true }
+t[#t+1] = LoadActor( THEME:GetPathS("", "_change value"))..{    Name="delete",  IsAction=true, SupportPan=true }
+t[#t+1] = LoadActor( THEME:GetPathS("Common", "start"))..{      Name="enter",   IsAction=true, SupportPan=true }
+t[#t+1] = LoadActor( THEME:GetPathS("MusicWheel", "change"))..{ Name="move",    IsAction=true, SupportPan=true }
+t[#t+1] = LoadActor( THEME:GetPathS("common", "invalid"))..{    Name="invalid", IsAction=true, SupportPan=true }
 
 --
 return t

--- a/BGAnimations/ScreenPlayAgain underlay.lua
+++ b/BGAnimations/ScreenPlayAgain underlay.lua
@@ -178,7 +178,7 @@ local t = Def.ActorFrame{
 
 }
 
-t[#t+1] = LoadActor( THEME:GetPathS("ScreenSelectMaster", "change") )..{ Name="change_sound", SupportPan = false }
-t[#t+1] = LoadActor( THEME:GetPathS("common", "start") )..{ Name="start_sound", SupportPan = false }
+t[#t+1] = LoadActor( THEME:GetPathS("ScreenSelectMaster", "change") )..{ Name="change_sound", IsAction=true, SupportPan = false }
+t[#t+1] = LoadActor( THEME:GetPathS("common", "start") )..{ Name="start_sound", IsAction=true, SupportPan = false }
 
 return t

--- a/BGAnimations/ScreenPromptToResetPreferencesToStock overlay.lua
+++ b/BGAnimations/ScreenPromptToResetPreferencesToStock overlay.lua
@@ -113,6 +113,7 @@ t[#t+1] = choices_af
 
 -- sound effect
 t[#t+1] = LoadActor( THEME:GetPathS("ScreenSelectMaster", "change") )..{
+	IsAction=true,
 	DirectionButtonCommand=function(self) self:play() end
 }
 

--- a/BGAnimations/ScreenPromptToSetSrpgVisualStyle overlay.lua
+++ b/BGAnimations/ScreenPromptToSetSrpgVisualStyle overlay.lua
@@ -97,6 +97,7 @@ t[#t+1] = choices_af
 
 -- sound effect
 t[#t+1] = LoadActor( THEME:GetPathS("ScreenSelectMaster", "change") )..{
+	IsAction=true,
 	DirectionButtonCommand=function(self) self:play() end
 }
 

--- a/BGAnimations/ScreenSelectColor underlay.lua
+++ b/BGAnimations/ScreenSelectColor underlay.lua
@@ -229,7 +229,7 @@ if style == "SRPG6" then
 	}
 end
 
-t[#t+1] = LoadActor( THEME:GetPathS("ScreenSelectMaster", "change") )..{ Name="change_sound", SupportPan = false }
-t[#t+1] = LoadActor( THEME:GetPathS("common", "start") )..{ Name="start_sound", SupportPan = false }
+t[#t+1] = LoadActor( THEME:GetPathS("ScreenSelectMaster", "change") )..{ Name="change_sound", IsAction=true, SupportPan=false }
+t[#t+1] = LoadActor( THEME:GetPathS("common", "start") )..{ Name="start_sound", IsAction=true, SupportPan=false }
 
 return t

--- a/BGAnimations/ScreenSelectMusic overlay/EscapeFromEventMode.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/EscapeFromEventMode.lua
@@ -104,8 +104,8 @@ local af = Def.ActorFrame{
 }
 
 -- sound effects
-af[#af+1] = Def.Sound{ File=THEME:GetPathS("ScreenSelectMaster", "change"), InitCommand=function(self) sfx.change = self end }
-af[#af+1] = Def.Sound{ File=THEME:GetPathS("Common", "Start"), InitCommand=function(self) sfx.start = self end }
+af[#af+1] = Def.Sound{ File=THEME:GetPathS("ScreenSelectMaster", "change"), IsAction=true, InitCommand=function(self) sfx.change = self end }
+af[#af+1] = Def.Sound{ File=THEME:GetPathS("Common", "Start"),              IsAction=true, InitCommand=function(self) sfx.start  = self end }
 
 -- darkened background
 af[#af+1] = Def.Quad{ InitCommand=function(self) self:FullScreen():diffuse(0,0,0,0.925) end }

--- a/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
@@ -402,6 +402,6 @@ local t = Def.ActorFrame {
 	-- this returns an ActorFrame ( see: ./Scripts/Consensual-sick_wheel.lua )
 	sort_wheel:create_actors( "Sort Menu", 7, wheel_item_mt, _screen.cx, _screen.cy )
 }
-t[#t+1] = LoadActor( THEME:GetPathS("ScreenSelectMaster", "change") )..{ Name="change_sound", SupportPan = false }
-t[#t+1] = LoadActor( THEME:GetPathS("common", "start") )..{ Name="start_sound", SupportPan = false }
+t[#t+1] = LoadActor( THEME:GetPathS("ScreenSelectMaster", "change") )..{ Name="change_sound", IsAction=true, SupportPan=false }
+t[#t+1] = LoadActor( THEME:GetPathS("common", "start") )..{ Name="start_sound", IsAction=true, SupportPan=false }
 return t

--- a/BGAnimations/ScreenSelectProfile underlay/default.lua
+++ b/BGAnimations/ScreenSelectProfile underlay/default.lua
@@ -222,21 +222,25 @@ local t = Def.ActorFrame {
 
 	-- sounds
 	LoadActor( THEME:GetPathS("Common", "start") )..{
+		IsAction=true,
 		StartButtonMessageCommand=function(self) self:play() end
 	},
 	LoadActor( THEME:GetPathS("ScreenSelectMusic", "select down") )..{
+		IsAction=true,
 		BackButtonMessageCommand=function(self) self:play() end
 	},
 	LoadActor( THEME:GetPathS("ScreenSelectMaster", "change") )..{
+		IsAction=true,
 		DirectionButtonMessageCommand=function(self)
 			self:play()
 			if invalid_count then invalid_count = 0 end
 		end
 	},
 	LoadActor( THEME:GetPathS("Common", "invalid") )..{
+		IsAction=true,
 		InvalidChoiceMessageCommand=function(self)
 			self:play()
-			if invalid_count then
+			if PREFSMAN:GetPreference("EasterEggs") and invalid_count then
 				invalid_count = invalid_count + 1
 				if invalid_count >= 10 then MESSAGEMAN:Broadcast("What"); invalid_count = nil end
 			end

--- a/BGAnimations/ScreenSelectStyle underlay/default.lua
+++ b/BGAnimations/ScreenSelectStyle underlay/default.lua
@@ -313,7 +313,7 @@ for i,choice in ipairs(choices) do
 	t[#t+1] = LoadActor("./choice.lua", {choice, i} )
 end
 
-t[#t+1] = LoadActor( THEME:GetPathS("ScreenSelectMaster", "change") )..{ Name="Change", SupportPan=false }
-t[#t+1] = LoadActor( THEME:GetPathS("common", "start") )..{ Name="Start", SupportPan=false }
+t[#t+1] = LoadActor( THEME:GetPathS("ScreenSelectMaster", "change") )..{ Name="Change", IsAction=true, SupportPan=false }
+t[#t+1] = LoadActor( THEME:GetPathS("common", "start") )..{ Name="Start", IsAction=true, SupportPan=false }
 
 return t

--- a/BGAnimations/_prompt in instant.lua
+++ b/BGAnimations/_prompt in instant.lua
@@ -1,3 +1,4 @@
 return LoadActor(THEME:GetPathS("", "_prompt"))..{
+	IsAction=true,
 	StartTransitioningCommand=function(self) self:play() end
 }

--- a/BGAnimations/_prompt in normal.lua
+++ b/BGAnimations/_prompt in normal.lua
@@ -1,4 +1,5 @@
 return LoadActor(THEME:GetPathS("", "_prompt"))..{
+	IsAction=true,
 	OnCommand=function(self) self:sleep(0.3) end,
 	StartTransitioningCommand=function(self) self:play() end
 }


### PR DESCRIPTION
# Context
StepMania has a `MuteActions` preference, added in [8993cfe729](https://github.com/stepmania/stepmania/commit/8993cfe729c5a6f24e6d3a928879e03c3fabe00f), which silences sound effects handled by the StepMania engine if `true`.  `MuteActions` can be toggled at any time with <kbd>F3</kbd>+<kbd>A</kbd>.

In Lua, ActorSounds can have a boolean attribute `IsAction` which designates that ActorSound as a sound effect for the engine's `MuteActions` preference.

Simply Love uses ActorSounds for sound effects in several screens, typically those that rely heavily on Lua for UX (as opposed to relying on the engine). For example, ScreenSelectProfile has 4 ActorSounds that act as "theme sound effects."

# Bug + Fix

Most of Simply Love's ActorSounds did not have the `IsAction` attribute set, resulting in an inconsistent user experience when `MuteActions` was enabled  — sound effects managed by the engine were muted, while sound effects managed by SL continued to play.  This was an oversight on my part; I'm just catching it now.

This PR adds `IsAction=true` to all of SL's ActorSounds that can be thought of as "theme sound effects."  A handful of SL's ActorSounds (EasterEggs, dynamic BGM) aren't normal UX sound effects, and I've left those alone here.

To test, use <kbd>F3</kbd>+<kbd>A</kbd> to toggle `MuteActions` on ScreenSelectProfile, or ScreenNameEntryTraditional.