### PR TITLE
bugfix: always reassess SortMenu's choices before opening

### DIFF
--- a/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
@@ -30,8 +30,6 @@ local leaderboard_input = LoadActor("Leaderboard_InputHandler.lua")
 local wheel_item_mt = LoadActor("WheelItemMT.lua")
 local sortmenu = { w=210, h=160 }
 
-local hasSong = GAMESTATE:GetCurrentSong() and true or false
-
 local FilterTable = function(arr, func)
 	local new_index = 1
 	local size_orig = #arr
@@ -177,19 +175,6 @@ local t = Def.ActorFrame {
 	OffCommand=function(self) self:playcommand("DirectInputToEngine") end,
 	-- Figure out which choices to put in the SortWheel based on various current conditions.
 	OnCommand=function(self) self:playcommand("AssessAvailableChoices") end,
-	-- We'll want to (re)assess available choices in the SortMenu if a player late-joins
-	PlayerJoinedMessageCommand=function(self, params) self:queuecommand("AssessAvailableChoices") end,
-	-- We'll also (re)asses if we want to display the leaderboard depending on if we're actually hovering over a song.
-	CurrentSongChangedMessageCommand=function(self)
-		if IsServiceAllowed(SL.GrooveStats.Leaderboard) then
-			local curSong = GAMESTATE:GetCurrentSong()
-			-- Only reasses if we go from song->group or group->song
-			if (curSong and not hasSong) or (not curSong and hasSong) then
-				self:queuecommand("AssessAvailableChoices")
-			end
-			hasSong = curSong and true or false
-		end
-	end,
 	ShowSortMenuCommand=function(self) self:visible(true) end,
 	HideSortMenuCommand=function(self) self:visible(false) end,
 	DirectInputToSortMenuCommand=function(self)
@@ -201,7 +186,7 @@ local t = Def.ActorFrame {
 		for player in ivalues(PlayerNumber) do
 			SCREENMAN:set_input_redirected(player, true)
 		end
-		self:playcommand("ShowSortMenu")
+		self:queuecommand("AssessAvailableChoices"):queuecommand("ShowSortMenu")
 		overlay:playcommand("HideTestInput")
 		overlay:playcommand("HideLeaderboard")
 	end,


### PR DESCRIPTION
# Bug

In the `itgmania-beta` branch, it's possible to use ScreenSelectMusic's SortMenu to change profiles mid-game-cycle.

If two players are initially joined, and one un-joins using ScreenSelectProfile, the remaining player would not immediately see the option to switch to Double style.  The SortMenu would need to reassess its available options.

## Context

ScreenSelectMusic's "SortMenu" has substantial logic for determining which choices to present to players wrapped up in `AssessAvailableChoicesCommand`

Many situations can occur after SSM's OnCommand in which the SortMenu needs to reassess its choices, for example:
  * if a player late-joins, the option to switch to doubles should be removed
  * if hovering over a song, the option to show the GS Leaderboard should be added
  * if hovering over a group, the option to show the GS Leaderboard should be removed

One additional situation that wasn't previously handled was when:
  1. two players are joined
  2. one of the players un-joins using the SortMenu's access to SelectProfile
  3. the remaining player wishes to then switch to double

The option to switch to double wouldn't immediately be available in the SortMenu, since the list hadn't been reassessed after leaving ScreenSelectProfile.

## Other Possible Fixes

One fix could be to have ScreenSelectProfile's FinishCommand use something like
```lua
MESSAGEMAN:Broadcast("SelectProfileFinish")
```

and have the SortMenu's default.lua listen for that via
```lua
SelectProfileFinishMessageCommand=function(self)
  self:playcommand("AssessAvailableChoices")
end
```

but, that feels like piling on additional special-case code, and the SortMenu already has a lot of that.  

## Fix

The fix I went with is straightforward: have the SortMenu reassess its choices every time just before it shows.

Reassessing the SortMenu's choices isn't a demanding operation, so I think this is fine.  The existing code was likely reassessing more frequently, anyway — every time the MusicWheel scrolled from a song to a group and vice versa — and we can remove that now.