### PR TITLE
Implementation of the player specific playtime statistics

### DIFF
--- a/BGAnimations/ScreenEvaluation common/PerPlayer/Lower/default.lua
+++ b/BGAnimations/ScreenEvaluation common/PerPlayer/Lower/default.lua
@@ -3,6 +3,8 @@
 local player = ...
 local NumPlayers = #GAMESTATE:GetHumanPlayers()
 
+local stats = SessionDataForStatistics(player)
+
 local pane_spacing = 10
 local small_pane_w = 300
 
@@ -30,6 +32,59 @@ local af = Def.ActorFrame{
 		end
 	end
 }
+
+if IsUsingWideScreen() then 
+	af[#af+1] = LoadFont("Common Normal").. {
+		Name="Steps",
+		Text=(""),
+
+		InitCommand=function(self)
+			local align   = (player==PLAYER_1 and right or left)
+			local stats_position_x   = 0
+			local right_side_offset = 0
+			local left_side_offset = 0
+
+			if NumPlayers == 2 or SL.Global.GameMode == "Casual" then 
+				left_side_offset = small_pane_w * -0.5
+				right_side_offset =  small_pane_w * 0.5
+				stats_position_x  = (player==PLAYER_1 and left_side_offset or right_side_offset)
+			else
+				left_side_offset = small_pane_w * -0.5
+				right_side_offset =  small_pane_w + pane_spacing + small_pane_w * 0.5
+				stats_position_x  = (player==PLAYER_1 and left_side_offset or right_side_offset)
+			end
+			self:xy(stats_position_x, _screen.h-65):horizalign(align)
+		end,
+
+		ScreenChangedMessageCommand=function(self) self:playcommand("Refresh") end,
+			RefreshCommand=function(self)
+				stats = SessionDataForStatistics(player)
+				if stats.hours < 10 then
+					stats.hours = 0 .. stats.hours
+				end
+				if stats.minutes < 10 then
+					stats.minutes = 0 .. stats.minutes
+				end
+				if stats.notesHitThisGame > 9999 then
+					stats.notesHitThisGame = tonumber(string.format("%.1f", stats.notesHitThisGame/1000)) .. "k"
+				end
+				if player==PLAYER_1 then 
+				self:settext(("%s 👟\n%s:%s ⏱\n%s 💿"):format(
+					stats.notesHitThisGame,
+					stats.hours,
+					stats.minutes,
+					stats.songsPlayedThisGame))
+				else 
+				self:settext(("👟 %s \n⏱ %s:%s\n💿 %s"):format(
+					stats.notesHitThisGame,
+					stats.hours,
+					stats.minutes,
+					stats.songsPlayedThisGame))
+				end
+			end	
+		
+	}
+end
 
 -- -----------------------------------------------------------------------
 -- background quad for player stats

--- a/BGAnimations/ScreenSystemLayer overlay.lua
+++ b/BGAnimations/ScreenSystemLayer overlay.lua
@@ -17,14 +17,49 @@ local function CreditsText( player )
 	return LoadFont("Common Normal") .. {
 		InitCommand=function(self)
 			self:visible(false)
+			self:maxwidth(325)
 			self:name("Credits" .. PlayerNumberToString(player))
 			ActorUtil.LoadAllCommandsAndSetXY(self,Var "LoadingScreen")
 		end,
 		VisualStyleSelectedMessageCommand=function(self) self:playcommand("UpdateVisible") end,
 		UpdateTextCommand=function(self)
 			-- this feels like a holdover from SM3.9 that just never got updated
+			local screen = SCREENMAN:GetTopScreen()
 			local str = ScreenSystemLayerHelpers.GetCreditsMessage(player)
-			self:settext(str)
+			local stats = SessionDataForStatistics(player)
+			if not IsUsingWideScreen() then 
+				self:settext(str)
+			else 
+				if stats.hours < 10 then
+					stats.hours = 0 .. stats.hours
+				end
+				if stats.minutes < 10 then
+					stats.minutes = 0 .. stats.minutes
+				end
+				if stats.notesHitThisGame > 9999 then
+					stats.notesHitThisGame = tonumber(string.format("%.1f", stats.notesHitThisGame/1000)) .. "k"
+				end
+				if (screen:GetName() == "ScreenEvaluationStage") or (screen:GetName() == "ScreenEvaluationNonstop") then
+					self:settext(str)
+				elseif player == PLAYER_1 and stats.songsPlayedThisGame > 0 then
+					self:settext(("%s - 💿 %s | ⏱%s:%s | 👟 %s "):format(
+						str,
+						stats.songsPlayedThisGame,	
+						stats.hours,
+						stats.minutes,
+						stats.notesHitThisGame))
+				elseif player == PLAYER_2 and stats.songsPlayedThisGame > 0 then
+					self:settext((" %s 👟 | %s:%s⏱ | %s 💿 - %s"):format(
+						stats.notesHitThisGame,
+						stats.hours,
+						stats.minutes,
+						stats.songsPlayedThisGame,
+						str))
+				else
+					self:settext(str)
+				end
+			end
+			
 		end,
 		UpdateVisibleCommand=function(self)
 			local screen = SCREENMAN:GetTopScreen()

--- a/BGAnimations/ScreenSystemLayer overlay.lua
+++ b/BGAnimations/ScreenSystemLayer overlay.lua
@@ -1,6 +1,8 @@
 -- This is mostly copy/pasted directly from SM5's _fallback theme with
 -- very minor modifications.
 
+local maxWidth = ((GetScreenAspectRatio() > 21/9) and 420 or 320)
+
 local t = Def.ActorFrame{
 	InitCommand=function(self)
 		-- In case we loaded the theme with SRPG6 and had Rainbow Mode enabled, disable it.
@@ -17,7 +19,7 @@ local function CreditsText( player )
 	return LoadFont("Common Normal") .. {
 		InitCommand=function(self)
 			self:visible(false)
-			self:maxwidth(325)
+			self:maxwidth(maxWidth)
 			self:name("Credits" .. PlayerNumberToString(player))
 			ActorUtil.LoadAllCommandsAndSetXY(self,Var "LoadingScreen")
 		end,

--- a/Scripts/SL_SessionDataForStatistics.lua
+++ b/Scripts/SL_SessionDataForStatistics.lua
@@ -1,0 +1,42 @@
+SessionDataForStatistics = function(player)
+
+    local totalTime = 0
+    local songsPlayedThisGame = 0
+    local notesHitThisGame = 0
+
+    -- Use pairs here (instead of ipairs) because this player might have late-joined
+    -- which will result in nil entries in the the Stats table, which halts ipairs.
+    -- We're just summing total time anyway, so order doesn't matter.
+    for i,stats in pairs( SL[ToEnumShortString(player)].Stages.Stats ) do
+        totalTime = totalTime + (stats and stats.duration or 0)
+        songsPlayedThisGame = songsPlayedThisGame + (stats and 1 or 0)
+
+        if stats and stats.column_judgments then
+            -- increment notesHitThisGame by the total number of tapnotes hit in this particular stepchart by using the per-column data
+            -- don't rely on the engine's non-Miss judgment counts here for two reasons:
+            -- 1. we want jumps/hands to count as more than 1 here
+            -- 2. stepcharts can have non-1 #COMBOS parameters set which would artbitraily inflate notesHitThisGame
+
+            for column, judgments in ipairs(stats.column_judgments) do
+                for judgment, judgment_count in pairs(judgments) do
+                    if judgment ~= "Miss" then
+                        notesHitThisGame = notesHitThisGame + judgment_count
+                    end
+                end
+            end
+        end
+    end
+
+    local hours = math.floor(totalTime/3600)
+    local minutes = math.floor((totalTime-(hours*3600))/60)
+    local seconds = round(totalTime%60)
+
+    return { 
+        totalTime = totalTime, 
+        hours = hours,
+        minutes = minutes, 
+        seconds = seconds, 
+        songsPlayedThisGame = songsPlayedThisGame, 
+        notesHitThisGame = notesHitThisGame }
+
+end


### PR DESCRIPTION
With this feature players can see:

- how much time they have spent actually playing songs
- how many steps they have taken
- how many songs they have played

This feature is widescreen only and will not be shown in 4:3.

Pros:
- You can aim to specific time/song/step count
- Extra motivation to push if you are really close to nice round number

![image](https://user-images.githubusercontent.com/35954453/233454171-87cab96f-967b-4798-b63b-954d0fdb6099.png)

![image](https://user-images.githubusercontent.com/35954453/233454233-c568a985-f5b3-4e4a-81e3-f4baa43232d6.png)

