### PR TITLE
Timing scatterplot and histogram scaling

### DIFF
--- a/BGAnimations/ScreenEvaluation common/Panes/Pane5/default.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane5/default.lua
@@ -11,6 +11,10 @@ local pane_width, pane_height = 300, 180
 local topbar_height = 26
 local bottombar_height = 13
 
+-- Determine timing windows that need to be covered in the histogram based on worst judgment hit during gameplay
+local num_judgments_available = math.max(3, GetWorstJudgment(sequential_offsets))
+local worst_window = GetTimingWindow(num_judgments_available)
+
 -- ---------------------------------------------
 
 local abbreviations = {
@@ -19,7 +23,7 @@ local abbreviations = {
 }
 
 local colors = {}
-for w=NumJudgmentsAvailable(),1,-1 do
+for w=num_judgments_available,1,-1 do
 	if SL.Global.ActiveModifiers.TimingWindows[w]==true then
 		colors[w] = DeepCopy(SL.JudgmentColors[SL.Global.GameMode][w])
 	else
@@ -27,22 +31,6 @@ for w=NumJudgmentsAvailable(),1,-1 do
 		colors[w] = DeepCopy(colors[w+1] or SL.JudgmentColors[SL.Global.GameMode][w+1])
 	end
 end
-
--- ---------------------------------------------
--- if players have disabled W5 or W4+W5, there will be a smaller range
--- of judgments that could have possibly been earned
-local num_judgments_available = NumJudgmentsAvailable()
-local worst_window = GetTimingWindow(num_judgments_available)
-local windows = SL.Global.ActiveModifiers.TimingWindows
-
-for i=NumJudgmentsAvailable(),1,-1 do
-	if windows[i]==true then
-		num_judgments_available = i
-		worst_window = GetTimingWindow(i)
-		break
-	end
-end
-
 
 -- ---------------------------------------------
 -- sequential_offsets is a table of all timing offsets in the order they were earned.

--- a/BGAnimations/ScreenEvaluation common/PerPlayer/Lower/ScatterPlot.lua
+++ b/BGAnimations/ScreenEvaluation common/PerPlayer/Lower/ScatterPlot.lua
@@ -25,16 +25,10 @@ local LastSecond = GAMESTATE:GetCurrentSong():GetLastSecond()
 local Offset, CurrentSecond, TimingWindow, x, y, c, r, g, b
 
 -- ---------------------------------------------
--- if players have disabled W4 or W4+W5, there will be a smaller pool
--- of judgments that could have possibly been earned
-local worst_window = GetTimingWindow(NumJudgmentsAvailable())
-local windows = SL.Global.ActiveModifiers.TimingWindows
-for i=NumJudgmentsAvailable(),1,-1 do
-	if windows[i] then
-		worst_window = GetTimingWindow(i)
-		break
-	end
-end
+-- scale worst_window to the worst judgment hit in the song
+-- start at Excellent window as the worst window since most quads are
+-- hard to make sense of visually
+local worst_window = GetTimingWindow(math.max(2, GetWorstJudgment(sequential_offsets)))
 
 -- ---------------------------------------------
 
@@ -70,7 +64,7 @@ for t in ivalues(sequential_offsets) do
 		-- get the appropriate color from the global SL table
 		c = colors[TimingWindow]
 
-		if mods.ShowFaPlusPane then
+		if mods.ShowFaPlusWindow and mods.ShowFaPlusPane then
 			abs_offset = math.abs(Offset)
 			if abs_offset > GetTimingWindow(1, "FA+") and abs_offset <= GetTimingWindow(2, "FA+") then
 				c = SL.JudgmentColors["FA+"][2]

--- a/Scripts/SL-Helpers.lua
+++ b/Scripts/SL-Helpers.lua
@@ -67,6 +67,23 @@ NumJudgmentsAvailable = function()
 end
 
 -- -----------------------------------------------------------------------
+-- get worst timing judgment hit for a song
+
+GetWorstJudgment = function(offsets)
+	local worst_judgment = 1
+	for i in ivalues(offsets) do
+		if i[2] ~= "Miss" then
+			local judgment = DetermineTimingWindow(i[2])
+			if worst_judgment < judgment then
+				worst_judgment = judgment
+			end
+		end
+	end
+	
+	return worst_judgment
+end
+
+-- -----------------------------------------------------------------------
 -- some common information needed by ScreenSystemOverlay's credit display,
 -- as well as ScreenTitleJoin overlay and ./Scripts/SL-Branches.lua regarding coin credits
 


### PR DESCRIPTION
Automatically cap scatterplot and histogram to worst timing window that was hit during the song. Scatterplot scales to Excellent at worst, while histogram scales to Great at worst (to match playing with boys off).