### PR TITLE
FA+ support for Per Arrow Breakdown and Score Evaluation Summary

### DIFF
--- a/BGAnimations/ScreenEvaluation common/Panes/Pane2/JudgmentNumbers.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane2/JudgmentNumbers.lua
@@ -24,6 +24,7 @@ local RadarCategories = {
 	x = { P1=-180, P2=218 }
 }
 
+-- TODO(Zankoku) - EX judgments are in storage now, so we shouldn't have to calculate this all over again
 local counts = GetExJudgmentCounts(player)
 
 local t = Def.ActorFrame{

--- a/BGAnimations/ScreenEvaluation common/Panes/Pane3/Arrows.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane3/Arrows.lua
@@ -1,5 +1,6 @@
 local player = ...
 local pn = ToEnumShortString(player)
+local mods = SL[pn].ActiveModifiers
 
 -- a string representing the NoteSkin the player was using
 local noteskin = GAMESTATE:GetPlayerState(player):GetCurrentPlayerOptions():NoteSkin()
@@ -17,6 +18,9 @@ local style_name = style:GetName()
 local num_columns = style:ColumnsPerPlayer()
 
 local rows = { "W1", "W2", "W3", "W4", "W5", "Miss" }
+if mods.ShowFaPlusWindow and mods.ShowFaPlusPane then
+	rows = { "W0", "W1", "W2", "W3", "W4", "W5", "Miss" }
+end
 local cols = {}
 
 -- loop num_columns number of time to fill the cols table with
@@ -70,7 +74,8 @@ for i, column in ipairs( cols ) do
 	-- for each possible judgment
 	for j, judgment in ipairs(rows) do
 		-- don't add rows for TimingWindows that were turned off, but always add Miss
-		if gmods.TimingWindows[j] or j==#rows then
+		-- (GMODS Timing Windows) - Zankoku
+		if gmods.TimingWindows[j] or j==#rows or (mods.ShowFaPlusWindow and mods.ShowFaPlusPane and gmods.TimingWindows[j-1]) then
 			-- add a BitmapText actor to be the number for this column
 			af[#af+1] = LoadFont("Common Normal")..{
 				Text=SL[pn].Stages.Stats[SL.Global.Stages.PlayedThisGame + 1].column_judgments[i][judgment],

--- a/BGAnimations/ScreenEvaluation common/Panes/Pane3/JudgmentLabels.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane3/JudgmentLabels.lua
@@ -1,11 +1,45 @@
 local player = ...
 local pn = ToEnumShortString(player)
+local mods = SL[pn].ActiveModifiers
 
-local TapNoteScores = { Types={'W1', 'W2', 'W3', 'W4', 'W5', 'Miss'}, Names={} }
-local tns_string = "TapNoteScore" .. (SL.Global.GameMode=="ITG" and "" or SL.Global.GameMode)
--- get TNS names appropriate for the current GameMode, localized to the current language
-for i, judgment in ipairs(TapNoteScores.Types) do
-	TapNoteScores.Names[#TapNoteScores.Names+1] = THEME:GetString(tns_string, judgment)
+local TapNoteScores = {Types={}, Names={}}
+local Colors = {}
+if mods.ShowFaPlusWindow and mods.ShowFaPlusPane then
+	TapNoteScores.Types = {'W0', 'W1', 'W2', 'W3', 'W4', 'W5', 'Miss'}
+	Colors = {
+		SL.JudgmentColors["FA+"][1],
+		SL.JudgmentColors["FA+"][2],
+		SL.JudgmentColors["FA+"][3],
+		SL.JudgmentColors["FA+"][4],
+		SL.JudgmentColors["FA+"][5],
+		SL.JudgmentColors["ITG"][5], -- FA+ mode doesn't have a Way Off window. Extract color from the ITG mode.
+		SL.JudgmentColors["FA+"][6],
+	}
+	-- get all TNS names
+	TapNoteScores.Names = {
+		THEME:GetString("TapNoteScoreFA+", "W1"),
+		THEME:GetString("TapNoteScoreFA+", "W2"),
+		THEME:GetString("TapNoteScoreFA+", "W3"),
+		THEME:GetString("TapNoteScoreFA+", "W4"),
+		THEME:GetString("TapNoteScoreFA+", "W5"),
+		THEME:GetString("TapNoteScore", "W5"), -- FA+ mode doesn't have a Way Off window. Extract name from the ITG mode.
+		THEME:GetString("TapNoteScoreFA+", "Miss"),
+	}
+else
+	TapNoteScores.Types = {'W1', 'W2', 'W3', 'W4', 'W5', 'Miss'}
+	Colors = {
+		SL.JudgmentColors[SL.Global.GameMode][1],
+		SL.JudgmentColors[SL.Global.GameMode][2],
+		SL.JudgmentColors[SL.Global.GameMode][3],
+		SL.JudgmentColors[SL.Global.GameMode][4],
+		SL.JudgmentColors[SL.Global.GameMode][5],
+		SL.JudgmentColors[SL.Global.GameMode][6],
+	}
+	local tns_string = "TapNoteScore" .. (SL.Global.GameMode=="ITG" and "" or SL.Global.GameMode)
+	-- get TNS names appropriate for the current GameMode, localized to the current language
+	for i, judgment in ipairs(TapNoteScores.Types) do
+		TapNoteScores.Names[#TapNoteScores.Names+1] = THEME:GetString(tns_string, judgment)
+	end
 end
 
 local box_height = 146
@@ -22,7 +56,7 @@ local windows = SL.Global.ActiveModifiers.TimingWindows
 --  labels: W1 ---> Miss
 for i=1, #TapNoteScores.Types do
 	-- no need to add BitmapText actors for TimingWindows that were turned off
-	if windows[i] or i==#TapNoteScores.Types then
+	if windows[i] or i == #TapNoteScores.Types or (mods.ShowFaPlusWindow and mods.ShowFaPlusPane and windows[i-1]) then
 
 		local window = TapNoteScores.Types[i]
 		local label = TapNoteScores.Names[i]
@@ -33,7 +67,7 @@ for i=1, #TapNoteScores.Types do
 				self:zoom(0.8):horizalign(right):maxwidth(65/self:GetZoom())
 					:x( (player == PLAYER_1 and -130) or -28 )
 					:y( i * row_height )
-					:diffuse( SL.JudgmentColors[SL.Global.GameMode][i] )
+					:diffuse( Colors[i] )
 
 				if i == #TapNoteScores.Types then miss_bmt = self end
 			end

--- a/BGAnimations/ScreenEvaluation common/PerPlayer/Storage.lua
+++ b/BGAnimations/ScreenEvaluation common/PerPlayer/Storage.lua
@@ -1,5 +1,6 @@
 local player = ...
 local pn = ToEnumShortString(player)
+local mods = SL[pn].ActiveModifiers
 
 local TNSTypes = {
 	'TapNoteScore_W1',
@@ -26,6 +27,7 @@ return Def.Actor{
 
 		storage.grade = pss:GetGrade()
 		storage.score = pss:GetPercentDancePoints()
+		storage.exscore = CalculateExScore(player)
 		storage.judgments = {
 			W1 = pss:GetTapNoteScores(TNSTypes[1]),
 			W2 = pss:GetTapNoteScores(TNSTypes[2]),
@@ -34,6 +36,12 @@ return Def.Actor{
 			W5 = pss:GetTapNoteScores(TNSTypes[5]),
 			Miss = pss:GetTapNoteScores(TNSTypes[6])
 		}
+		
+		if mods.ShowFaPlusWindow and mods.ShowFaPlusPane then
+			local counts = GetExJudgmentCounts(player)
+			storage.judgments.W0 = counts.W0
+			storage.judgments.W1 = counts.W1
+		end
 
 		if GAMESTATE:IsCourseMode() then
 			storage.steps      = GAMESTATE:GetCurrentTrail(player)

--- a/BGAnimations/ScreenEvaluationSummary overlay/PlayerStageStats.lua
+++ b/BGAnimations/ScreenEvaluationSummary overlay/PlayerStageStats.lua
@@ -3,7 +3,16 @@ local player = ...
 local LetterGradesAF
 local playerStats
 local steps, meter, difficulty, stepartist, grade, score
-local TNSTypes = { 'W1', 'W2', 'W3', 'W4', 'W5', 'Miss' }
+local TNSTypes = { 'W0', 'W1', 'W2', 'W3', 'W4', 'W5', 'Miss' }
+local Colors = {
+			SL.JudgmentColors["FA+"][1],
+			SL.JudgmentColors["FA+"][2],
+			SL.JudgmentColors["FA+"][3],
+			SL.JudgmentColors["FA+"][4],
+			SL.JudgmentColors["FA+"][5],
+			SL.JudgmentColors["ITG"][5], -- FA+ mode doesn't have a Way Off window. Extract color from the ITG mode.
+			SL.JudgmentColors["FA+"][6],
+		}
 
 -- variables for positioning and horizalign, dependent on playernumber
 local col1x, col2x, gradex, align1, align2
@@ -45,6 +54,10 @@ af[#af+1] = LoadFont("Common Bold")..{
 	InitCommand=function(self) self:zoom(0.5):horizalign(align1):x(col1x):y(-24) end,
 	DrawStageCommand=function(self)
 		if playerStats and score then
+		
+			if playerStats.judgments and playerStats.judgments.W0 then
+				self:zoom(0.48):y(-32)
+			end
 
 			-- trim off the % symbol
 			local score = string.sub(FormatPercentScore(score),1,-2)
@@ -57,6 +70,18 @@ af[#af+1] = LoadFont("Common Bold")..{
 			if grade and grade == "Grade_Failed" then
 				self:diffuse(Color.Red)
 			end
+		else
+			self:settext("")
+		end
+	end
+}
+
+--ex score
+af[#af+1] = LoadFont("Common Bold")..{
+	InitCommand=function(self) self:zoom(0.38):horizalign(align1):x(col1x):y(-12) end,
+	DrawStageCommand=function(self)
+		if playerStats and playerStats.judgments and playerStats.judgments.W0 then
+			self:settext(playerStats.exscore):diffuse(Colors[1])
 		else
 			self:settext("")
 		end
@@ -100,6 +125,9 @@ af[#af+1] = LoadFont("Common Bold")..{
 	DrawStageCommand=function(self)
 		if playerStats and meter then
 			self:diffuse(DifficultyColor(difficulty)):settext(meter)
+			if playerStats.judgments and playerStats.judgments.W0 then
+				self:zoom(0.3):y(5)
+			end
 		else
 			self:settext("")
 		end
@@ -134,19 +162,28 @@ af[#af+1] = Def.ActorProxy{
 
 
 -- numbers
+
 for i=1,#TNSTypes do
 
 	af[#af+1] = LoadFont("Common Bold")..{
 		InitCommand=function(self)
 			self:zoom(0.28):horizalign(align2):x(col2x):y(i*13 - 50)
-				:diffuse( SL.JudgmentColors[SL.Global.GameMode][i] )
+				:diffuse( Colors[i] )
 		end,
 		DrawStageCommand=function(self, params)
 			if playerStats and playerStats.judgments then
+				if playerStats.judgments.W0 then
+					self:zoom(0.28):horizalign(align2):x(col2x):y(i*13 - 58):diffuse( Colors[i] )
+				else
+					self:zoom(0.28):horizalign(align2):x(col2x):y(i*13 - 63):diffuse( Colors[i] )
+					if i == 2 then
+						self:diffuse( Colors[1] )
+					end
+				end
 				local val = playerStats.judgments[TNSTypes[i]]
 				if val then self:settext(val) end
 
-				self:visible( SL.Global.Stages.Stats[params.StageNum].TimingWindows[i] or i==#TNSTypes )
+				self:visible( (i == 1 and SL.Global.Stages.Stats[params.StageNum].TimingWindows[1]) or SL.Global.Stages.Stats[params.StageNum].TimingWindows[i-1] or i==#TNSTypes )
 			else
 				self:settext("")
 			end

--- a/BGAnimations/ScreenGameplay overlay/PerColumnJudgmentTracking.lua
+++ b/BGAnimations/ScreenGameplay overlay/PerColumnJudgmentTracking.lua
@@ -21,10 +21,12 @@
 if SL.Global.GameMode == "Casual" then return end
 
 local player = ...
+local pn = ToEnumShortString(player)
+local mods = SL[pn].ActiveModifiers
 
 local judgments = {}
 for i=1,GAMESTATE:GetCurrentStyle():ColumnsPerPlayer() do
-	judgments[#judgments+1] = { W1=0, W2=0, W3=0, W4=0, W5=0, Miss=0 }
+	judgments[#judgments+1] = { W0=0, W1=0, W2=0, W3=0, W4=0, W5=0, Miss=0 }
 end
 
 local actor = Def.Actor{
@@ -87,6 +89,10 @@ actor.JudgmentMessageCommand=function(self, params)
 			-- see: https://quietly-turning.github.io/Lua-For-SM5/LuaAPI#Enums-TapNoteType
 			if tnt == "TapNoteType_Tap" or tnt == "TapNoteType_HoldHead" or tnt == "TapNoteType_Lift" then
 				local tns = ToEnumShortString(params.TapNoteScore)
+				if mods.ShowFaPlusWindow and mods.ShowFaPlusPane and IsW0Judgment(params, player) then
+					tns = "W0"
+				end
+				
 				judgments[col][tns] = judgments[col][tns] + 1
 
 				if tns == "Miss" and held[params.Player][ buttons[col] ] then


### PR DESCRIPTION
Add support for FA+ window on per arrow breakdown tab for song results, as well as displaying FA+ counts and EX score for any songs that had it enabled in score summary pages.