### PR TITLE
Correct math to pick a secret from the player's colour

### DIFF
--- a/BGAnimations/ScreenSrpgCutscenes overlay.lua
+++ b/BGAnimations/ScreenSrpgCutscenes overlay.lua
@@ -108,8 +108,7 @@ if FILEMAN:DoesFileExist(path) then
   f:destroy()
 end
 
-local idx = (SL.Global.ActiveColorIndex % #SL.SRPG7.Colors) + 1
-local factionName = SL.SRPG7.GetFactionName(idx)
+local factionName = SL.SRPG7.GetFactionName(SL.Global.ActiveColorIndex)
 
 -- Select a random cutscene that hasn't previously been shown.
 local cutscenes = {}

--- a/Scripts/SL_SRPG6.lua
+++ b/Scripts/SL_SRPG6.lua
@@ -1,17 +1,22 @@
 SL.SRPG7 = {
 	Colors = {
-		"#666000",
-		"#3d6526",	-- green (main)
-		"#36855b",
-		"#36a392",
-		"#51c0c8",	-- teal (DPRT)
-		"#009bcf",
-		"#006ecb",
-		"#5131a4",	-- blue (Footspeed Empire)
-		"#9c0082",
-		"#bf0052",
-		"#c32020",	-- red (Stamina Nation)
-		"#954f00",
+		            ----------+--------------
+		"#666000",  -- Unaff. | Yellow     --
+		"#3d6526",  --        | Green      --
+		"#36855b",  --        | Green-Blue --
+		            ----------+--------------
+		"#36a392",  -- DPRT   | Teal       --
+		"#51c0c8",  --        | Cyan       --
+		"#009bcf",  --        | Light Blue --
+		            ----------+--------------
+		"#006ecb",  -- FE     | Blue       --
+		"#5131a4",  --        | Violet     --
+		"#9c0082",  --        | Purple     --
+		            ----------+--------------
+		"#bf0052",  -- SN     | Pink       --
+		"#c32020",  --        | Red        --
+		"#954f00",  --        | Orange     --
+		            ----------+--------------
 	},
 	TextColor = "#ffffff",
 
@@ -22,6 +27,8 @@ SL.SRPG7 = {
 		return "logo_main (doubleres).png"
 	end,
 	GetFactionName = function(idx)
+		-- Assuming that idx is 1-indexed and
+		-- follows the order of the colours above
 		if idx <= 3 then
 			return "Unaffiliated"
 		elseif idx <= 6 then


### PR DESCRIPTION
Fixes a bug found on Stamina Nation's Discord where picking a faction's 3rd colour would lead to the next faction being used instead for the _Secret Easter Egg™_.

I did away with the modulo, as it was making the math harder to follow as it mapped the 12th color (SN's 3rd, orange) to 0, which then had to be corrected as `GetFactionName` expects the colours to come in a certain order. Ultimately, it seems like `SL.Global.ActiveColorIndex` already goes from 1-12 and matches `GetFactionName`'s expectations, so it can be used directly. I couldn't find any issues during my tests, but do feel free to put it back if you know why it was there. ^^

Tested on ITGmania built from tag `v0.7.0`.