### PR TITLE
Fix Early Decents throwing errors in Edit mode.

### DIFF
--- a/Graphics/Player judgment.lua
+++ b/Graphics/Player judgment.lua
@@ -3,6 +3,49 @@ local pn = ToEnumShortString(player)
 local mods = SL[pn].ActiveModifiers
 local sprite
 
+-- helper function for returning the player AF
+-- works as expected in ScreenGameplay
+--     arguments:  pn is short string PlayerNumber like "P1" or "P2"
+--     returns:    the "PlayerP1" or "PlayerP2" ActorFrame in ScreenGameplay
+--                 or, the unnamed equivalent in ScrenEdit
+local GetPlayerAF = function(pn)
+	local topscreen = SCREENMAN:GetTopScreen()
+	if not topscreen then
+		lua.ReportScriptError("GetPlayerAF() failed to find the player ActorFrame because there is no Screen yet.")
+		return nil
+	end
+
+	local playerAF = nil
+
+	-- Get the player ActorFrame on ScreenGameplay
+	-- It's a direct child of the screen and named "PlayerP1" for P1
+	-- and "PlayerP2" for P2.
+	-- This naming convention is hardcoded in the SM5 engine.
+	--
+	-- ScreenEdit does not name its player ActorFrame, but we can still find it.
+
+	-- find the player ActorFrame in edit mode
+	if (THEME:GetMetric(topscreen:GetName(), "Class") == "ScreenEdit") then
+		-- loop through all nameless children of topscreen
+		-- and find the one that contains the NoteField
+		-- which is thankfully still named "NoteField"
+		for _,nameless_child in ipairs(topscreen:GetChild("")) do
+			if nameless_child:GetChild("NoteField") then
+				playerAF = nameless_child
+				break
+			end
+		end
+
+	-- find the player ActorFrame in gameplay
+	else
+		local player_af = topscreen:GetChild("Player"..pn)
+		if player_af then
+			playerAF = player_af
+		end
+	end
+
+	return playerAF
+end
 ------------------------------------------------------------
 -- A profile might ask for a judgment graphic that doesn't exist
 -- If so, use the first available Judgment graphic
@@ -18,10 +61,7 @@ if file_to_load == "None" then
 			if param.Player ~= player then return end
 	
 			if not mods.HideEarlyDecentWayOffFlash then
-				SCREENMAN:GetTopScreen()
-								 :GetChild("Player"..pn)
-								 :GetChild("NoteField")
-								 :did_tap_note(param.Column + 1, param.TapNoteScore, --[[bright]] false)
+				GetPlayerAF(pn):GetChild("NoteField"):did_tap_note(param.Column + 1, param.TapNoteScore, --[[bright]] false)
 			end
 		end
 	}
@@ -51,10 +91,7 @@ return Def.ActorFrame{
 		if not frame then return end
 
 		if not mods.HideEarlyDecentWayOffFlash then
-			SCREENMAN:GetTopScreen()
-							 :GetChild("Player"..pn)
-							 :GetChild("NoteField")
-							 :did_tap_note(param.Column + 1, param.TapNoteScore, --[[bright]] false)
+			GetPlayerAF(pn):GetChild("NoteField"):did_tap_note(param.Column + 1, param.TapNoteScore, --[[bright]] false)
 		end
 
 		if not mods.HideEarlyDecentWayOffJudgments then


### PR DESCRIPTION
Getting an Early Decent in Edit Mode will throw the following error:
![image](https://github.com/Simply-Love/Simply-Love-SM5/assets/30600688/78ecae88-d839-400e-96c3-d88cc38a5ec3)
 
```
if not mods.HideEarlyDecentWayOffFlash and not SCREENMAN:GetTopScreen():GetName():match("ScreenEdit")  then
	SCREENMAN:GetTopScreen()
		:GetChild("Player"..pn)
		:GetChild("NoteField")
		:did_tap_note(param.Column + 1, param.TapNoteScore, --[[bright]] false)
end
```
This is because ScreenEdit does not name its player ActorFrame and wouldn't be accessible through the same means as in ScreenGameplay. So ```SCREENMAN:GetTopScreen():GetChild("Player"..pn)``` returns a nil value.

I didn't think this would be needed in EditMode anyways so this PR adds an additional check for if we're in edit mode. (I can edit this PR otherwise)
