### PR TITLE
Preserve the MenuTimer when going into Favorites

### DIFF
--- a/BGAnimations/ScreenSelectMusic overlay/SortMenu/SortMenu_InputHandler.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SortMenu/SortMenu_InputHandler.lua
@@ -47,8 +47,9 @@ local input = function(event)
 				end
 				-- the player wants to change styles, for example from single to double
 			elseif focus.kind == "ChangeStyle" then
-				-- If the MenuTimer is in effect, make sure to grab its current
-				-- value before reloading the screen.
+				-- If the MenuTimer is in effect, we need to make sure the current number of seconds
+				-- remaining is preserved so we can reinstate it later. ShowPressStartForOptions
+				-- will save the current number of seconds before transitioning to the next screen.
 				if PREFSMAN:GetPreference("MenuTimer") then
 					overlay:playcommand("ShowPressStartForOptions")
 				end
@@ -224,7 +225,13 @@ local input = function(event)
 						-- loaded consistently.
 						-- TODO(teejusb): Fix this in the engine.
 						-- MESSAGEMAN:Broadcast("Sort", { order = "Preferred" })
-						
+							
+						-- If the MenuTimer is in effect, we need to make sure the current number of seconds
+						-- remaining is preserved so we can reinstate it later. ShowPressStartForOptions
+						-- will save the current number of seconds before transitioning to the next screen.
+						if PREFSMAN:GetPreference("MenuTimer") then
+							overlay:playcommand("ShowPressStartForOptions")
+						end
 						screen:GetMusicWheel():ChangeSort("SortOrder_Preferred")
 						screen:SetNextScreenName("ScreenSelectMusic")
 						screen:StartTransitioningScreen("SM_GoToNextScreen")

--- a/BGAnimations/ScreenSelectMusic overlay/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/default.lua
@@ -30,8 +30,8 @@ local af = Def.ActorFrame{
 	-- ---------------------------------------------------
 	--  first, load files that contain no visual elements, just code that needs to run
 
-	-- MenuTimer code for preserving SSM's timer value when going
-	-- from SSM to Player Options and then back to SSM
+	-- MenuTimer code for preserving SSM's timer value when going 
+	-- from SSM to a different screen and back to SSM (i.e. returning from PlayerOptions).
 	LoadActor("./PreserveMenuTimer.lua"),
 	-- Apply player modifiers from profile
 	LoadActor("./PlayerModifiers.lua"),


### PR DESCRIPTION
After choosing to view your Favorites in the SortMenu, the MenuTimer freezes on 100.

Steps to Reproduce:
- Ensure the MenuTimer is enabled on ScreenSelectMusic
- Reach the SelectMusic screen with a profile with at least 1 favorite
- Choose "Favorites" from the SortMenu
- The MenuTimer will lock at 100 upon reload.

I used the same command that's used when Changing styles to preserve the Menu Timer @ [Line 52](https://github.com/CrashCringle12/Simply-Love-SM5/blob/c4bf7e87a8f85427e30067e23b6e59234803a47e/BGAnimations/ScreenSelectMusic%20overlay/SortMenu/SortMenu_InputHandler.lua#L52C9-L52C9)
