### PR TITLE
Allow changing difficulty with just one press of the menu button

### DIFF
--- a/metrics.ini
+++ b/metrics.ini
@@ -1615,6 +1615,8 @@ Codes="CourseCodeDetector"
 [CodeDetector]
 PrevSteps1=GetCodeForGame("PrevSteps1")
 NextSteps1=GetCodeForGame("NextSteps1")
+PrevSteps2="MenuUp"
+NextSteps2="MenuDown"
 
 # Sorting should done via ScreenSelectMusic's SortMenu
 # which is accessed via codes defined under [ScreenSelectMusic]


### PR DESCRIPTION
I often see people new to the game struggle to change difficulty, this should help with that.

Pad up/down still requires two presses.