### PR TITLE
fix GameButton label y-pos in ScreenMapControllers

### DIFF
--- a/metrics.ini
+++ b/metrics.ini
@@ -1213,8 +1213,15 @@ LineScrollerOnCommand=%function(self) \
 	self:SetTransformFromHeight(24); \
 end;
 
-PrimaryOnCommand=x,_screen.cx;y,-6;zoom,16/24
-SecondaryOnCommand=x,_screen.cx;y,6;zoom,12/24
+# ListHeaderCenterOnCommand is for the center element of the ListHeader.
+ListHeaderCenterOnCommand=x,_screen.cx;zoom,0.9;shadowlength,1
+ListHeaderOnCommand=shadowlength,1;zoom,0.8;maxwidth,130;
+
+PrimaryOnCommand=%function(self) \
+	self:x(_screen.cx):zoom(0.666) \
+	self:y(IsGameAndMenuButton(self:GetText()) and -5 or 0) \
+end
+SecondaryOnCommand=xy,_screen.cx,5;zoom,0.5
 MappedToOnCommand=zoom,16/24;diffuse,color("#808080");maxwidth,150
 
 ListHeaderGainFocusCommand=%function(self) \


### PR DESCRIPTION
# Description of Issue

The GameButton labels in *ScreenMapControllers* have appeared vertically "misaligned" since this theme's initial commit.  It became more noticeable after [my recent PR](https://github.com/Simply-Love/Simply-Love-SM5/pull/497) which added a wide gray Quad to highlight the active row.

You can see the *EffectDown* label appears top-aligned.
![Screenshot 2023-12-17 at 8 32 42 PM](https://github.com/Simply-Love/Simply-Love-SM5/assets/1253483/2c78dbf8-e934-4475-a010-54619c705dae)

This was due to hardcoded `y` values of `-6` (primary label) and `6` (secondary label) in Metrics: https://github.com/Simply-Love/Simply-Love-SM5/blob/a206fdbd9e8216113ab890145b3ce47d09f2631e/metrics.ini#L1216-L1217

For context, a row's secondary label only appears when `OnlyDedicatedMenuButtons=0`, meaning that some GameButtons need to serve double duty.  For example, the GameButton for _Left_ will also serve as _MenuLeft_ and that row needs both labels.

I knew this was a minor issue during my 2019 cleanup in 9ec479917065dae0d4d9a673bbfd710ede5ab2ab, but couldn't think of a fix at the time.  4+ years later, I'm closing the loop. :)

---

# Fix

This PR changes the `PrimaryOnCommand` under `[ScreenMapControllers]` to only offset by `-5` if the button is both a GameButton and menu button.

https://github.com/Simply-Love/Simply-Love-SM5/assets/1253483/702d26a8-671c-4bea-9a00-225e928717fb

My implementation supports _dance_, _pump_, _techno_, _kb7_, and _para_ games, and should work with any language.
