### PR TITLE
Logic for white flashes when FA+ window is enabled

### DIFF
--- a/Graphics/Player judgment.lua
+++ b/Graphics/Player judgment.lua
@@ -12,7 +12,24 @@ local available_judgments = GetJudgmentGraphics()
 local file_to_load = (FindInTable(mods.JudgmentGraphic, available_judgments) ~= nil and mods.JudgmentGraphic or available_judgments[1]) or "None"
 
 if file_to_load == "None" then
-	return Def.Actor{ InitCommand=function(self) self:visible(false) end }
+	return Def.Actor{
+		InitCommand=function(self) self:visible(false) end,
+		JudgmentMessageCommand=function(self,param)
+			if not IsW0Judgment(param, player) and not IsAutoplay(player) then
+				frame = 1
+				
+				for col,tapnote in pairs(param.Notes) do
+					local tnt = ToEnumShortString(tapnote:GetTapNoteType())
+					if tnt == "Tap" or tnt == "HoldHead" or tnt == "Lift" then
+						SCREENMAN:GetTopScreen()
+						 :GetChild("Player"..pn)
+						 :GetChild("NoteField")
+						 :did_tap_note(col, "TapNoteScore_CheckpointHit", --[[bright]] true)
+					end
+				end
+			end
+	  end
+	}
 end
 
 ------------------------------------------------------------
@@ -55,6 +72,16 @@ return Def.ActorFrame{
 					-- This technically causes a discrepency on the histogram, but it's likely okay.
 					if not IsW0Judgment(param, player) and not IsAutoplay(player) then
 						frame = 1
+						
+						for col,tapnote in pairs(param.Notes) do
+							local tnt = ToEnumShortString(tapnote:GetTapNoteType())
+							if tnt == "Tap" or tnt == "HoldHead" or tnt == "Lift" then
+								SCREENMAN:GetTopScreen()
+								 :GetChild("Player"..pn)
+								 :GetChild("NoteField")
+								 :did_tap_note(col, "TapNoteScore_CheckpointHit", --[[bright]] true)
+							end
+						end
 					end
 				end
 				-- We don't need to adjust the top window otherwise.


### PR DESCRIPTION
On hitting within white window if FA+ window is enabled, sends a tapnote command of type "checkpoint" with bright true, to make use of noteskins that have a rewritten BrightCommand for the purpose of blue/white differentiation. Kind of breaks DDR noteskin dim/bright functionality...