### PR TITLE
Set the starting profile to Guest & Require both players to select profile before moving forward.

### DIFF
--- a/BGAnimations/ScreenSelectProfile underlay/PlayerFrame.lua
+++ b/BGAnimations/ScreenSelectProfile underlay/PlayerFrame.lua
@@ -144,7 +144,8 @@ return Def.ActorFrame{
 			end
 
 			scroller.focus_pos = 5
-			scroller:set_info_set(scroller_data, 0)
+			scroller:set_info_set(scroller_data, 1)
+			scroller:scroll_by_amount(-1 )
 		end,
 
 		FrameBackground(PlayerColor(player), player, frame.w * 1.1),
@@ -164,7 +165,7 @@ return Def.ActorFrame{
 			InitCommand=function(self)
 				self:x(15.5)
 			end,
-			OnCommand=function(self) self:playcommand("Set", profile_data[1]) end,
+			OnCommand=function(self) self:playcommand("Set", profile_data[0]) end,
 
 			-- semi-transparent Quad to the right of this colored frame to present profile stats and mods
 			Def.Quad {
@@ -338,7 +339,7 @@ return Def.ActorFrame{
 	LoadFont("Common Normal")..{
 		Name='SelectedProfileText',
 		InitCommand=function(self)
-			self:settext(profile_data[1] and profile_data[1].displayname or "")
+			self:settext(profile_data[0] and profile_data[0].displayname or "")
 			self:y(160):zoom(1.35):shadowlength(ThemePrefs.Get("RainbowMode") and 0.5 or 0):cropright(1)
 		end,
 		OnCommand=function(self) self:sleep(0.2):smooth(0.2):cropright(0) end

--- a/BGAnimations/ScreenSelectProfile underlay/PlayerFrame.lua
+++ b/BGAnimations/ScreenSelectProfile underlay/PlayerFrame.lua
@@ -104,17 +104,29 @@ return Def.ActorFrame{
 
 		LoadFont("Common Normal")..{
 			InitCommand=function(self)
+				self:diffuseshift():effectcolor1(1,1,1,1):effectcolor2(0.5,0.5,0.5,1)
+				self:diffusealpha(0):maxwidth(180)
+				self:queuecommand("ResetText")
+			end,
+			OnCommand=function(self) self:sleep(0.3):linear(0.1):diffusealpha(1) end,
+			OffCommand=function(self) self:linear(0.1):diffusealpha(0) end,
+			ResetTextCommand=function(self)
 				if IsArcade() and not GAMESTATE:EnoughCreditsToJoin() then
 					self:settext( THEME:GetString("ScreenSelectProfile", "EnterCreditsToJoin") )
 				else
 					self:settext( THEME:GetString("ScreenSelectProfile", "PressStartToJoin") )
 				end
-
-				self:diffuseshift():effectcolor1(1,1,1,1):effectcolor2(0.5,0.5,0.5,1)
-				self:diffusealpha(0):maxwidth(180)
 			end,
-			OnCommand=function(self) self:sleep(0.3):linear(0.1):diffusealpha(1) end,
-			OffCommand=function(self) self:linear(0.1):diffusealpha(0) end,
+			UnselectedProfileMessageCommand=function(self, params)
+				if params.PlayerNumber ~= player then return end
+
+				self:queuecommand("ResetText")
+			end,
+			SelectedProfileMessageCommand=function(self, params)
+				if params.PlayerNumber ~= player then return end
+
+				self:settext("Waiting...")
+			end,
 			CoinsChangedMessageCommand=function(self)
 				if IsArcade() and GAMESTATE:EnoughCreditsToJoin() then
 					self:settext(THEME:GetString("ScreenSelectProfile", "PressStartToJoin"))

--- a/BGAnimations/ScreenSelectProfile underlay/default.lua
+++ b/BGAnimations/ScreenSelectProfile underlay/default.lua
@@ -187,7 +187,7 @@ local t = Def.ActorFrame {
 			else
 				-- only attempt to unjoin the player if that side is currently joined
 				if GAMESTATE:IsSideJoined(params.PlayerNumber) then
-					MESSAGEMAN:Broadcast("BackButton")
+					MESSAGEMAN:Broadcast("BackButton", {PlayerNumber=params.PlayerNumber})
 					-- ScreenSelectProfile:SetProfileIndex() will interpret -2 as
 					-- "Unjoin this player and unmount their USB stick if there is one"
 					-- see ScreenSelectProfile.cpp for details
@@ -263,7 +263,36 @@ end
 if AutoStyle=="none" or AutoStyle=="versus" then
 	t[#t+1] = LoadActor("PlayerFrame.lua", {Player=PLAYER_1, Scroller=scrollers[PLAYER_1], ProfileData=profile_data, Avatars=avatars})
 	t[#t+1] = LoadActor("PlayerFrame.lua", {Player=PLAYER_2, Scroller=scrollers[PLAYER_2], ProfileData=profile_data, Avatars=avatars})
-
+		-- decorative arrows
+	t[#t+1] = LoadActor(THEME:GetPathG("", "EditMenu Right.png"))..{
+		InitCommand=function(self)
+			self:visible(false):Center():addx(-275):zoom(0.60)
+		end,
+		CursorMessageCommand=function(self, pn)
+			if pn.PlayerNumber == PLAYER_1 then self:visible(true) end
+		end,
+		StartButtonMessageCommand=function(self)
+			self:visible(false)
+		end,
+		BackButtonMessageCommand=function(self, pn)
+			if pn.PlayerNumber == PLAYER_1 then self:visible(false) end
+				self:visible(false)
+		end
+	}
+	t[#t+1] = LoadActor(THEME:GetPathG("", "EditMenu Right.png"))..{
+		InitCommand=function(self)
+			self:visible(false):Center():addx(25):zoom(0.60)
+		end,
+		CursorMessageCommand=function(self, pn)
+			if pn.PlayerNumber == PLAYER_2 then self:visible(true) end
+		end,
+		StartButtonMessageCommand=function(self)
+			self:visible(false)
+		end,
+		BackButtonMessageCommand=function(self, pn)
+			if pn.PlayerNumber == PLAYER_2 then self:visible(false) end
+		end
+	}
 -- load only for the MasterPlayerNumber
 else
 	t[#t+1] = LoadActor("PlayerFrame.lua", {Player=mpn, Scroller=scrollers[mpn], ProfileData=profile_data, Avatars=avatars})


### PR DESCRIPTION
This PR has two commits:

1) Sets the starting profile in SelectProfile to guest rather than the first local profile. I think this is ideal as the default to avoid guests using the first profile. I think this might solve https://github.com/Simply-Love/Simply-Love-SM5/issues/489

2) "I noticed that if there were two players selecting profiles on the SelectProfile screen, if one of those players pressed
enter and selected their profile it would proceed to the next screen. This meant that the other player was forced to use
whichever profile they were last focused on." This commit makes it so both players must choose their profile to move forward. 

