### PR TITLE
Keep scroller hidden when using a memorycard

### DIFF
--- a/BGAnimations/ScreenSelectProfile underlay/default.lua
+++ b/BGAnimations/ScreenSelectProfile underlay/default.lua
@@ -47,6 +47,8 @@ local HandleStateChange = function(self, Player)
 			usbsprite:visible(false)
 		else
 			-- using memorycard profile
+			joinframe:visible(false)
+			scrollerframe:visible(false)
 			seltext:settext(MEMCARDMAN:GetName(Player))
 			usbsprite:visible(true)
 


### PR DESCRIPTION
Quick fix to keep join and scroller frame hidden when using a memory card after https://github.com/Simply-Love/Simply-Love-SM5/commit/76d53f7eafd9ead0a2ac3a872689a5d7cb8d1384
![image](https://github.com/Simply-Love/Simply-Love-SM5/assets/30600688/56ec35d5-36d8-4654-8f0c-922af64491e1)
