### PR TITLE
Add Block level and Top Grades sorts, Remove legacy sorts

### DIFF
--- a/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
@@ -247,26 +247,16 @@ local t = Def.ActorFrame {
 			{"SortBy", "Genre"},
 			{"SortBy", "BPM"},
 			{"SortBy", "Length"},
+			{"SortBy", "Meter"},
 		}
-		-- the engine's MusicWheel has distinct items in the SortOrder enum for double
-		if style == "double" then
-			table.insert(wheel_options, {"SortBy", "DoubleChallengeMeter"})
-			table.insert(wheel_options, {"SortBy", "DoubleHardMeter"})
-			table.insert(wheel_options, {"SortBy", "DoubleMediumMeter"})
-			table.insert(wheel_options, {"SortBy", "DoubleEasyMeter"})
-			table.insert(wheel_options, {"SortBy", "DoubleBeginnerMeter"})
-		-- Otherwise... use the SortOrders that don't specify double.
-		-- Does this imply that difficulty sorting in more uncommon styles
-		-- (solo, routine, etc.) probably doesn't work?
-		else
-			table.insert(wheel_options, {"SortBy", "ChallengeMeter"})
-			table.insert(wheel_options, {"SortBy", "HardMeter"})
-			table.insert(wheel_options, {"SortBy", "MediumMeter"})
-			table.insert(wheel_options, {"SortBy", "EasyMeter"})
-			table.insert(wheel_options, {"SortBy", "BeginnerMeter"})
-		end
 		table.insert(wheel_options, {"SortBy", "Popularity"})
 		table.insert(wheel_options, {"SortBy", "Recent"})
+		-- Loop through players and add their TopGrades to the wheel options if they've a profile
+		for player in ivalues(GAMESTATE:GetHumanPlayers()) do
+			if (PROFILEMAN:IsPersistentProfile(player)) then
+				table.insert(wheel_options, {"SortBy", "Top".. ToEnumShortString(player).."Grades" })
+			end
+		end
 		-- Allow players to switch from single to double and from double to single
 		-- but only present these options if Joint Double or Joint Premium is enabled
 		if not (PREFSMAN:GetPreference("Premium") == "Premium_Off" and GAMESTATE:GetCoinMode() == "CoinMode_Pay") then

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -142,16 +142,9 @@ BPM=BPM
 Length=Length
 Recent=Recently Played
 Popularity=Most Played
-BeginnerMeter=Beginner
-EasyMeter=Easy
-MediumMeter=Medium
-HardMeter=Hard
-ChallengeMeter=Expert
-DoubleBeginnerMeter=Beginner
-DoubleEasyMeter=Easy
-DoubleMediumMeter=Medium
-DoubleHardMeter=Hard
-DoubleChallengeMeter=Expert
+Meter=Level
+TopP1Grades=P1 Clear Rank
+TopP2Grades=P2 Clear Rank
 # SortMenu "Change Style To" choices
 Single=Single
 Double=Double
@@ -201,6 +194,28 @@ NoInfo=Keep playing.
 
 # PaneDisplay info that is custom for SL
 NPS=NPS
+
+[Grade]
+Tier01=☆☆☆☆
+Tier02=☆☆☆
+Tier03=☆☆
+Tier04=☆
+Tier05=S+
+Tier06=S
+Tier07=S-
+Tier08=A+
+Tier09=A
+Tier10=A-
+Tier11=B+
+Tier12=B
+Tier13=B-
+Tier14=C+
+Tier15=C
+Tier16=C-
+Tier17=D
+NoData=Not Played
+Failed=F
+None=N/A
 
 [ScreenViewDownloads]
 HeaderText=View Downloads


### PR DESCRIPTION
Add Block level and Top Grades sorts, remove Difficulty dependent meter sorts
- Adds Meter (Block level) sort to menu
- Adds profile top grades sort to menu
- Remove Difficulty dependent meter sorts from menu.