### PR TITLE
Judgment Labels

### DIFF
--- a/BGAnimations/ScreenEvaluation common/Panes/Pane1/JudgmentLabels.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane1/JudgmentLabels.lua
@@ -2,6 +2,7 @@ local player, controller = unpack(...)
 
 local pn = ToEnumShortString(player)
 local stats = STATSMAN:GetCurStageStats():GetPlayerStageStats(pn)
+local pss = STATSMAN:GetCurStageStats():GetPlayerStageStats(player)
 
 local tns_string = "TapNoteScore" .. (SL.Global.GameMode=="ITG" and "" or SL.Global.GameMode)
 
@@ -48,6 +49,16 @@ local t = Def.ActorFrame{
 local windows = SL.Global.ActiveModifiers.TimingWindows
 
 --  labels: W1, W2, W3, W4, W5, Miss
+
+-- Shift labels left if any tap note counts exceeded 9999
+-- The positioning logic breaks if we get to 7 digits, please nobody hit a million Fantastics
+local maxCount = 1
+for i=1, #TapNoteScores.Types do
+	local window = TapNoteScores.Types[i]
+	local number = pss:GetTapNoteScores( "TapNoteScore_"..window )
+	if number > maxCount then maxCount = number end
+end
+
 for i=1, #TapNoteScores.Types do
 	-- no need to add BitmapText actors for TimingWindows that were turned off
 	if windows[i] or i==#TapNoteScores.Types then
@@ -57,6 +68,13 @@ for i=1, #TapNoteScores.Types do
 			InitCommand=function(self) self:zoom(0.833):horizalign(right):maxwidth(76) end,
 			BeginCommand=function(self)
 				self:x( (controller == PLAYER_1 and 28) or -28 )
+				if maxCount > 9999 then
+					length = math.floor(math.log10(maxCount)+1)
+					modifier = controller == PLAYER_1 and -11*(length-4) or 11*(length-4)
+					finalPos = 28 + modifier
+					finalZoom = 0.833 - 0.1*(length-4)
+					self:x( (controller == PLAYER_1 and finalPos) or -finalPos ):zoom(finalZoom)
+				end
 				self:y((i-1)*28 -16)
 				-- diffuse the JudgmentLabels the appropriate colors for the current GameMode
 				self:diffuse( SL.JudgmentColors[SL.Global.GameMode][i] )

--- a/BGAnimations/ScreenEvaluation common/Panes/Pane2/JudgmentLabels.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane2/JudgmentLabels.lua
@@ -59,6 +59,16 @@ for v in ivalues( SL.Global.ActiveModifiers.TimingWindows) do
 	windows[#windows + 1] = v
 end
 
+-- Shift labels left if any tap note counts exceeded 9999
+-- The positioning logic breaks if we get to 7 digits, please nobody hit a million Fantastics
+local maxCount = 1
+local counts = GetExJudgmentCounts(player)
+for i=1, #TapNoteScores.Types do
+	local window = TapNoteScores.Types[i]
+	local number = counts[window] or 0
+	if number > maxCount then maxCount = number end
+end
+
 --  labels: W1, W2, W3, W4, W5, Miss
 for i=1, #TapNoteScores.Types do
 	-- no need to add BitmapText actors for TimingWindows that were turned off
@@ -68,6 +78,13 @@ for i=1, #TapNoteScores.Types do
 			InitCommand=function(self) self:zoom(0.833):horizalign(right):maxwidth(76) end,
 			BeginCommand=function(self)
 				self:x( (controller == PLAYER_1 and 28) or -28 )
+				if maxCount > 9999 then
+					length = math.floor(math.log10(maxCount)+1)
+					modifier = controller == PLAYER_1 and -11*(length-4) or 11*(length-4)
+					finalPos = 28 + modifier
+					finalZoom = 0.833 - 0.1*(length-4)
+					self:x( (controller == PLAYER_1 and finalPos) or -finalPos ):zoom(finalZoom)
+				end
 				self:y(i*26 -46)
 				-- diffuse the JudgmentLabels the appropriate colors for the current GameMode
 				self:diffuse( TapNoteScores.Colors[i] )


### PR DESCRIPTION
Resize and shift judgment labels on score screen if the number of steps in a judgment exceeds the initially accounted-for 4 digits.