### PR TITLE
Prevent additional input if two players are ready on SelectProfile

### DIFF
--- a/BGAnimations/ScreenSelectProfile underlay/Input.lua
+++ b/BGAnimations/ScreenSelectProfile underlay/Input.lua
@@ -97,6 +97,8 @@ Handle.Start = function(event)
 		MESSAGEMAN:Broadcast("SelectedProfile", {PlayerNumber=event.PlayerNumber})
 
 		if readyPlayers["P1"] and readyPlayers["P2"] then
+			-- Set finished to true so that we don't process any more input
+			finished = true	
 			-- if we're here, both players have selected a profile
 			-- play the StartButton sound
 			MESSAGEMAN:Broadcast("StartButton")


### PR DESCRIPTION
This commit aims to address: https://github.com/Simply-Love/Simply-Love-SM5/issues/511
This bug was initially fixed in https://github.com/Simply-Love/Simply-Love-SM5/commit/5346e11461a10fcf77a610d64cd72209b20ea0cf by quietly-turning

It looks like the boolean wasn't getting set to true as it got yoinked accidentally here: https://github.com/Simply-Love/Simply-Love-SM5/commit/76d53f7eafd9ead0a2ac3a872689a5d7cb8d1384 

