### PR TITLE
Initialize profile data to the DefaultLocalProfile when in use.

### DIFF
--- a/BGAnimations/ScreenSelectProfile underlay/PlayerFrame.lua
+++ b/BGAnimations/ScreenSelectProfile underlay/PlayerFrame.lua
@@ -47,7 +47,6 @@ if SL.Global.FastProfileSwitchInProgress then
 			break
 		end
 	end
-
 	-- If we haven't found a matching profile looking in profile_data, this has to
 	-- be [GUEST]
 	pos = pos or 0
@@ -180,8 +179,9 @@ return Def.ActorFrame{
 			end
 
 			scroller.focus_pos = 5
-
-			scroller:set_info_set(scroller_data, 0)
+			-- initialize to the guest profile in case we don't have a default profile
+			scroller:set_info_set(scroller_data, 1)
+			scroller:scroll_by_amount(-1)
 
 			-- Scroll to the current player profile, if any
 			if pos then
@@ -192,17 +192,13 @@ return Def.ActorFrame{
 				if PREFSMAN:GetPreference("DefaultLocalProfileID"..pn) ~= "" then
 					local default_profile_id = PREFSMAN:GetPreference("DefaultLocalProfileID"..pn)
 					local profile_dir = PROFILEMAN:LocalProfileIDToDir(default_profile_id)
-					
 					for i, profile_item in ipairs(scroller_data) do
 						if profile_item.dir == profile_dir then
-							scroller:set_info_set(scroller_data, 1)
-							scroller:scroll_by_amount(i-5)
+							scroller:scroll_by_amount(i-4)
+							initial_data = profile_data[i-4]
 							break
 						end
 					end
-				else
-					scroller:set_info_set(scroller_data, 1)
-					scroller:scroll_by_amount(-1 )
 				end
 			end
 		end,


### PR DESCRIPTION
Stealing nvanleerdrums' video to depict bug:
https://github.com/Simply-Love/Simply-Love-SM5/assets/30600688/80c12ba6-778a-4766-8fce-c201658f6863

This commit ensures that initial_data gets set to the correct information when there's default profiles. (The initial information shown in SelectProfile)
