### PR TITLE
Add the Local Leaderboard as a viewable Leaderboard

### DIFF
--- a/BGAnimations/ScreenSelectMusic overlay/Leaderboard.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/Leaderboard.lua
@@ -158,7 +158,7 @@ local LeaderboardRequestProcessor = function(res, master)
 			local leaderboardList = master[pn]["Leaderboards"]
 			local localData = getLocalLeaderboard(pn)
 			leaderboardList[#leaderboardList + 1] = {
-				Name="Local Leaderboard",
+				Name="Machine's  Best",
 				Data=DeepCopy(localData),
 				IsEX=false
 			}
@@ -239,16 +239,14 @@ local LeaderboardRequestProcessor = function(res, master)
 				end
 			end
 
-			-- Display the local leaderboard last if the preference is not set
-			if not ThemePrefs.Get("PrioritizeLocalLeaderboard") then
-				local localData = getLocalLeaderboard(pn)
-				leaderboardList[#leaderboardList + 1] = {
-					Name="Local Leaderboard",
-					Data=DeepCopy(localData),
-					IsEX=false
-				}
-				master[pn]["LeaderboardIndex"] = 1
-			end
+			-- Display the local leaderboard last
+			local localData = getLocalLeaderboard(pn)
+			leaderboardList[#leaderboardList + 1] = {
+				Name="Machine's  Best",
+				Data=DeepCopy(localData),
+				IsEX=false
+			}
+			master[pn]["LeaderboardIndex"] = 1
 
 			if #leaderboardList > 1 then
 				leaderboard:GetChild("PaneIcons"):visible(true)
@@ -321,31 +319,15 @@ local af = Def.ActorFrame{
 	RequestResponseActor(17, 50)..{
 		SendLeaderboardRequestCommand=function(self)
 			-- If a player does not have an API key or chart hash just show the local leaderboard.
-			
 			for i=1,2 do
 				local pn = "P"..i
-				if SL[pn].ApiKey == "" or SL[pn].Streams.Hash == "" or ThemePrefs.Get("PrioritizeLocalLeaderboard") or not IsServiceAllowed(SL.GrooveStats.Leaderboard) then
+				if SL[pn].ApiKey == "" or SL[pn].Streams.Hash == "" or not IsServiceAllowed(SL.GrooveStats.Leaderboard) then
 					local pn = "P"..i
 					local leaderboard = self:GetParent():GetChild(pn.."Leaderboard")
 					local leaderboardList = self:GetParent()[pn]["Leaderboards"]
 					local localData = getLocalLeaderboard(pn)
 					leaderboardList[#leaderboardList + 1] = {
-						Name="Local Leaderboard",
-						Data=DeepCopy(localData),
-						IsEX=false
-					}
-					self:GetParent()[pn]["LeaderboardIndex"] = 1
-				end
-			end
-			-- Display the local leaderboard first if the preference is set
-			if ThemePrefs.Get("PrioritizeLocalLeaderboard") or not IsServiceAllowed(SL.GrooveStats.Leaderboard) then
-				for i=1, 2 do
-					local pn = "P"..i
-					local leaderboard = self:GetParent():GetChild(pn.."Leaderboard")
-					local leaderboardList = self:GetParent()[pn]["Leaderboards"]
-					local localData = getLocalLeaderboard(pn)
-					leaderboardList[#leaderboardList + 1] = {
-						Name="Local Leaderboard",
+						Name="Machine's  Best",
 						Data=DeepCopy(localData),
 						IsEX=false
 					}

--- a/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
@@ -343,7 +343,7 @@ local wheel_options = {
 	{ {"ChangeMode", "Casual"}, SL.Global.Stages.PlayedThisGame == 0 and SL.Global.GameMode ~= "Casual" },
 	{ {"ImLovinIt", "AddFavorite"}, function() return GAMESTATE:GetCurrentSong() ~= nil end},
 	AddFavorites(),
-	{ {"GrooveStats", "Leaderboard"}, function() return IsServiceAllowed(SL.GrooveStats.Leaderboard) and GAMESTATE:GetCurrentSong() ~= nil end },	
+	{ {"GrooveStats", "Leaderboard"}, function() return GAMESTATE:GetCurrentSong() ~= nil end },	
 }
 
 

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -820,7 +820,6 @@ EnableGrooveStats=Enable GrooveStats
 AutoDownloadUnlocks=Auto-Download Unlocks
 SeparateUnlocksByPlayer=Separate Unlocks By Player
 QRLogin=Display GrooveStats QR Login
-PrioritizeLocalLeaderboard=Show Machine Scores First
 
 ##############################################
 # now we get into the longer explanations of options
@@ -975,8 +974,6 @@ SeparateUnlocksByPlayer=Separate Downloaded Unlocks for Each Profile.
 QRLogin=When to display that QR Login screen.\n\nAlways - Always display the QR Login screen.\n\nSometimes - Only display the QR Login screen if needed for the profiles.\n\nDisable QR Login entirely.
 
 
-
-PrioritizeLocalLeaderboard=When viewing the leaderboard, Show the scores obtained on this machine first before showing any obtained from Groovestats.
 # ScreenPlayerOptions
 SpeedModType=Change the way arrows react to changing BPMs.
 SpeedMod=Adjust the speed at which arrows travel toward the targets.

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -820,6 +820,7 @@ EnableGrooveStats=Enable GrooveStats
 AutoDownloadUnlocks=Auto-Download Unlocks
 SeparateUnlocksByPlayer=Separate Unlocks By Player
 QRLogin=Display GrooveStats QR Login
+PrioritizeLocalLeaderboard=Show Machine Scores First
 
 ##############################################
 # now we get into the longer explanations of options
@@ -974,6 +975,8 @@ SeparateUnlocksByPlayer=Separate Downloaded Unlocks for Each Profile.
 QRLogin=When to display that QR Login screen.\n\nAlways - Always display the QR Login screen.\n\nSometimes - Only display the QR Login screen if needed for the profiles.\n\nDisable QR Login entirely.
 
 
+
+PrioritizeLocalLeaderboard=When viewing the leaderboard, Show the scores obtained on this machine first before showing any obtained from Groovestats.
 # ScreenPlayerOptions
 SpeedModType=Change the way arrows react to changing BPMs.
 SpeedMod=Adjust the speed at which arrows travel toward the targets.

--- a/Scripts/99 SL-ThemePrefs.lua
+++ b/Scripts/99 SL-ThemePrefs.lua
@@ -312,7 +312,6 @@ SL_CustomPrefs.Get = function()
 			Choices =  { THEME:GetString("ThemePrefs","Yes"), THEME:GetString("ThemePrefs", "No") },
 			Values  = { true, false }
 		},
-
 		QRLogin = {
 			Default = "Sometimes",
 			Choices = {
@@ -321,6 +320,11 @@ SL_CustomPrefs.Get = function()
 				THEME:GetString("ThemePrefs", "Never"),
 			},
 			Values = { "Always", "Sometimes", "Never" }
+		},
+		PrioritizeLocalLeaderboard = {
+			Default = false,
+			Choices =  { THEME:GetString("ThemePrefs","Yes"), THEME:GetString("ThemePrefs", "No") },
+			Values  = { true, false }
 		}
 	}
 end

--- a/Scripts/99 SL-ThemePrefs.lua
+++ b/Scripts/99 SL-ThemePrefs.lua
@@ -320,11 +320,6 @@ SL_CustomPrefs.Get = function()
 				THEME:GetString("ThemePrefs", "Never"),
 			},
 			Values = { "Always", "Sometimes", "Never" }
-		},
-		PrioritizeLocalLeaderboard = {
-			Default = false,
-			Choices =  { THEME:GetString("ThemePrefs","Yes"), THEME:GetString("ThemePrefs", "No") },
-			Values  = { true, false }
 		}
 	}
 end

--- a/metrics.ini
+++ b/metrics.ini
@@ -1291,14 +1291,12 @@ ItemOnCommand=visible,false
 
 [ScreenGrooveStatsOptions]
 Fallback="ScreenOptionsServiceChild"
-LineNames="EnableGrooveStats,AutoDownloadUnlocks,SeparateUnlocksByPlayer,QRLogin,PrioritizeLocalLeaderboard"
+LineNames="EnableGrooveStats,AutoDownloadUnlocks,SeparateUnlocksByPlayer,QRLogin"
 
 LineEnableGrooveStats="lua,ThemePrefsRows.GetRow('EnableGrooveStats')"
 LineAutoDownloadUnlocks="lua,ThemePrefsRows.GetRow('AutoDownloadUnlocks')"
 LineSeparateUnlocksByPlayer="lua,ThemePrefsRows.GetRow('SeparateUnlocksByPlayer')"
 LineQRLogin="lua,ThemePrefsRows.GetRow('QRLogin')"
-LinePrioritizeLocalLeaderboard="lua,ThemePrefsRows.GetRow('PrioritizeLocalLeaderboard')"
-
 
 [ScreenTournamentModeOptions]
 Fallback="ScreenOptionsServiceChild"

--- a/metrics.ini
+++ b/metrics.ini
@@ -1291,12 +1291,13 @@ ItemOnCommand=visible,false
 
 [ScreenGrooveStatsOptions]
 Fallback="ScreenOptionsServiceChild"
-LineNames="EnableGrooveStats,AutoDownloadUnlocks,SeparateUnlocksByPlayer,QRLogin"
+LineNames="EnableGrooveStats,AutoDownloadUnlocks,SeparateUnlocksByPlayer,QRLogin,PrioritizeLocalLeaderboard"
 
 LineEnableGrooveStats="lua,ThemePrefsRows.GetRow('EnableGrooveStats')"
 LineAutoDownloadUnlocks="lua,ThemePrefsRows.GetRow('AutoDownloadUnlocks')"
 LineSeparateUnlocksByPlayer="lua,ThemePrefsRows.GetRow('SeparateUnlocksByPlayer')"
 LineQRLogin="lua,ThemePrefsRows.GetRow('QRLogin')"
+LinePrioritizeLocalLeaderboard="lua,ThemePrefsRows.GetRow('PrioritizeLocalLeaderboard')"
 
 
 [ScreenTournamentModeOptions]


### PR DESCRIPTION
Adds the Local leaderboard to the leaderboard menu. 

- If the player does not have a groovestats account connected or groovestats is disabled, the player will still be able to view the Local Leaderboard.
- Added a new preference (mainly oriented for public cabs) to prioritize displaying the local leaderboard before the the groovestats board. The preference dictates whether the local leaderboard is shown first or last. By default it is shown last.
- Always allow viewing the leaderboard in the sort menu. 
- If one player has groovestats and the other does not, the player without groovestats will only see the local board.


### Using Guest Account
![image](https://github.com/Simply-Love/Simply-Love-SM5/assets/30600688/381b3640-6afa-4164-842e-17c3fa6aed7e)
<br><br>
### P1 (Has Groovestats account), P2 (No Groovestats)
![image](https://github.com/Simply-Love/Simply-Love-SM5/assets/30600688/99a20e53-f0eb-45ff-a2e8-9109aceae461)
![image](https://github.com/Simply-Love/Simply-Love-SM5/assets/30600688/9ec652e1-f331-49d5-996f-393c28a5fcc2)
