### PR TITLE
Only allow 'reload songs' sort menu option in event mode

### DIFF
--- a/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
@@ -301,9 +301,9 @@ local t = Def.ActorFrame {
 			if (game=="dance" or game=="pump" or game=="techno") then
 				table.insert(wheel_options, {"FeelingSalty", "TestInput"})
 			end
-		end
 
-		table.insert(wheel_options, {"TakeABreather", "LoadNewSongs"})
+			table.insert(wheel_options, {"TakeABreather", "LoadNewSongs"})
+		end
 
 		-- Only display the View Downloads option if we're connected to
 		-- GrooveStats and Auto-Downloads are enabled.


### PR DESCRIPTION
Judging by the comment a few lines up, I think this was intended to be nested in the event mode check