### PR TITLE
Add Timing Windows string to ScreenGameplay

### DIFF
--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -257,6 +257,7 @@ Course=course
 GiveUpStartText=Continue holding &START; to give up
 GiveUpBackText=Continue holding &BACK; to give up
 GiveUpAbortedText=Don't go back!
+TimingWindowScale=%.0f%% Timing Windows
 #'
 
 # Simply Love doens't really support ScreenHeartEntry


### PR DESCRIPTION
The X% Timing Windows string is needed to construct the modifiers string, which was previously only used in ScreenEvaluation. The addition of the modifiers box means it needs to be included in ScreenGameplay now, too.