### PR TITLE
bugfix: adjust mask positioning for CourseMode's ScreenSelectMusic

### DIFF
--- a/BGAnimations/ScreenSelectMusic overlay/StepsDisplayList/CourseContentsList.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/StepsDisplayList/CourseContentsList.lua
@@ -1,6 +1,7 @@
 local numItemsToDraw = 8
 local PrevCurrentItem = 0
 local SecondsToPause = 0.5
+local PaneWidth = 320
 
 local transform_function = function(self,offsetFromCenter,itemIndex,numitems)
 	self:y( offsetFromCenter * 23 )
@@ -52,8 +53,8 @@ local af = Def.ActorFrame{
 	-- lower mask
 	Def.Quad{
 		InitCommand=function(self)
-			self:xy(IsUsingWideScreen() and -44 or 0,98)
-				:zoomto(_screen.w/2, 40)
+			self:xy(0, 98)
+				:zoomto(PaneWidth, 40)
 				:MaskSource()
 		end
 	},
@@ -62,8 +63,8 @@ local af = Def.ActorFrame{
 	Def.Quad{
 		InitCommand=function(self)
 			self:vertalign(bottom)
-				:xy(IsUsingWideScreen() and -44 or 0,-18)
-				:zoomto(_screen.w/2, 100)
+				:xy(0, -18)
+				:zoomto(PaneWidth, 100)
 				:MaskSource()
 		end
 	},
@@ -72,7 +73,7 @@ local af = Def.ActorFrame{
 	-- gray background Quad
 	Def.Quad{
 		InitCommand=function(self)
-			self:diffuse(color("#1e282f")):zoomto(320, 96)
+			self:diffuse(color("#1e282f")):zoomto(PaneWidth, 96)
 				:xy(0, 30)
 
 			if ThemePrefs.Get("RainbowMode") then


### PR DESCRIPTION
This adjusts the positioning of Quads used in CourseMode's ScreenSelectMusic to mask the `CourseContentsList` scroller.  Previously, its text wasn't always covered by the masks in 16:10 aspect ratio.

I've tested these changes in 4:3, 16:10, 16:9, and 21:9 aspect ratios.

---

### before

https://github.com/Simply-Love/Simply-Love-SM5/assets/1253483/d5e36f5b-5bae-4e13-b006-af84e38337d1

Not sure what I was thinking when I wrote the original code here.

### after

https://github.com/Simply-Love/Simply-Love-SM5/assets/1253483/e3c3ecd8-1910-42df-9b87-2dbad9d6dd29

