### PR TITLE
feature: let players change SpeedMod before 1st note in CourseMode

### DIFF
--- a/BGAnimations/ScreenGameplay next course song/ChangeSpeedModBeforeFirstNote.lua
+++ b/BGAnimations/ScreenGameplay next course song/ChangeSpeedModBeforeFirstNote.lua
@@ -1,0 +1,87 @@
+-- player options objects, used to figure out what mods each player has active
+local po = {}
+for player in ivalues(GAMESTATE:GetHumanPlayers()) do
+	po[player] = GAMESTATE:GetPlayerState(player):GetPlayerOptions('ModsLevel_Song')
+end
+
+local increment = {
+	XMod = 0.25,
+	MMod = 10,
+	CMod = 10,
+}
+
+local upper_limit = {
+	XMod = 10,
+	MMod = 2000,
+	CMod = 2000,
+}
+
+local fmt = {
+	XMod = "mod,%.2fx",
+	MMod = "mod,m%d",
+	CMod = "mod,c%d",
+}
+
+local InputHandler = function( event )
+	if not event.PlayerNumber or not event.button then return false end
+	if po[event.PlayerNumber] == nil              then return false end
+	if event.type == "InputEventType_Release"     then return false end
+
+	-- check event.button instead of event.MenuButton to ensure the player definitely pressed a dedicated MenuButton.
+	-- we don't want to change speed mod if a player has OnlyDedicatedMenuButtons=0 and is, for example, tapping out
+	-- the beat on their dance pad before the first note.
+	if event.button == "MenuRight" or event.button == "MenuLeft" then
+		local xmod = po[event.PlayerNumber]:XMod()
+		local mmod = po[event.PlayerNumber]:MMod()
+		local cmod = po[event.PlayerNumber]:CMod()
+
+		local speedmod     = (cmod ~= nil and cmod)   or (mmod ~= nil and mmod)   or (xmod ~= nil and xmod)
+		local speedmod_str = (cmod ~= nil and "CMod") or (mmod ~= nil and "MMod") or (xmod ~= nil and "XMod")
+
+		if event.button == "MenuRight" then
+			if speedmod + increment[speedmod_str] <= upper_limit[speedmod_str] then
+				speedmod = speedmod + increment[speedmod_str]
+			end
+		elseif event.button == "MenuLeft" then
+			if speedmod - increment[speedmod_str] > 0 then
+				speedmod = speedmod - increment[speedmod_str]
+			end
+		end
+
+		-- update SL table with new speed
+		SL[ToEnumShortString(event.PlayerNumber)].ActiveModifiers.SpeedMod = speedmod
+
+		-- format a GameCommand string like "mod,1.75x" or "mod,c460" or "mod,m900"
+		local gcString = fmt[speedmod_str]:format(speedmod)
+
+		-- apply the new speed mod to the player immediately
+		GAMESTATE:ApplyGameCommand(gcString, event.PlayerNumber)
+
+		-- broadcast which player's mods changed so that ScreenGameplay's DisplayMods.lua
+		-- can update its BitmapText string to show the player updated text
+		MESSAGEMAN:Broadcast("PlayerOptionsChanged", {Player=event.PlayerNumber})
+	end
+
+	return false
+end
+
+return Def.Actor{
+	OnCommand=function(self)                        self:playcommand("AddInputHandler") end,
+	CurrentSongChangedMessageCommand=function(self) self:playcommand("AddInputHandler") end,
+
+	OffCommand=function(self)             self:playcommand("RemoveInputHandler") end,
+	JudgmentMessageCommand=function(self) self:playcommand("RemoveInputHandler") end,
+
+	AddInputHandlerCommand=function(self)
+		local screen = SCREENMAN:GetTopScreen()
+		if screen then
+			screen:AddInputCallback( InputHandler )
+		end
+	end,
+	RemoveInputHandlerCommand=function(self)
+		local screen = SCREENMAN:GetTopScreen()
+		if screen then
+			screen:RemoveInputCallback( InputHandler )
+		end
+	end
+}

--- a/BGAnimations/ScreenGameplay next course song/default.lua
+++ b/BGAnimations/ScreenGameplay next course song/default.lua
@@ -1,4 +1,4 @@
-return Def.ActorFrame{
+local af = Def.ActorFrame{
 	StartCommand=function(self)
 		self:diffusealpha(0):visible(true):sleep(0.75):decelerate(0.5):diffusealpha(1)
 	end,
@@ -27,3 +27,9 @@ return Def.ActorFrame{
 		StartCommand=function(self) self:scale_or_crop_background() end
   }
 }
+
+if GAMESTATE:IsCourseMode() then
+	af[#af+1] = LoadActor("ChangeSpeedModBeforeFirstNote.lua")
+end
+
+return af

--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/NoteField/DisplayMods.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/NoteField/DisplayMods.lua
@@ -1,16 +1,20 @@
 local player = ...
 
-if SL.Global.GameMode == "Casual" or GAMESTATE:IsCourseMode() then return end
+if SL.Global.GameMode == "Casual" then return end
 
 local optionslist = GetPlayerOptionsString(player)
 
 local af = Def.ActorFrame{
   InitCommand = function(self)
-      self:xy(GetNotefieldX(player), SCREEN_HEIGHT/4*1.3)
+    self:diffusealpha(1):xy(GetNotefieldX(player), SCREEN_HEIGHT/4*1.3)
   end,
   OnCommand=function(self)
     self:sleep(5):decelerate(0.5):diffusealpha(0)
-  end
+  end,
+  PlayerOptionsChangedMessageCommand=function(self, params)
+    if params.Player ~= player then return false end
+    self:stoptweening():playcommand("Init"):queuecommand("On")
+  end,
 }
 
 af[#af+1] = LoadFont("Common Normal")..{
@@ -22,6 +26,11 @@ af[#af+1] = LoadFont("Common Normal")..{
     self:shadowcolor(Color.Black)
     self:shadowlength(1)
   end,
+  PlayerOptionsChangedMessageCommand=function(self, params)
+    if params.Player ~= player then return false end
+    optionslist = GetPlayerOptionsString(player, "ModsLevel_Song")
+    self:settext(optionslist)
+  end
 }
 
 return af

--- a/Scripts/SL-Helpers.lua
+++ b/Scripts/SL-Helpers.lua
@@ -918,9 +918,10 @@ end
 
 -- -----------------------------------------------------------------------
 -- Returns a stringified form of a player's selected options.
-GetPlayerOptionsString = function(player)
+GetPlayerOptionsString = function(player, modsLevel)
+	local modsLevel = modsLevel or "ModsLevel_Preferred"
 	-- grab the song options from this PlayerState
-	local PlayerOptions = GAMESTATE:GetPlayerState(player):GetPlayerOptionsArray("ModsLevel_Preferred")
+	local PlayerOptions = GAMESTATE:GetPlayerState(player):GetPlayerOptionsArray(modsLevel)
 	local pn = ToEnumShortString(player)
 
 	-- start with an empty string...

--- a/metrics.ini
+++ b/metrics.ini
@@ -1726,6 +1726,7 @@ MemoryCardIcons=false
 GiveUpSeconds=0.33
 MusicFadeOutSeconds=0.25
 UsePauseMenuInsteadOfGiveUp=false
+RepeatRate=30
 
 # Engine stuff we can cut out of the render pipeline
 # Thanks, kyzentun.


### PR DESCRIPTION
This allows players to increase/decrease their speed mods before their first `JudgmentCommand` at the start of each song in CourseMode gameplay.  

It was requested by a local player who wants to play courses in ITGm, but prefers to stick to DDR-style XMods in increments of 0.25.

---

I went with increments of:

* XMod: `0.25`
* MMod: `10`
* CMod: `10`

I also specified upper limits of:

* XMod: `10`
* MMod: `2000`
* CMod: `2000`

to match the upper limits currently enforced in ScreenPlayerOptions.

---

Some design considerations:

1. In my `InputHandler` function, I use `event.button == "MenuRight"` and not `event.MenuButton == "MenuRight"` to ensure the player has pressed a dedicated MenuButton that is separate from their dance pad.  

   This has the unfortunate effect of making this feature inaccessible to players who navigate using their dance pad with `OnlyDedicatedMenuButtons=0`, but that seems preferable to them accidentally changing their speed mods while tapping out the beat at the start of gameplay (as would happen with DDR X Raw Thrills cabs 😖).

2. I've specified `RepeatRate=30` under `[ScreenGameplay]` in metrics.ini, the same SL uses for `[ScreenPlayerOptions]`.  This allows players to hold MenuLeft or MenuRight and change their speedmod at the same rate seen in ScreenPlayerOptions (i.e. a rate they're possibly familiar with).

3. The increments for MMod and CMod are (usually) much finer-grain than 0.25x and this is intentional.  The quick RepeatRate should allow players to rapidly change their MMod or CMod.

4. I've updated ScreenGameplay's *DisplayMods.lua* to reset the `self:sleep(5):decelerate(0.5):diffusealpha(0)` on the mod-string BitmapText each time the player changes their speed mod.

---

https://github.com/Simply-Love/Simply-Love-SM5/assets/1253483/74ee7fdd-61dc-4eef-b1b5-ae293dd1989a


