### PR TITLE
Fix MeasureLines on non-english values

### DIFF
--- a/Scripts/SL-PlayerOptions.lua
+++ b/Scripts/SL-PlayerOptions.lua
@@ -634,15 +634,6 @@ local Overrides = {
 	-------------------------------------------------------------------------
 	MeasureLines = {
 		Choices = { "Off", "Measure", "Quarter", "Eighth" },
-		SaveSelections = function(self, list, pn)
-			local mods, playeroptions = GetModsAndPlayerOptions(pn)
-
-			for i=1,#self.Choices do
-				if list[i] then
-					mods.MeasureLines = self.Choices[i]
-				end
-			end
-		end
 	},
 	-------------------------------------------------------------------------
 	VisualDelay = {


### PR DESCRIPTION
Seems like SaveSelections doesn't work on Values that are not in english, in those cases it uses a non-existing value instead. I tested it both on english and other languages and I couldn't find an unexpected behavior without SaveSelections.

**Before**


https://github.com/Simply-Love/Simply-Love-SM5/assets/74380856/4b76d60e-e3a1-4e2c-8a64-111acfaf5aa4

**After**


https://github.com/Simply-Love/Simply-Love-SM5/assets/74380856/9d720e36-f94a-4556-8ce0-5430de6aeb8b



