### PR TITLE
Make MeasureLines work correctly with localized values

### DIFF
--- a/Scripts/SL-PlayerOptions.lua
+++ b/Scripts/SL-PlayerOptions.lua
@@ -633,16 +633,7 @@ local Overrides = {
 	},
 	-------------------------------------------------------------------------
 	MeasureLines = {
-		Choices = { "Off", "Measure", "Quarter", "Eighth" },
-		SaveSelections = function(self, list, pn)
-			local mods, playeroptions = GetModsAndPlayerOptions(pn)
-
-			for i=1,#self.Choices do
-				if list[i] then
-					mods.MeasureLines = self.Choices[i]
-				end
-			end
-		end
+		Values = { "Off", "Measure", "Quarter", "Eighth" },
 	},
 	-------------------------------------------------------------------------
 	VisualDelay = {


### PR DESCRIPTION
Use `Values` instead of `Choices` to properly display localized choices in the menu and remove `SaveSelection()` since the default function does the right thing automatically.