### PR TITLE
Rewrite descriptions of fail types

### DIFF
--- a/Languages/de.ini
+++ b/Languages/de.ini
@@ -779,7 +779,7 @@ ScreenNameEntryMenuTimer=Set the MenuTimer value for ScreenNameEntry.
 
 
 # Advanced Options
-DefaultFailType=• Immediate - Ends gameplay when all players run out of life.\n\n• ImmediateContinue - Fails players when they run out of life, but allows gameplay to continue.\n\n• EndOfSong - Evaluates whether a player passes or fails at the end of the song.\n\n• Off - Disables fail.
+DefaultFailType=• Immediate - Beendet das Spiel, wenn alle Spieler keine Lebenszeit mehr haben.\n\n• ImmediateContinue - Lässt Spieler im Stich, wenn sie keine Lebenszeit mehr haben, ermöglicht aber die Fortsetzung des Spiels.\n\n• Off - Deaktiviert Fail.\n\nImmediate oder ImmediateContinue ist erforderlich, wenn Sie die Ergebnisse an GrooveStats übermitteln möchten.
 UseUnlockSystem=Enable or disable StepMania's unlock system.\n\nSimply Love does not support the unlock system, and I don't know of any other theme that does.
 AllowExtraStage=When enabled (and Event Mode is off), this allows players to earn extra stages after completing certain requirements.\n\nThis presumably impacts other themes, but has no bearing on Simply Love.
 HiddenSongs=Simfiles with #SELECTABLE:NO; will not appear in the MusicWheel, but might be accessible via specific courses.\n\nLeave this 'Off' to always display all songs.

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -816,7 +816,7 @@ ScreenEvaluationSummaryMenuTimer=Set the MenuTimer value for ScreenEvaluationSum
 ScreenNameEntryMenuTimer=Set the MenuTimer value for ScreenNameEntry.
 
 # Advanced Options
-DefaultFailType=• Immediate - Ends gameplay when all players run out of life.\n\n• ImmediateContinue - Fails players when they run out of life, but allows gameplay to continue.\n\n• EndOfSong - Evaluates whether a player passes or fails at the end of the song.\n\n• Off - Disables fail.
+DefaultFailType=• Immediate - Ends gameplay when all players run out of life.\n\n• ImmediateContinue - Fails players when they run out of life, but allows gameplay to continue.\n\n• Off - Disables fail.\n\nImmediate or ImmediateContinue is required if you wish to submit scores to GrooveStats.
 UseUnlockSystem=Enable or disable StepMania's unlock system.\n\nSimply Love does not support the unlock system, and I don't know of any other theme that does.
 AllowExtraStage=When enabled (and Event Mode is off), this allows players to earn extra stages after completing certain requirements.\n\nThis presumably impacts other themes, but has no bearing on Simply Love.
 HiddenSongs=Simfiles with #SELECTABLE:NO; will not appear in the MusicWheel, but might be accessible via specific courses.\n\nLeave this 'Off' to always display all songs.

--- a/Languages/es.ini
+++ b/Languages/es.ini
@@ -900,7 +900,7 @@ ScreenEvaluationSummaryMenuTimer=Ajusta el limite de tiempo para ScreenEvaluatio
 ScreenNameEntryMenuTimer=Ajusta el limite de tiempo para ScreenNameEntry.
 
 # Advanced Options
-DefaultFailType=• Immediate - Finaliza el juego cuando todos los jugadores se quedan sin vida.\n\n• ImmediateContinue - Marca Perdida a los jugadores que se queden sin vida, pero permite continuar el juego.\n\n• EndOfSong - Evalua si algún jugador para o falla al final de la canción.\n\n• Off - Deshabilita la perdida de la partida.
+DefaultFailType=• Immediate - Finaliza el juego cuando todos los jugadores se quedan sin vida.\n\n• ImmediateContinue - Falla a los jugadores cuando se quedan sin vida, pero permite que el juego continúe.\n\n• Off - Desactiva el fallo.\n\nImmediate o ImmediateContinue es necesario si desea enviar las puntuaciones a GrooveStats.
 UseUnlockSystem=Enciende o deshabilita el sistema de desbloqueos de StepMania.\n\nSimply Love no soporta el sistema, y no sé otro tema que lo utilize.
 AllowExtraStage=Cuando está habilitado (Y el modo Evento está apagado), esto permite a los jugadores obtener rondas extra despues de completar ciertos requisitos.\n\nEsto mayormente afecta otros temas, pero no tiene mucho efecto en Simply Love.
 HiddenSongs=Los Simfiles con #SELECTABLE:NO; no aparecerán en el MusicWheel, pero pueden ser accesibles en cursos especiales.\n\nDeja esto "Apagado" para mostrar todas las canciones.

--- a/Languages/fr.ini
+++ b/Languages/fr.ini
@@ -652,7 +652,7 @@ ScreenEvaluationSummaryMenuTimer=Définir le temps sur l'écran de sommaire d'é
 ScreenNameEntryMenuTimer=Définir le temps pour saisir un nom.
 
 # Advanced Options
-DefaultFailType=• Immediate - Termine le jeu quand tous les joueurs n'ont plus de vie.\n\n• ImmediateContinue - Termine le jeu quand tous les joueurs n'ont plus de vie, mais permet de continuer à jouer.\n\n• Fin de chanson – Détermine si un joueur rate à la fin de la chanson.\n\n• Off - Désactive le fait de rater.
+DefaultFailType=• Immediate - Termine le jeu lorsque tous les joueurs n'ont plus de vie.\n\n• ImmediateContinue - Fait échouer les joueurs lorsqu'ils n'ont plus de vie, mais permet au jeu de continuer.\n\n• Off - Désactive l'échec.\n\nImmediate ou ImmediateContinue est nécessaire si vous souhaitez soumettre des scores à GrooveStats.
 UseUnlockSystem=Activer ou non le système de débloquage de chansons de StepMania.\n\nSimply Love ne supporte pas ce système, et je ne connais aucun autre thème le supportant.
 AllowExtraStage=Quand activé (en dehors du mode évènement), permet aux joueurs de gagner des manches supplémentaires selon certaines actions.\n\nCeci impacte probablement les autres thèmes, mais n'a aucun effet sur Simply Love.
 HiddenSongs=Les chansons avec #SELECTABLE:NO; ne vont pas apparaître dans l'écran de choix de musique, mais peuvent être accessibles via des courses.\n\nDésactivez ceci pour toujours afficher toutes les chansons.

--- a/Languages/it.ini
+++ b/Languages/it.ini
@@ -1106,7 +1106,7 @@ ScreenEvaluationSummaryMenuTimer=Regola il limite di tempo per la schermata di r
 ScreenNameEntryMenuTimer=Regola il limite di tempo per la schermata di immissione del nome.
 
 # Advanced Options
-DefaultFailType=• Immediato: termina il gioco quando tutti i giocatori sono senza vita.\n\n• Immediato Continua: I giocatori che sono senza vita perdono il round, ma possono completare la canzone.\n\n• Fine del brano: valuta se un giocatore passa o fallisce la canzone alla fine del brano.\n\n• Disabilitato: Non si perde mai.
+DefaultFailType=• Immediate - Termina il gioco quando tutti i giocatori esauriscono la loro vita.\n\n• ImmediateContinue - Fa fallire i giocatori quando esauriscono la loro vita, ma permette al gioco di continuare.\n\n• Off - Disattiva i fallimenti.\n\nImmediate o ImmediateContinue è necessario se si desidera inviare i punteggi a GrooveStats.
 UseUnlockSystem=Attiva o disattiva il sistema di sblocco StepMania.\n\nPuoi ignorare questa impostazione perchè non viene usata da Simply Love nè da nessun altro dei temi più conosciuti.
 AllowExtraStage==Se abilitato (e con la Event Mode disabilitata), consente ai giocatori di ricevere un round extra dopo aver completato determinati requisiti.\n\nQuesto riguarda principalmente altri temi, ma non influenza Simply Love.
 HiddenSongs=I simfile con la stringa #SELECTABLE: NO; non verranno visualizzati nella selezione delle canzoni, ma sarà possibile accedervi se sono all'interno di una maratona.\n\nLascialo 'Disattivato' per accedere a tutti i brani, compresi quelli segreti.

--- a/Languages/ja.ini
+++ b/Languages/ja.ini
@@ -605,7 +605,7 @@ ScreenEvaluationSummaryMenuTimer=総合リザルト画面の制限時間を指�
 ScreenNameEntryMenuTimer=名前入力画面の制限時間を指定します。
 
 # Advanced Options
-DefaultFailType=• Immediate - ライフが無くなった時点でFailedとなり、曲を終了します。\n\n• ImmediateContinue - ライフが無くなった時点でFailedとなりますが、ゲームプレイは曲が終了するまで継続します。\n\n• EndOfSong - 曲が終わった時点でライフが少しでも残っていればクリアとなります。\n\n• Off - Failを無効化します。
+DefaultFailType=• Immediate - 全プレイヤーのライフが尽きたらゲームプレイを終了する\n\n• ImmediateContinue - プレイヤーのライフが尽きたらフェイルするが、ゲームプレイは継続できる\n\n• Off - フェイルを無効にする。\n\nImmediateまたはImmediateContinueは、GrooveStatsにスコアを提出する場合に必要です。
 UseUnlockSystem=StepManiaのアンロックシステムを有効化・無効化します。\n\nただ、Simply Loveではアンロックシステムをサポートしていませんし、他のテーマで実装されているのを見たこともありません。
 AllowExtraStage='On'にすると、プレイヤーがある特定の条件を達成したときにエクストラステージに進めるようになります。\n\n他のテーマでは特殊な演出が用意されていたりしますが、Simply Loveには特にありません。\n\nこの設定はEventモードでは無視されます。
 HiddenSongs='On'にすると、 #SELECTABLE:NO; と記述されたSimfileがゲーム内に表示されなくなります。この場合も、コースによってその曲が選択されていれば、そのコースでは遊ぶことができます。\n\n'Off'にすると、この設定に関係なくすべての曲が選曲画面から選択できるようになります。

--- a/Languages/pl.ini
+++ b/Languages/pl.ini
@@ -787,7 +787,7 @@ ScreenEvaluationSummaryMenuTimer=Wybierz wartość licznika menu dla ekranu pods
 ScreenNameEntryMenuTimer=Wybierz wartość licznika menu dla ekranu wpisu imienia.
 
 # Opcje Zaawansowane
-DefaultFailType=• Natychmiast - Kończy rozgrywkę, gdy wszystkim graczom skończy się życie.\n\n• Z opóźnieniem - Po opróżnieniu paska życia utwór zakończy się porażką, ale można go dokończyć.\n\n• Koniec Utworu - Porażka graczy rozstrzygana jest pod koniec utworu.\n\n• Wyłącz - Wyłącza możliwość porażki.
+DefaultFailType=• Immediate - kończy rozgrywkę, gdy wszystkim graczom skończy się życie.\n\n• ImmediateContinue - kończy grę, gdy graczom skończy się życie, ale pozwala kontynuować rozgrywkę.\n\n• Off - wyłącza niepowodzenie.\n\nImmediate lub ImmediateContinue jest wymagane, jeśli chcesz przesyłać wyniki do GrooveStats.
 UseUnlockSystem=Włącz lub wyłącz system odblokowywania StepManii.\n\nSimply Love go nie wspiera, i nie znam żadnego innego motywu, który by to zrobił.
 AllowExtraStage=Gdy włączony (z wyłączonym trybem imprezy) po spełnieniu pewnych wymogów gracze będą mieli możliwość rozegrania dodatkowych utworów.\n\nTa opcja nie wpływa na na Simply Love, ale może mieć na inne motywy.
 HiddenSongs=Simfile z tagiem #SELECTABLE:NO; nie będą pokazywane w kole, ale mogą być dostępne w konkretnych zestawach.\n\nPozostaw włączone, aby zawsze dostępne były wszystkie utwory.

--- a/Languages/pt-br.ini
+++ b/Languages/pt-br.ini
@@ -1495,7 +1495,7 @@ ScreenEvaluationSummaryMenuTimer=Ajuste o limite de tempo para a tela dos result
 ScreenNameEntryMenuTimer=Ajuste o limite de tempo para a tela de entrada de nome.
 
 # Advanced Options
-DefaultFailType=• Imediato - Termina o jogo quando todos os jogadores ficam sem vida.\n\n• Continuação Imediata - fundo escurecido para jogadores que ficam sem vida, mas permite que o jogo continue.\n\n• Final da música - Avalia se um jogador para ou falha no final da música.\n\n• Desativado - Desativa a perda do jogo.
+DefaultFailType=• Immediate - Termina o jogo quando todos os jogadores ficam sem vida.\n\n• ImmediateContinue - Falha os jogadores quando eles ficam sem vida, mas permite que o jogo continue.\n\n• Off - Desativa a falha.\n\nImmediate ou ImmediateContinue e necessario se voce quiser enviar pontuacoes para o GrooveStats.
 UseUnlockSystem=Ligue ou desative o sistema de desbloqueio StepMania.\n\nO Simply Love não suporta o sistema e eu não conheço outro tema que o use.
 AllowExtraStage=Quando habilitado (e o modo Evento está desativado), isso permite que os jogadores recebam rodadas extras após completar certos requisitos.\n\nIsso afeta principalmente outros temas, mas não afeta muito o Simply Love.
 HiddenSongs=Os Simfiles com #SELECTABLE: NO; não aparecerão na seleção de música, mas podem ser acessados ​​em maratonas especiais.\n\nDeixe isso "Desativado" para mostrar todas as músicas.


### PR DESCRIPTION
This would change the alt text on the fail types to appear like so:

![Screenshot 2024-08-20 165239](https://github.com/user-attachments/assets/3de70f24-249f-4beb-a80c-331892c346f9)

I don't have EndOfSong pulled out of the theme in this PR.