### PR TITLE
enforce ITGmania requirement

### DIFF
--- a/BGAnimations/ScreenInit overlay/CompatibilityChecks.lua
+++ b/BGAnimations/ScreenInit overlay/CompatibilityChecks.lua
@@ -16,7 +16,7 @@ return Def.Actor{
 
 		-- defined in ./Scripts/SL-Helpers.lua
 		if not StepManiaVersionIsSupported() then
-			SM( THEME:GetString("ScreenInit", "UnsupportedSMVersion"):format(ProductFamily(), ProductVersion()) )
+			SM( THEME:GetString("ScreenInit", "UnsupportedSMVersion"):format(ProductFamily(), ProductVersion(), MinimumVersionString()) )
 			-- ScreenSystemOptions is the first choice in the operator menu
 			-- players can set their game, theme, default NoteSkin, etc. from it
 			SCREENMAN:SetNewScreen("ScreenSystemOptions")

--- a/BGAnimations/ScreenOptionsService overlay/Support.lua
+++ b/BGAnimations/ScreenOptionsService overlay/Support.lua
@@ -61,7 +61,7 @@ a.OffCommand=function(self)
 		end
 
 		if not StepManiaVersionIsSupported() then
-			SM( THEME:GetString("ScreenInit", "UnsupportedSMVersion"):format(ProductFamily(), ProductVersion()) )
+			SM( THEME:GetString("ScreenInit", "UnsupportedSMVersion"):format(ProductFamily(), ProductVersion(), MinimumVersionString()) )
 			SCREENMAN:SetNewScreen("ScreenSystemOptions")
 		end
 	end

--- a/Languages/de.ini
+++ b/Languages/de.ini
@@ -16,7 +16,7 @@ PopupDismissText=Drücke &START; um zu schließen.
 
 [ScreenInit]
 UnsupportedGame=%s ist in Simply Love nicht spielbar.\nBitte wähle ein anderes Spiel.
-UnsupportedSMVersion=%s %s wird nicht von Simply Love unterstützt.\nBitte wähle ein anderes Theme oder nutz ITGmania 0.8 oder neuer.
+UnsupportedSMVersion=%s %s wird nicht von Simply Love unterstützt.\nBitte wähle ein anderes Theme oder nutz ITGmania %s oder neuer.
 
 #' Attract Loop
 [ScreenLogo]

--- a/Languages/de.ini
+++ b/Languages/de.ini
@@ -16,7 +16,7 @@ PopupDismissText=Drücke &START; um zu schließen.
 
 [ScreenInit]
 UnsupportedGame=%s ist in Simply Love nicht spielbar.\nBitte wähle ein anderes Spiel.
-
+UnsupportedSMVersion=%s %s wird nicht von Simply Love unterstützt.\nBitte wähle ein anderes Theme oder nutz ITGmania 0.8 oder neuer.
 
 #' Attract Loop
 [ScreenLogo]

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -10,7 +10,7 @@ PopupDismissText=Press &START; to dismiss.
 [ScreenInit]
 # UnsupportedGame is a SystemMessage displayed at startup if SM5 is in kickbox, beat, lights, etc. game
 UnsupportedGame=%s is not a playable game in Simply Love.\nPlease choose a different game.
-UnsupportedSMVersion=%s %s is not supported by Simply Love.\nPlease choose a different theme or use SM5.1-beta or SM5.0.12.
+UnsupportedSMVersion=%s %s is not supported by Simply Love.\nPlease choose a different theme or use ITGmania 0.8.0.
 
 ##############################################
 # Attract Loop

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -10,7 +10,7 @@ PopupDismissText=Press &START; to dismiss.
 [ScreenInit]
 # UnsupportedGame is a SystemMessage displayed at startup if SM5 is in kickbox, beat, lights, etc. game
 UnsupportedGame=%s is not a playable game in Simply Love.\nPlease choose a different game.
-UnsupportedSMVersion=%s %s is not supported by Simply Love.\nPlease choose a different theme or use ITGmania 0.8.0.
+UnsupportedSMVersion=%s %s is not supported by Simply Love.\nPlease choose a different theme or use ITGmania %s.
 
 ##############################################
 # Attract Loop

--- a/Scripts/SL-SupportHelpers.lua
+++ b/Scripts/SL-SupportHelpers.lua
@@ -67,6 +67,8 @@ function IsITGmania()
 	return ProductFamily() == "ITGmania"
 end
 
+-- define the required version here
+local MinimumVersion = {0, 8, 0}
 
 -- -----------------------------------------------------------------------
 -- use StepManiaVersionIsSupported() to check if Simply Love supports the version of SM5 in use
@@ -75,13 +77,20 @@ StepManiaVersionIsSupported = function()
 	-- SM5.0.12, SM5.1.x and OutFox are no longer supported
 	-- ITGmania >= 0.8.0
 	if IsITGmania() then
-		return IsMinimumProductVersion(0, 8, 0)
+		return IsMinimumProductVersion(MinimumVersion[1], MinimumVersion[2], MinimumVersion[3])
 	end
 
 	return false
 end
 
 -- -----------------------------------------------------------------------
+-- used for the unsupported engine message to avoid having to change every language file for every release
+
+MinimumVersionString = function()
+	return string.format("%i.%i.%i", MinimumVersion[1], MinimumVersion[2], MinimumVersion[3])
+end
+
+- -----------------------------------------------------------------------
 -- game types like "kickbox" and "lights" aren't supported in Simply Love, so we
 -- use this function to hardcode a list of game modes that are supported, and use it
 -- in ScreenInit overlay.lua to redirect players to ScreenSelectGame if necessary.

--- a/Scripts/SL-SupportHelpers.lua
+++ b/Scripts/SL-SupportHelpers.lua
@@ -62,19 +62,6 @@ function IsMinimumProductVersion(...)
 	return true
 end
 
-
-function IsStepMania()
-	if type(ProductFamily) ~= "function" then return false end
-	return ProductFamily() == "StepMania"
-end
-
-
-function IsOutFox()
-	if type(ProductFamily) ~= "function" then return false end
-	return ProductFamily() == "OutFox"
-end
-
-
 function IsITGmania()
 	if type(ProductFamily) ~= "function" then return false end
 	return ProductFamily() == "ITGmania"

--- a/Scripts/SL-SupportHelpers.lua
+++ b/Scripts/SL-SupportHelpers.lua
@@ -86,13 +86,6 @@ end
 
 StepManiaVersionIsSupported = function()
 	-- SM5.0.12, SM5.1.x and OutFox are no longer supported
-	if IsStepMania() then
-		return false
-	end
-	if IsOutFox() then
-		return false
-	end
-
 	-- ITGmania >= 0.8.0
 	if IsITGmania() then
 		return IsMinimumProductVersion(0, 8, 0)

--- a/Scripts/SL-SupportHelpers.lua
+++ b/Scripts/SL-SupportHelpers.lua
@@ -85,17 +85,12 @@ end
 -- use StepManiaVersionIsSupported() to check if Simply Love supports the version of SM5 in use
 
 StepManiaVersionIsSupported = function()
-	-- SM5.0.12 is supported (latest stable release)
-	-- SM5.1.x is supported
-	-- SM5.2 is not supported because it saw significant
-	--       backwards-incompatible API changes and is now abandoned
+	-- SM5.0.12, SM5.1.x and OutFox are no longer supported
 	if IsStepMania() then
-		return IsProductVersion(5, 0, 12) or IsProductVersion(5, 1)
+		return false
 	end
-
-	-- OutFox >= 0.4 is supported (beta status because it's not open source yet)
 	if IsOutFox() then
-		return IsMinimumProductVersion(0, 4)
+		return false
 	end
 
 	-- ITGmania >= 0.8.0


### PR DESCRIPTION
Right now, you can still use the theme on older versions of SM5 and OutFox, even though many things either don't work or break entirely (specifically the results screen has been reported to no longer work on OutFox). 

Since we're only supporting ITGmania now anyway, we should actually start to enforce this.

`UnsupportedSMVersion` would still have to get updated in the remaining languages, I've only changed it in the English language file.

EDIT: added German too because I might as well.