### PR TITLE
Add Practice Mode support

### DIFF
--- a/BGAnimations/ScreenPractice underlay.lua
+++ b/BGAnimations/ScreenPractice underlay.lua
@@ -1,0 +1,53 @@
+local t = Def.ActorFrame{
+	Name="Text",
+	OnCommand=function(self) self:queuecommand("Show") end,
+	EditCommand=function(self) self:playcommand("Show") end,
+
+	PlayingCommand=function(self) self:playcommand("Hide") end,
+	RecordCommand=function(self) self:playcommand("Hide") end,
+	RecordPausedCommand=function(self) self:playcommand("Hide") end,
+
+	-- Info
+	Def.ActorFrame{
+		InitCommand=function(self) self:xy(_screen.w, 10) end,
+		ShowCommand=function(self) self:visible(true) end,
+		HideCommand=function(self) self:visible(false) end,
+
+		Def.Quad{ InitCommand=function(self) self:zoomto(30,1):horizalign(right) end },
+
+		LoadFont("Common Bold") .. {
+			Name="InfoText",
+			Text="PRACTICE MODE",
+			InitCommand=function(self) self:zoom(0.265):horizalign(right):x(-35):diffuse(PlayerColor(PLAYER_1)) end,
+		}
+	}
+}
+
+local sections = {
+	NavigationHelp = 0,
+	MenuHelp = 100,
+	MiscHelp = 136
+}
+
+for section, offset in pairs(sections) do
+	t[#t+1] = Def.ActorFrame{
+		Name=section,
+		InitCommand=function(self) self:xy(0, offset) end,
+		ShowCommand=function(self) self:visible(true) end,
+		HideCommand=function(self) self:visible(false) end,
+
+		LoadFont("Common Bold")..{
+			Text=THEME:GetString("ScreenPractice", section.."Label"),
+			InitCommand=function(self) self:zoom(0.265):horizalign(left):xy(35, 10):diffuse(PlayerColor(PLAYER_1)) end
+		},
+		Def.Quad{
+			InitCommand=function(self) self:y(10):zoomto(30,1):horizalign(left):diffusealpha(0.75) end
+		},
+		LoadFont("Common Normal")..{
+			Text=THEME:GetString("ScreenPractice", section.."Text"),
+			InitCommand=function(self) self:xy(10, 20):zoom(0.6):horizalign(left):vertalign(top):vertspacing(-1) end,
+		},
+	}
+end
+
+return t

--- a/BGAnimations/ScreenSelectMusic overlay/SortMenu/SortMenu_InputHandler.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SortMenu/SortMenu_InputHandler.lua
@@ -101,6 +101,9 @@ local input = function(event)
 					screen:GetMusicWheel():Move(1)
 					screen:GetMusicWheel():Move(-1)
 					screen:GetMusicWheel():Move(0)
+				elseif focus.new_overlay == "PracticeMode" then
+					SCREENMAN:GetTopScreen():SetNextScreenName("ScreenPractice")
+					SCREENMAN:GetTopScreen():StartTransitioningScreen("SM_GoToNextScreen")
 				elseif focus.new_overlay == "Preferred" then
 					-- Only allow sorting by favorites if there are favorites available
 					if (#SL[ToEnumShortString(event.PlayerNumber)].Favorites > 0) then

--- a/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
@@ -298,6 +298,9 @@ local t = Def.ActorFrame {
 			if (game=="dance" or game=="pump" or game=="techno") then
 				table.insert(wheel_options, {"FeelingSalty", "TestInput"})
 			end
+			if GAMESTATE:GetCurrentSong() ~= nil and ThemePrefs.Get("KeyboardFeatures") then
+				table.insert(wheel_options, {"HardTime", "PracticeMode"})
+			end
 		end
 
 		table.insert(wheel_options, {"TakeABreather", "LoadNewSongs"})

--- a/Languages/de.ini
+++ b/Languages/de.ini
@@ -159,6 +159,10 @@ DoubleChallengeMeter=Experte
 FeelingSalty=Feeling salty?
 TestInput=Test Input
 
+# Practice mode
+HardTime=Ist es zu schwierig?
+PracticeMode=Übungsmodus
+
 
 SortBy=Sortieren Nach
 ChangeMode=Modus Ändern zum

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -161,6 +161,10 @@ Versus8=Versus
 FeelingSalty=Feeling salty?
 TestInput=Test Input
 
+# Practice mode
+HardTime=Having a hard time?
+PracticeMode=Practice Mode
+
 # For displaying the GrooveStats leaderboard (available from SortMenu)
 GrooveStats=GrooveStats
 Leaderboard=Leaderboard
@@ -461,6 +465,24 @@ MenuHelpText=Escape: Main Menu\nEnter: Area Menu\nA: Alter Menu\nF4: Timing Menu
 RecordModeHelpText=Control + R: Start Record Mode\nQ/W: Change record hold time.\nE/R: Toggle record holds
 KeyMappingHelpText=F1: Keymappings Help
 MiscHelpText=Space bar: Set area marker\nT: Toggle Song/Steps Timing
+
+[ScreenPractice]
+PlayRecordHelpText=
+EditHelpText=
+
+Main title=Song Title
+
+# Help Section Headers
+NavigationHelpLabel=Navigating
+MenuHelpLabel=Available Menus
+KeyMappingHelpLabel=KeyMappings
+MiscHelpLabel=Misc.
+
+# Explanations
+NavigationHelpText=Up/Down:\n     Move One Measure\nSemicolon/Apostrophe:\n     Move One Measure\nHome/End:\n    Move to Start/End of Steps
+MenuHelpText=Escape\Enter: Main Menu
+KeyMappingHelpText=F1: Keymappings Help
+MiscHelpText=Space: Set area marker
 
 
 [ScreenAttackMenu]

--- a/Languages/es.ini
+++ b/Languages/es.ini
@@ -160,6 +160,10 @@ Cancel=PRESIONA &SELECT; PARA CANCELAR
 FeelingSalty=¿Sientes Ira?
 TestInput=Probar Botones
 
+# Practice mode
+HardTime=¿Demasiado difícil?
+PracticeMode=Modo practica
+
 GrooveStats=GrooveStats
 Leaderboard=Tabla de clasificaciones
 

--- a/Languages/fr.ini
+++ b/Languages/fr.ini
@@ -126,6 +126,11 @@ ChangeStyle=Changer le style en
 
 Cancel=APPUYEZ SUR &SELECT; POUR ANNULER
 
+
+# Practice mode
+HardTime=Est-ce trop difficile?
+PracticeMode=Mode entraînement
+
 Double=Double
 Single=Simple
 Versus=Versus

--- a/Languages/it.ini
+++ b/Languages/it.ini
@@ -175,6 +175,10 @@ Versus8=Battaglia
 FeelingSalty=Hai una strana sensazione?
 TestInput=Test Input
 
+# Practice mode
+HardTime=È troppo difficile?
+PracticeMode=Modalità pratica
+
 # For displaying the GrooveStats leaderboard (available from SortMenu)
 GrooveStats=GrooveStats
 Leaderboard=Classifica

--- a/Languages/ja.ini
+++ b/Languages/ja.ini
@@ -118,6 +118,10 @@ ChangeStyle=スタイル変更
 
 Cancel=PRESS &SELECT; TO CANCEL
 
+# Practice mode
+HardTime=難しすぎる?
+PracticeMode=練習モード
+
 Double=Double
 Single=Single
 Versus=Versus

--- a/Languages/pl.ini
+++ b/Languages/pl.ini
@@ -170,6 +170,10 @@ FeelingSalty=Coś nie styka?
 TestInput=Test Kontrolerów
 TestInputHelpText=&START; powrót do wyboru utworu.
 
+# Practice mode
+HardTime=Czy to zbyt trudne?
+PracticeMode=Tryb ćwiczeń
+
 # Panel GrooveStats w SortMenu.
 GrooveStats=GrooveStats
 Leaderboard=Tablica wyników

--- a/Languages/pt-br.ini
+++ b/Languages/pt-br.ini
@@ -178,6 +178,10 @@ DoubleMediumMeter=Medio
 DoubleHardMeter=Dificil
 DoubleChallengeMeter=Profissional
 
+# Practice mode
+HardTime=É muito difícil?
+PracticeMode=Modo de prática
+
 FeelingSalty=Está se sentido nervoso?
 TestInput=Teste de Entrada
 

--- a/metrics.ini
+++ b/metrics.ini
@@ -1624,6 +1624,12 @@ MusicWheelSortMessageCommand=%function(self, params) \
 	self:ChangeSort('SortOrder_'..params.order) \
 end
 
+[ScreenPractice]
+Fallback="ScreenEdit"
+Class="ScreenEdit"
+NextScreen="ScreenSelectMusic"
+PrevScreen="ScreenOptionsEdit"
+EditMode="EditMode_Practice"
 
 [ScreenSelectCourse]
 Class="ScreenSelectMusic"


### PR DESCRIPTION
Adds a new entry into the SortMenu for accessing practice mode, and hides it if the sort menu is called when not hovering over a song.

Language support here is a simple google translate on "Practice mode", with flavor text added in English and Japanese (the only two languages I'm sure about here). Though I'm totally open to changing or removing said flavor text.