### PR TITLE
Update histogram white window display condition

### DIFF
--- a/BGAnimations/ScreenEvaluation common/Panes/Pane5/Calculations.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane5/Calculations.lua
@@ -127,7 +127,7 @@ for offset=-worst_window, worst_window, 0.001 do
 
 		c = colors[DetermineTimingWindow(offset)]
 
-		if mods.ShowFaPlusPane then
+		if mods.ShowFaPlusPane and mods.ShowFaPlusWindow then
 			abs_offset = math.abs(offset)
 			if abs_offset > GetTimingWindow(1, "FA+") and abs_offset <= GetTimingWindow(2, "FA+") then
 				c = SL.JudgmentColors["FA+"][2]


### PR DESCRIPTION
Require both FA Plus pane and FA Plus timing window to be enabled for histogram display