### PR TITLE
Couples Primer - Add ""support"" for couples and routine charts in the ChartParser

### DIFF
--- a/Scripts/SL-ChartParser.lua
+++ b/Scripts/SL-ChartParser.lua
@@ -728,6 +728,11 @@ end
 
 local MaybeCopyFromOppositePlayer = function(pn, filename, stepsType, difficulty, description)
 	local opposite_player = pn == "P1" and "P2" or "P1"
+	-- If the stepsType ends in routine or couple just return false
+	-- because players do not have the same chart despite the same simfile
+	if stepsType:match("routine") or stepsType:match("couple") then
+		return false
+	end
 
 	-- Check if we already have the data stored in the opposite player's cache.
 	if (SL[opposite_player].Streams.Filename == filename and
@@ -788,6 +793,15 @@ ParseChartInfo = function(steps, pn)
 			if chartString ~= nil and BPMs ~= nil then
 				-- We use 16 characters for the V3 GrooveStats hash.
 				local Hash = BinaryToHex(CRYPTMAN:SHA1String(chartString..BPMs)):sub(1, 16)
+
+				-- Check if there is an & present, we're dealing with a couples chart:
+				-- Couples charts have P1 and P2 steps in the same chart string.
+				-- We need to split the chart string into two separate chart strings.
+				local splitIndex = chartString:find("&")
+				-- If the pn is P1 use the first half of the chart string, otherwise use the second half.
+				if splitIndex then
+					chartString = pn == "P1" and chartString:sub(1, splitIndex-1) or chartString:sub(splitIndex+1)
+				end
 
 				-- Append the semi-colon at the end so it's easier for GetMeasureInfo to get the contents
 				-- of the last measure.


### PR DESCRIPTION
While this technically only gives proper support for dance-couples charts in terms of the pattern info (since those are still 4-panel). It prevents the huge overflow from the DensityGraph when you're hovered over both couples and routine charts

Before:
![image](https://github.com/user-attachments/assets/de3ab420-7f2f-4502-a965-5f7189caf257)
After:
![image](https://github.com/user-attachments/assets/a7d46281-b20b-4b4a-9ee0-d5468b297b29)

The overflow was caused by routine/couples charts having an & in the chart to signify where P1s notes end and P2s begin. The ChartParser was parsing the entirety of the chart (both p1 and p2) for both players.