### PR TITLE
Add Subcategories to the SortMenu

### DIFF
--- a/BGAnimations/ScreenSelectMusic overlay/SortMenu/SortMenu_InputHandler.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SortMenu/SortMenu_InputHandler.lua
@@ -63,7 +63,13 @@ local input = function(event)
 				screen:SetNextScreenName("ScreenReloadSSM")
 				screen:StartTransitioningScreen("SM_GoToNextScreen")
 			elseif focus.new_overlay then
-				if focus.new_overlay == "TestInput" then
+				if focus.new_overlay == "GoBack" then
+					sortmenu:playcommand("AssessAvailableChoices")
+				-- if the overlay starts with "Category"
+				elseif focus.new_overlay:match("^Category") then
+					-- Pass in everything after "Category" to the broadcast
+					MESSAGEMAN:Broadcast('EnterCategory', { Category = focus.new_overlay })
+				elseif focus.new_overlay == "TestInput" then
 					sortmenu:queuecommand("DirectInputToTestInput")
 				elseif focus.new_overlay == "Leaderboard" then
 					-- The leaderboard entry is removed altogether if the service isn't available.

--- a/BGAnimations/ScreenSelectMusic overlay/SortMenu/WheelItemMT.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SortMenu/WheelItemMT.lua
@@ -80,12 +80,19 @@ return {
 			else
 				self.new_overlay = info[2]
 			end
-
+			
 			local toptext    = self.kind ~= "" and THEME:GetString("ScreenSelectMusic", self.kind) or ""
 			local bottomtext = THEME:GetString(self.kind == "ChangeMode" and "ScreenSelectPlayMode" or "ScreenSelectMusic", info[2])
 
 			self.top_text:settext(toptext)
 			self.bottom_text:settext(bottomtext)
+			if bottomtext == "Go Back" then
+				self.bottom_text:diffuse(Color.Red)
+			elseif toptext == "" then
+				self.bottom_text:diffuse(Color.Blue)
+			else
+				self.bottom_text:diffuse(Color.White)
+			end
 		end
 	}
 }

--- a/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
@@ -274,6 +274,7 @@ local wheel_options = {
 		{"", "CategoryAdvanced"},
 		{
 			{ {"FeelingSalty", "TestInput"}, GAMESTATE:IsEventMode() },
+			{ {"HardTime", "PracticeMode"}, GAMESTATE:IsEventMode() and GAMESTATE:GetCurrentSong() ~= nil and ThemePrefs.Get("KeyboardFeatures")},
 			{ {"TakeABreather", "LoadNewSongs"} },
 			{ {"NeedMoreRam", "ViewDownloads"}, DownloadsExist() },
 			{ {"WhereforeArtThou", "SongSearch"}, not GAMESTATE:IsCourseMode() and ThemePrefs.Get("KeyboardFeatures") },

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -131,6 +131,12 @@ SortBy=Sort By
 ChangeMode=Change Mode To
 ChangeStyle=Change Style To
 Cancel=PRESS &SELECT; TO CANCEL
+Category=More...
+GoBack=Go Back
+CategorySorts=Sorts...
+#CategoryModes=Modes...
+CategoryStyles=Styles...
+CategoryAdvanced=Options...
 
 # SortMenu choices
 # SortMenu "Sort By" choices
@@ -141,10 +147,14 @@ Genre=Genre
 BPM=BPM
 Length=Length
 Recent=Recently Played
+RecentP1Played= P1 Recently Played
+RecentP2Played= P2 Recently Played
 Popularity=Most Played
 Meter=Level
+TopGrades=Machine Top Scores
 TopP1Grades=P1 Clear Rank
 TopP2Grades=P2 Clear Rank
+
 # SortMenu "Change Style To" choices
 Single=Single
 Double=Double


### PR DESCRIPTION
This PR adds Subcategories to the sort menu in order to reduce the amount of items in a single wheel. The current categories are:
- Sorts (Options that sort the MusicWheel)
- Styles (Change styles)
- Advanced (Misc other more advanced options like test input)
- Playlists (More on this below)

I kept some things outside of categories as well just so we're not adding extra steps for people (i.e. Group and Title sorting exist both in the main menu and within the "Sort" submenu.

In addition to subcategories, this also adds support for drop-in playlists in the Playlists folder. I can split this into a separate PR if needed, I left it in one since on my end it was all added at once. Playlists are just txt files (exact format as favorites) placed in the Playlists folder. All available playlists will be shown under the Playlist category and will load the respective listing as preferred sorting. This can aid users who wish to distribute their favorites or recommendations, hold small tournaments, or just want separate listings for groups of songs.

I've attached a video showing all of the above, let me know if there are any adjustments to make and if the current list of submenus is sufficient:

https://github.com/user-attachments/assets/c39f986d-a3a3-46af-8f02-e1c85cb900de
