### PR TITLE
Fix scores being submitted with FailOffForFirstStageEasy or FailOffInBeginner set

### DIFF
--- a/Scripts/SL-Helpers-GrooveStats.lua
+++ b/Scripts/SL-Helpers-GrooveStats.lua
@@ -441,8 +441,11 @@ ValidForGrooveStats = function(player)
 		or po:Big()
 	)
 
+	-- we can't use po:FailSetting() here because effective fail type can be overridden by preferences
+	-- use GAMESTATE:GetPlayerFailType() since ScreenGameplay uses the same function internally
+	local failType = GAMESTATE:GetPlayerFailType(player);
 	-- only FailTypes "Immediate" and "ImmediateContinue" are valid for GrooveStats
-	valid[11] = (po:FailSetting() == "FailType_Immediate" or po:FailSetting() == "FailType_ImmediateContinue")
+	valid[11] = (failType == "FailType_Immediate" or failType == "FailType_ImmediateContinue")
 
 	-- AutoPlay/AutoplayCPU is not allowed
 	valid[12] = IsHumanPlayer(player)


### PR DESCRIPTION
Use the newly addded `GAMESTATE:GetPlayerFailType()` to get the actual `FailType` and correctly reject submission to GrooveStats based on that.