### PR TITLE
GlobalOffsetSeconds: Allow up to 1000ms (from 100).

### DIFF
--- a/Scripts/SL-OperatorMenuOptions.lua
+++ b/Scripts/SL-OperatorMenuOptions.lua
@@ -264,8 +264,8 @@ function offsetMS(pref, low, high)
 end
 
 OperatorMenuOptionRows.GlobalOffsetSeconds = function()
-	-- 100ms should be sufficient to accomodate for audio delay
-	return offsetMS("GlobalOffsetSeconds", -100, 100)
+	-- up to 1s of audio delay (via HDMI), because some TVs are really slow
+	return offsetMS("GlobalOffsetSeconds", -1000, 1000)
 end
 
 OperatorMenuOptionRows.VisualDelaySeconds = function()


### PR DESCRIPTION
If the audio output is from the TV itself (sacrilege!) then this could be as large as VisualDelaySeconds.