### PR TITLE
Updating Japanese Translations

### DIFF
--- a/BGAnimations/ScreenGrooveStatsLogin underlay/default.lua
+++ b/BGAnimations/ScreenGrooveStatsLogin underlay/default.lua
@@ -75,11 +75,11 @@ local af = Def.ActorFrame{
   end,
 
   LoadFont("Common Normal")..{
-    Text="Scan the QR code to log in to GrooveStats!",
+    Text=THEME:GetString("ScreenSelectProfile", "LoginInstructions"),
     InitCommand=function(self) self:y(-150) end,
   },
   LoadFont("Common Normal")..{
-    Text="Visit www.groovestats.com to create an account.",
+    Text=THEME:GetString("ScreenSelectProfile", "VisitWebsite"),
     InitCommand=function(self) self:y(-120) end,
   },
 
@@ -112,7 +112,7 @@ for player in ivalues(GAMESTATE:GetHumanPlayers()) do
     },
 
     LoadFont("Common Normal")..{
-      Text=SL[pn].ApiKey and "Profile already\nconnected!" or "",
+      Text=SL[pn].ApiKey and THEME:GetString("ScreenSelectProfile", "ProfileConnected") or "",
       HideQrMessageCommand=function(self, params)
         if params.pn == pn then
           WriteGrooveStatsIni(player)
@@ -132,7 +132,7 @@ for player in ivalues(GAMESTATE:GetHumanPlayers()) do
     childAf[#childAf+1] = LoadActor( qrModulePath , {url, qrcodeSize} )..{
       Name="QRCode",
       InitCommand=function(self) self:xy(-84, -84) end,
-      HideQrMessageCommand=function(self, params) 
+      HideQrMessageCommand=function(self, params)
         if params.pn == pn then
           self:visible(false)
         end

--- a/BGAnimations/ScreenSelectMusic overlay/PerPlayer/DensityGraph.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/PerPlayer/DensityGraph.lua
@@ -123,9 +123,10 @@ af2[#af2+1] = NPS_Histogram(player, width, height)..{
 af2[#af2]["CurrentSteps"..pn.."ChangedMessageCommand"] = nil
 
 -- The Peak NPS text
+local peakNPSText = THEME:GetString("ScreenGameplay", "PeakNPS")
 af2[#af2+1] = LoadFont("Common Normal")..{
 	Name="NPS",
-	Text="Peak NPS: ",
+	Text=peakNPSText..": ",
 	InitCommand=function(self)
 		self:horizalign(left):zoom(0.8)
 		if player == PLAYER_1 then
@@ -137,12 +138,12 @@ af2[#af2+1] = LoadFont("Common Normal")..{
 		self:diffuse((ThemePrefs.Get("RainbowMode") and not HolidayCheer()) and {0, 0, 0, 1} or {1, 1, 1, 1})
 	end,
 	HideCommand=function(self)
-		self:settext("Peak NPS: ")
+		self:settext(peakNPSText..": ")
 		self:visible(false)
 	end,
 	RedrawCommand=function(self)
 		if SL[pn].Streams.PeakNPS ~= 0 then
-			self:settext(("Peak NPS: %.1f"):format(SL[pn].Streams.PeakNPS * SL.Global.ActiveModifiers.MusicRate))
+			self:settext((peakNPSText..": %.1f"):format(SL[pn].Streams.PeakNPS * SL.Global.ActiveModifiers.MusicRate))
 			self:visible(not showPatternInfo)
 		end
 	end,
@@ -225,7 +226,7 @@ af2[#af2+1] = Def.ActorFrame{
 	TogglePatternInfoCommand=function(self)
 		self:visible(showPatternInfo)
 	end,
-	
+
 	-- Background for the additional chart info.
 	-- Only shown in 1 Player mode
 	Def.Quad{
@@ -288,7 +289,7 @@ for i, row in ipairs(layout) do
 		}
 
 		af3[#af3+1] = LoadFont("Common Normal")..{
-			Text=col,
+			Text=THEME:GetString("TechCategory", col),
 			Name=col,
 			InitCommand=function(self)
 				local textHeight = 17

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -57,6 +57,9 @@ MostRecentSong=Most Recent Song
 MostFrequentGrade=Most Frequent Grade
 SingularSongPlayed=%d Song Played
 SeveralSongsPlayed=%d Songs Played
+LoginInstructions=Scan the QR code to log in to GrooveStats!
+VisitWebsite=Visit www.groovestats.com to create an account.
+ProfileConnected=Profile already\nconnected!
 
 [ScreenSelectColor]
 HeaderText=Select A Color

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -514,6 +514,14 @@ Random=RANDOM
 [RadarCategory]
 Taps=Steps
 
+[TechCategory]
+Crossovers=Crossovers
+Footswitches=Footswitches
+Sideswitches=Sideswitches
+Jacks=Jacks
+Brackets=Brackets
+Total Stream=Total Stream
+
 [TapNoteScore]
 W1=Fantastic
 W2=Excellent

--- a/Languages/ja.ini
+++ b/Languages/ja.ini
@@ -560,9 +560,15 @@ Overscan Correction=ブラウン管のオーバースキャンの調査設定で
 CRT Test Patterns=ブラウン管調査と試験用のテストパトーンです。
 
 # Graphics/Sound Options
+VideoRenderer=ビデオレンダリングのAPIを選べます。OSによって, openglだけ使えます.\n\nd3d (Windowsのみ)は視覚効果のサポートされていません。例えば、たくさんのmod chartsが正しく表示出来ません。\n\n変更を有効するために再起動する必要があるます。
+TextureColorDepth=テクスチャの色深度を設定します。\n32bitにするとメモリを多く消費しますが綺麗に表示されます。
+MovieColorDepth=動画の色深度を設定します。\n32bitにするとメモリを多く消費しますが綺麗に表示されます。
 SmoothLines=テーマのアンチエイリアスを有効にするかを選択します。\n\nActorMultiVertexに'LineStrip'を使用しているテーマおよび楽曲がこの設定の影響を受けます。
 FastNoteRendering='On'にした場合、Zバッファが各ノートの描画毎にクリアされなくなります。これによって、3Dのノートスキンの表示がおかしくなる場合がありますが、パフォーマンスはけっこう改善されるはずです。
+ShowStats=パフォーマンス統計が画面の右上表示出来ます。右下はフレームスキップを表示できます。\n\nFPS = フレーム毎秒\nVPF = フレームごとの頂点\n\n高いVPFはitgmaniaが複雑なものを描くことです。同じFPSを保つために、もっと強いハードイェアとかもっと効果的なプログラミングが必要であります。\n\nF3+6でいつでもこの設定を切り替え可能です.
+GlobalOffsetSeconds= 数ミリ病で音楽のオフセットを調製出来ます。\n\n負の値になったら、オーディオを早く再生する (late arrows), positive values cause audio playback to be late (early arrows).
 VisualDelaySeconds=画面表示の遅延を調整します。LCDのレイテンシをなんとかするために、一応残っている設定項目らしいです。
+AttractSoundFrequency=アトラクトデモで音を流す頻度を設定します。Simply_Loveはアトラクトデモがないが他のテームがこの設定使うかも知りまえん。ALWAYSに設定すると毎回音が流れます。N_TIMESに設定するとN回ごとに音が流れます。NEVERに設定すると音が流れません。
 
 # Appearance Options
 ShowLyrics=歌詞を表示するか否かを選択します。\n\n歌詞は楽曲ごとに.lrcファイルで付与することができます。

--- a/Languages/ja.ini
+++ b/Languages/ja.ini
@@ -41,6 +41,7 @@ Press Start=Press &START; To Play
 HeaderText=Select Profile
 PressStartToJoin=Press &START; to join!
 NoProfile=No Profile
+GuestProfile=[ゲスト]
 Card=CARD
 MostRecentSong=Most Recent Song
 MostFrequentGrade=Most Frequent Grade
@@ -104,7 +105,7 @@ Entering Options...=Entering Options...
 Options=Options
 
 # StepArtist
-STEPS=STEPS
+STEPS=作者
 
 # SortMenu labels
 SortBy=並び替え
@@ -187,8 +188,9 @@ SetSummaryText=記憶を回復する
 
 # prompt players before exiting via LLRRLLRR
 PromptBeforeExiting=本当に終了しますか？
-YesInfo=I'm finished.
-NoInfo=Keep playing.
+YesInfo=終わる
+NoInfo=もっと遊びたい
+
 
 [SongDescription]
 Artist=Artist
@@ -225,10 +227,10 @@ Song Length=Song Length
 Heart Rate=Heart Rate
 
 [ScreenEvaluation]
-Holds=holds
-Mines=mines
-Hands=hands
-Rolls=rolls
+Holds=FA
+Mines=地雷
+Hands=３つ
+Rolls=ロール
 Max Combo=Max Combo
 Held=HELD
 HeaderText=Evaluation
@@ -400,19 +402,18 @@ HeaderText=Script Attack Modifiers
 Random=RANDOM
 
 [RadarCategory]
-Taps=Steps
 Hands=3つ押し
-Holds=ロング
+Holds=フリーズ
 Jumps=2つ押し
 Mines=地雷
 Rolls=ロール
-Taps=ノーツ
+Taps=ノーツ数
 
 [TechCategory]
 Crossovers=捻り
 Footswitches=スイッチ
 Sideswitches=横スイッチ
-Jacks=連打
+Jacks=縦連
 Brackets=2枚抜き
 Total Stream=合計滝
 
@@ -521,7 +522,7 @@ Theme=テーマ
 Language=言語
 Announcer=アナウンサー
 DefaultNoteSkin=デフォルトノートスキン
-EditorNoteSkin=エディターノートスキン
+EditorNoteSkin=編集ノートスキン
 
 # Arcade Options
 AllowMultipleHighScoreWithSameName=Multiple High Scores\nWith Same Name
@@ -591,13 +592,13 @@ SpeedModType=Type of Speed Mod
 SpeedMod=Speed Mod
 Mini=Mini
 NoteSkin=NoteSkin
-ScreenAfterPlayerOptions=What comes next?
+ScreenAfterPlayerOptions=次は?
 
 # ScreenPlayerOptions2
 DataVisualizations=Data Visualizations
 TargetScore=Target Score
 ActionOnMissedTarget=Action On Missed Target
-ScreenAfterPlayerOptions2=What comes next?
+ScreenAfterPlayerOptions2=次は?
 TimingWindowScale=Timing Window Scale
 TimingWindows=Disable Timing Windows
 GameplayExtras=Gameplay Extras
@@ -608,7 +609,7 @@ ErrorBarOptions=Error Bar Options
 MeasureCounterOptions=Measure Counter\nOptions
 MeasureCounter=Measure Counter
 LifeMeterType=LifeMeter Type
-ScreenAfterPlayerOptions2=What comes next?
+ScreenAfterPlayerOptions2=次は?
 
 # ScreenPlayAgain
 Yes=Yes
@@ -722,8 +723,7 @@ UseImageCache='On'にすると、Casualモードの動作がより快適にな�
 # Tournament Mode Options
 EnableTournamentMode=大会モードに有効する。
 ScoringSystem=大会がどの判定決める設定。
-StepStats=常にステップの統計が表示まｔ非表示設定。
-EnforceNoCmod=Whether or not to automatically convert "C" Mods to "M" mods during gameplay as needed.
+StepStats=常に判定の数リアルタイムが表示とか非表示設定。
 EnforceNoCmod=自動的にcmodがmmodになる。'on'になったら、プライヤーがcmod使いません。
 
 # USB Profile CustomSongs Options
@@ -785,8 +785,8 @@ Appearance=矢印が途中で消えたり現れたりします。 [m]
 Turn=矢印の配置を入れ替えます。 [m]
 Insert=矢印を増やします。 [m]
 Scroll=矢印の流れてくる方向を変更します。 [m]
-HoldJudgment=Holdノートの見た目を変更します。
-Holds=Holdノート・Rollノートを増やします。 [m]
+HoldJudgment=フリーズアローの見た目を変更します。
+Holds=フリーズアロー・ロールノートを増やします。 [m]
 Mines=Mineノートを無効化したり増やしたりできます。
 Attacks=アタックを有効化・無効化します。"Random Attacks"にすると、\nゲームプレイ中にランダムにModsが適用されます。
 PlayerAutoPlay=オートプレイを有効化・無効化します。
@@ -806,7 +806,7 @@ ErrorBarTrim=エラーバーの極端の範囲を表示することが出来ま�
 ErrorBarOptions=エラーバーの見た目を調整します。\nデフォルトでは、判定文字の真下に表示されます。Multi-TickはTextには反映されません。
 MeasureCounterOptions=Measure Counterの表示をカスタマイズできます。\nデフォルトでは、判定の真下・中央に表示されます。
 MeasureLines=ガイドラインの表示を設定します。
-MeasureCounter=Streamの小節数を表示することができます。
+MeasureCounter=滝の小節数を表示することができます。
 TimingWindowOptions=早めに踏んでしまったDecentsとかWay Offsの視覚的の行動。
 TimingWindows=一部の判定を無効化します。
 ScreenAfterPlayerOptions2=他の曲を選択するか、一つ前のオプション画面に戻ります。
@@ -881,9 +881,9 @@ CustomSongsMaxSeconds=アーケードで運用するなら、ArcadeOptionsの2-r
 ##############################################
 [SLPlayerOptions]
 #SpeedModType
-X=X (multiplier)
-C=C (constant)
-M=M (maximum)
+X=X (multiplier) (乗法)
+C=C (constant) (不変)
+M=M (maximum) (極値）
 
 #ScreenFilter
 Off=オフ
@@ -907,8 +907,8 @@ ComboExplosions=Combo Explosions
 
 # DataVisualizations
 Disabled=Disabled
-Target Score Graph=Target Score Graph
-Step Statistics=Step Statistics
+Target Score Graph=ターゲートグラフ表示
+Step Statistics=判定の数リアルタイム表示
 
 # TargetScore
 Machine best=Machine best
@@ -928,18 +928,38 @@ JudgmentTilt=判定を傾ける
 ColumnCues=列の手がかり
 DisplayScorebox=スコアボックスを表示する
 
+# ErrorBar
+None=なし
+Colorful=多彩
+Monochrome=一色
+Text=文字
+
+# ErrorBarOptions
+ErrorBarUp=上移動
+ErrorBarMultiTick=Multi-Tick
+
 # MeasureCounterOptions
-MeasureCounterLeft=Move Left
-MeasureCounterUp=Move Up
-# HideRestCounts=Hide Rest Counts
+MeasureCounterLeft=左移動
+MeasureCounterUp=上移動
+HideLookahead=先読み隠す
+
+# TimingWindowOptions
+HideEarlyDecentWayOffJudgments=判定隠す
+HideEarlyDecentWayOffFlash=NoteField Flash隠す
 
 # MeasureCounter
-None=None
-8th=8th
-12th=12th
-16th=16th
-24th=24th
-32nd=32nd
+None=なし
+8th=8分
+12th=12分
+16th=16分
+24th=24分
+32nd=32分
+
+# MeasureLines
+Off=なし
+Measure=小節
+Quarter=4分
+Eighth=8分
 
 # Disable TimingWindows
 All=All
@@ -952,8 +972,10 @@ Vertical=Vertical
 # ScreenAfterPlayerOptions
 Gameplay=ゲームプレイ
 Select Music=他の曲選ぶ
-Extra Modifiers=追加のModifiers
-Normal Modifiers=正常のModifiers
+
+Options1=正常のModifiers
+Options2=追加のModifiers
+Options3=異常のModifiers
 
 ##############################################
 [MusicWheelSpeed]
@@ -997,3 +1019,23 @@ Month9=September
 Month10=October
 Month11=November
 Month12=December
+
+##############################################
+# Whereas these months are used within HighScore Lists
+[HighScoreList]
+Month1=Jan
+Month2=Feb
+Month3=Mar
+Month4=Apr
+Month5=May
+Month6=Jun
+Month7=Jul
+Month8=Aug
+Month9=Sep
+Month10=Oct
+Month11=Nov
+Month12=Dec
+
+##############################################
+[ProfileAvatar]
+NoAvatar=No Avatar

--- a/Languages/ja.ini
+++ b/Languages/ja.ini
@@ -44,7 +44,7 @@ NoProfile=No Profile
 Card=CARD
 MostRecentSong=Most Recent Song
 MostFrequentGrade=Most Frequent Grade
-SingularSongPlayed=%d Song Played
+SingularSongPlayed=%d 遊んだ曲
 SeveralSongsPlayed=%d 遊んだ曲数
 LoginInstructions=ORコードスキャンしてログインしてください
 VisitWebsite=www.groovestats.comでアカウント作成できます
@@ -211,7 +211,7 @@ HeaderText=Select Modifiers
 HeaderText=Select Additional Modifiers
 
 [ScreenGameplay]
-PeakNPS=Peak NPS
+PeakNPS=最高NPS
 Remaining=残り時間
 Song=譜面の時間
 Course=コース
@@ -401,6 +401,20 @@ Random=RANDOM
 
 [RadarCategory]
 Taps=Steps
+Hands=3つ押し
+Holds=ロング
+Jumps=2つ押し
+Mines=地雷
+Rolls=ロール
+Taps=ノーツ
+
+[TechCategory]
+Crossovers=捻り
+Footswitches=スイッチ
+Sideswitches=横スイッチ
+Jacks=連打
+Brackets=2枚抜き
+Total Stream=合計滝
 
 [TapNoteScore]
 W1=Fantastic
@@ -699,7 +713,6 @@ CasualMaxMeter=この数値より難しい難易度の譜面はCasualモード�
 VisualStyle=背景などのテーマ各所に表示されるアイコンを指定します。\n\n各アイコンには、固有のグラフィックとBGMが用意されています。
 AllowThemeVideos=ゲームプレイに影響を与える可能性のあるビデオをテーマ画面に表示するかどうか。
 RainbowMode=Rainbow Modeを有効化・無効化します。\n\nRainbow Modeにすると、テーマ色選択画面はスキップされます。
-WriteCustomScores=This setting will enable the writing of custom scores files. They are stored in your profile directory. Scores are not stored for guest accounts.\n\nCustom score files can be uploaded to the simply.training website to track your personal progress.
 WriteCustomScores=カスタムのハイスコアを記録する。自分のプロファイルのフォルダを保存します。GUESTのアカウントが保存出来ません。\n\nこのファイルがsimply.trainingのサイトにアップロードしたら、自分の進捗状況を追跡できます。
 KeyboardFeatures=キーボードを有効化・無効化します。\n\nこれまで曲捜索だけこのオプションを使っています。
 SampleMusicLoops=選曲画面で音楽プリビューをループするかどうか。
@@ -867,7 +880,12 @@ CustomSongsMaxSeconds=アーケードで運用するなら、ArcadeOptionsの2-r
 
 ##############################################
 [SLPlayerOptions]
-# ScreenFilter
+#SpeedModType
+X=X (multiplier)
+C=C (constant)
+M=M (maximum)
+
+#ScreenFilter
 Off=オフ
 Dark=暗い
 Darker=もっと暗い
@@ -932,10 +950,10 @@ Surround=Surround
 Vertical=Vertical
 
 # ScreenAfterPlayerOptions
-Gameplay=Gameplay
-Select Music=Choose a Different Song
-Extra Modifiers=Choose Extra Modifiers
-Normal Modifiers=Change Normal Modifiers
+Gameplay=ゲームプレイ
+Select Music=他の曲選ぶ
+Extra Modifiers=追加のModifiers
+Normal Modifiers=正常のModifiers
 
 ##############################################
 [MusicWheelSpeed]

--- a/Languages/ja.ini
+++ b/Languages/ja.ini
@@ -176,10 +176,10 @@ Disqualified=Disqualified From Ranking
 Early=Early
 Late=Late
 
-StdDev=std dev * 3
-MeanTimingError=mean abs error
-MeanOffset=mean
-MaxError=max error
+StdDev=標準偏差 * 3
+MeanTimingError=平均絶対誤差
+MeanOffset=平均
+MaxError=極値
 
 QRInstructions=QRコードを読み取ってGrooveStatsアカウントにスコアをアップロードしよう！
 
@@ -698,6 +698,7 @@ Appearance=矢印が途中で消えたり現れたりします。 [m]
 Turn=矢印の配置を入れ替えます。 [m]
 Insert=矢印を増やします。 [m]
 Scroll=矢印の流れてくる方向を変更します。 [m]
+HoldJudgment=Holdノートの見た目を変更します。
 Holds=Holdノート・Rollノートを増やします。 [m]
 Mines=Mineノートを無効化したり増やしたりできます。
 Attacks=アタックを有効化・無効化します。"Random Attacks"にすると、\nゲームプレイ中にランダムにModsが適用されます。
@@ -714,12 +715,16 @@ GameplayExtras=ゲームプレイ中の様々な情報を表示することが�
 GameplayExtrasB=ゲームプレイ中の様々な情報を表示することができます。
 GameplayExtrasC=ゲームプレイ中の様々な情報を表示することができます。
 ErrorBar=判定エラーバーのスタイルを選択・もしくは無効にします。
+ErrorBarTrim=エラーバーの極端の範囲を表示することが出来ます。
 ErrorBarOptions=エラーバーの見た目を調整します。\nデフォルトでは、判定文字の真下に表示されます。Multi-TickはTextには反映されません。
 MeasureCounterOptions=Measure Counterの表示をカスタマイズできます。\nデフォルトでは、判定の真下・中央に表示されます。
+MeasureLines=ガイドラインの表示を設定します。
 MeasureCounter=Streamの小節数を表示することができます。
+TimingWindowOptions=早めに踏んでしまったDecentsとかWay Offsの視覚的の行動。
 TimingWindows=一部の判定を無効化します。
 ScreenAfterPlayerOptions2=他の曲を選択するか、一つ前のオプション画面に戻ります。
 LifeMeterType="Surround": ライフゲージが背景に縦向きに表示されます。\n"Vertical": ライフゲージがPlayField横に縦向きに表示されます。
+VisualDelay=プライヤー固有の画面表示の遅延を調整します。負の値は矢印が上に移動しますが、正の値が矢印が下に移動します。
 
 # Screen Profiles
 Select Profile=このプロファイルを使用または編集します。

--- a/Languages/ja.ini
+++ b/Languages/ja.ini
@@ -1,5 +1,5 @@
 [Common]
-WindowTitle=Simply Love
+WindowTitle=シンプリィ・ライブ(itgmania)
 
 ##############################################
 # Screens typically encountered during "normal use"
@@ -117,6 +117,8 @@ ChangeMode=モード変更
 ChangeStyle=スタイル変更
 
 Cancel=PRESS &SELECT; TO CANCEL
+
+PromptBeforeExiting=本当に終了しますか？
 
 # Practice mode
 HardTime=難しすぎる?
@@ -413,6 +415,7 @@ VisualOptions=🤍  見た目の設定
 Overscan Correction=🤍  画面位置の調整
 Timing Window Options=🤍  判定の設定
 ThemeOptions=🤍  Simply Love固有の設定
+TournamentModeOptions=🤍  試合の設定
 MenuTimerOptions=🤍  メニュータイマーの設定
 USBProfileOptions=🤍  USBカスタムソングの設定
 Set BG Fit Mode=🤍  背景サイズの設定
@@ -422,6 +425,11 @@ Clear Credits=🤍  クレジットをクリア
 GrooveStatsOptions=🤍  GrooveStatsオプション
 
 # SystemOptions
+Game=ゲーム
+Theme=テーマ
+Language=言語
+Announcer=アナウンサー
+DefaultNoteSkin=デフォルトノートスキン
 EditorNoteSkin=エディターノートスキン
 
 # Arcade Options
@@ -477,6 +485,9 @@ CustomTimingWindow=Timing Window
 
 # Arcade Options
 MusicWheelSpeed=MusicWheel\nScroll Speed
+
+# Acknowledgments Menu
+StepMania Credits=🤍  ITGMania の貢献者
 
 # ScreenPlayerOptions
 Perspective=Perspective
@@ -823,9 +834,9 @@ Custom=Custom
 
 ##############################################
 [TargetScoreGraph]
-You=You
-Personal=Personal
-Target=Target
+You=現在スコア
+Personal=自己ベスト
+Target=ターゲット
 
 ##############################################
 [ThemePrefs]

--- a/Languages/ja.ini
+++ b/Languages/ja.ini
@@ -547,7 +547,7 @@ GrooveStatsOptions=GrooveStatsオプションを管理します。
 
 # SystemOptions
 Game=ゲームタイプを変更します。\n\n• dance - 4パネル (DDRやITG)\n• pump - 5パネル (Pump It Up)\n• techno - 8パネル (TechnoMotion).
-Theme=StepManiaのテーマを変更します。\n\nテーマは見た目だけでなく、StepMania5の機能を拡張することもあります。
+Theme=ITGmaniaのテーマを変更します。\n\nテーマは見た目だけでなく、ITGmaniaの機能を拡張することもあります。
 Language=現在、Simply Loveは以下の言語を公::式にサポートしています\n• English\n• Español\n• Français\n• Italiano\n• 日本語\n• Polski\n• Português Brasileiro (pt-br)\n• Deutsch\n他の言語はSimply Loveでは一部的に::しかサポートされていませんが、他のテーマではもっとサポートされているかもしれません。
 Announcer=アナウンサーを変更します。
 DefaultNoteSkin=デフォルトで使うノートスキンを変更します。\n\nプレイヤーは、もしプレイヤーが望めば、楽曲選択後のオプションからこれ以外のものに変更することもできます。
@@ -565,8 +565,8 @@ TextureColorDepth=テクスチャの色深度を設定します。\n32bitにす�
 MovieColorDepth=動画の色深度を設定します。\n32bitにするとメモリを多く消費しますが綺麗に表示されます。
 SmoothLines=テーマのアンチエイリアスを有効にするかを選択します。\n\nActorMultiVertexに'LineStrip'を使用しているテーマおよび楽曲がこの設定の影響を受けます。
 FastNoteRendering='On'にした場合、Zバッファが各ノートの描画毎にクリアされなくなります。これによって、3Dのノートスキンの表示がおかしくなる場合がありますが、パフォーマンスはけっこう改善されるはずです。
-ShowStats=パフォーマンス統計が画面の右上表示出来ます。右下はフレームスキップを表示できます。\n\nFPS = フレーム毎秒\nVPF = フレームごとの頂点\n\n高いVPFはitgmaniaが複雑なものを描くことです。同じFPSを保つために、もっと強いハードイェアとかもっと効果的なプログラミングが必要であります。\n\nF3+6でいつでもこの設定を切り替え可能です.
-GlobalOffsetSeconds= 数ミリ病で音楽のオフセットを調製出来ます。\n\n負の値になったら、オーディオを早く再生する (late arrows), positive values cause audio playback to be late (early arrows).
+ShowStats=パフォーマンス統計が画面の右上表示出来ます。右下はフレームスキップを表示できます。\n\nFPS = フレーム毎秒\nVPF = フレームごとの頂点\n\n高いVPFはitgmaniaが複雑なものを描くことです。同じFPSを保つために、もっと強いハードイェアとかもっと効果的なプログラミングが必要であります。\n\nF3+6でいつでもこの設定を切り替え可能です
+GlobalOffsetSeconds= 数ミリ病で音楽のオフセットを調製出来ます。\n\n負の値になったら、オーディオを早く再生する (矢印がもっと遅く来る)、正の値になったら、オーディオを遅く再生する (矢印が早く来る)。
 VisualDelaySeconds=画面表示の遅延を調整します。LCDのレイテンシをなんとかするために、一応残っている設定項目らしいです。
 AttractSoundFrequency=アトラクトデモで音を流す頻度を設定します。Simply_Loveはアトラクトデモがないが他のテームがこの設定使うかも知りまえん。ALWAYSに設定すると毎回音が流れます。N_TIMESに設定するとN回ごとに音が流れます。NEVERに設定すると音が流れません。
 
@@ -580,6 +580,8 @@ Center1Player='On'にした場合、1プレイヤーモードのときにnotefie
 ShowDancingCharacters=もしdancing charactersがあれば、プレイヤーは2つ目のPlayerOptionsからキャラクターを選択することができます。\n\n他のテーマでは、これを"Select"にすればキャラクターを選択する画面が出せたかもしれませんが、Simply Loveではできません。\n\nもしキャラクターがインストールされていなければ、この項目は効力を持ちません。
 
 # Arcade Options
+EventMode=• Off - Play a specific number of songs per game.\n\n• On - Play as many songs as you want per game.  Play all day if you want; I'm not your mom. 🤷
+EventMode=• Off - NORMALモードにする。•onに設定すると、設定曲数プレイしても終わらなくなります。
 CoinMode=• Home - タイトル画面にOptionやEditなどの選択肢が表示されます。\n\n• Pay - タイトル画面の選択肢は表示されません。プレイヤーは遊ぶ前にクレジットを入れる必要があります。PayモードはEvent Modeが'Off'のときのみ有効です。\n\n• Free Play - タイトル画面の選択肢は表示されません。プレイヤーはクレジットを入れる必要はありません。
 CoinsPerCredit=1クレジットに必要なコインの枚数を指定します。
 MaxNumCredits=許可されるクレジットの最大額を指定します。\n\nこの設定は、コイン モードが「支払う」に設定されている場合にのみ適用されます。
@@ -589,11 +591,12 @@ AllowMultipleHighScoreWithSameName='Off'にすると、同一の名前のプレ�
 ComboContinuesBetweenSongs='Off'にすると、ステージ間でコンボが引き継がれなくなります。\n\n'On'の場合、ステージ間でコンボが引き継がれるようになります。\nまた、ゲーム間でも引き継がれるようになります（プロファイルを使用していなくても）。
 Disqualification='On'にすると、あるオプションを有効化したときに(C-Mod・Rate mod・Attack無効化など)スコアが記録されなくなります。\n\n'Off'にすると、これらのオプションに関係なくスコアが記録されるようになります。
 Premium=CoinModeが'Pay'のときのみ有効なオプションです。\n\n• 'Off' - プレミアムを無効化します。\n• 'Double for 1 Credit' - 1クレジットでダブルプレイが遊べるようになります。\n• '2 Players for 1 Credit' - 1クレジットだけで、ダブルプレイに加え2人プレイも遊べるようになります。
+SongsPerPlay=NORMALモードでプレイする曲数を設定します。
 
 # Input Options
 OnlyDedicatedMenuButtons=• Use Gameplay Buttons - パッドを使ってメニューを操作できるようになります。\n\n• Only Dedicated Buttons - メニューの操作はメニュー用のボタンでしかできなくなります。\n\nこの設定を変更する前に、メニュー用のボタンが設定されているかを確認してください。
 ThreeKeyNavigation=メニューボタンに &SELECT; がないタイプの筐体では（古いDDR筐体など）、これを'On'にしてください。\nスクリーンショットなどの操作が&MENULEFT; &MENURIGHT; の同時押しでできるようになります。
-ArcadeOptionsNavigation=オプションメニューにおける &START; の挙動を設定します。\n\n• StepMania Style - &START; で即座にExitへ移動します。\n\n• Arcade Style - &START; はオプションの次の項目に移動します。
+ArcadeOptionsNavigation=オプションメニューにおける &START; の挙動を設定します。\n\n• ITGmania Style - &START; で即座にExitへ移動します。\n\n• Arcade Style - &START; はオプションの次の項目に移動します。
 InputDebounceTime=パネルが離されたと判定されるまでにかかる時間を指定します。\nパネルが誤反応する際に使ってみてください。
 AxisFix=D-PadをAxisとして解釈する一部のUSBドライバでは、一部のジャンプがうまく反応しない場合があります。そのような場合は、このオプションを'On'にしてみてください。\n\nこのオプションは、macOSおよびLinuxのドライバにはまだ対応していません。
 
@@ -622,10 +625,23 @@ CasualMaxMeter=この数値より難しい難易度の譜面はCasualモード�
 VisualStyle=背景などのテーマ各所に表示されるアイコンを指定します。\n\n各アイコンには、固有のグラフィックとBGMが用意されています。
 AllowThemeVideos=ゲームプレイに影響を与える可能性のあるビデオをテーマ画面に表示するかどうか。
 RainbowMode=Rainbow Modeを有効化・無効化します。\n\nRainbow Modeにすると、テーマ色選択画面はスキップされます。
-UseImageCache='On'にすると、Casualモードの動作がより快適になります。ただし、StepManiaがより多くのRAMを消費するようになります。最低でも8GB以上のRAMを積んでいないマシンでは、この項目は'Off'にしておいたほうが良いでしょう。\n\nこの設定を反映させるには、StepManiaの再起動が必要です。
+WriteCustomScores=This setting will enable the writing of custom scores files. They are stored in your profile directory. Scores are not stored for guest accounts.\n\nCustom score files can be uploaded to the simply.training website to track your personal progress.
+WriteCustomScores=カスタムのハイスコアを記録する。自分のプロファイルのフォルダを保存します。GUESTのアカウントが保存出来ません。\n\nこのファイルがsimply.trainingのサイトにアップロードしたら、自分の進捗状況を追跡できます。
+KeyboardFeatures=キーボードを有効化・無効化します。\n\nこれまで曲捜索だけこのオプションを使っています。
+SampleMusicLoops=選曲画面で音楽プリビューをループするかどうか。
+RescoreEarlyHits=早めに踏んでしまったDecentsとWay Offsが繰り返してもっといい判定になれるかもしらません。\n\nこの設定を反映させるには、ITGmaniaの再起動が必要です。
+UseImageCache='On'にすると、Casualモードの動作がより快適になります。ただし、ITGmaniaがより多くのRAMを消費するようになります。最低でも8GB以上のRAMを積んでいないマシンでは、この項目は'Off'にしておいたほうが良いでしょう。\n\nこの設定を反映させるには、ITGmaniaの再起動が必要です。
+
+# Tournament Mode Options
+EnableTournamentMode=大会モードに有効する。
+ScoringSystem=大会がどの判定決める設定。
+StepStats=常にステップの統計が表示まｔ非表示設定。
+EnforceNoCmod=Whether or not to automatically convert "C" Mods to "M" mods during gameplay as needed.
+EnforceNoCmod=自動的にcmodがmmodになる。'on'になったら、プライヤーがcmod使いません。
 
 # USB Profile CustomSongs Options
-CustomSongsEnable=USBカスタムソングを有効化・無効化します。\n\nUSBカスタムソングが正常に動作するには、コンピュータがUSBメモリを認識するようOSを設定する必要があります。\n\n詳しくは、GitHub上のStepManiaレポジトリのWikiにある'Static mount points for USB pofiles'および hackmycab.com を参照してください。
+MemoryCards=USBドライブで各プレイヤーの自己ベストとオプションを保存します。.\n\n警告：自分のOSがまずちゃんと設定するべきです。\n\ngithubのウィキの説明を調べてください。\n\ngithub.com/stepmania/stepmania/wiki
+CustomSongsEnable=USBカスタムソングを有効化・無効化します。\n\nUSBカスタムソングが正常に動作するには、コンピュータがUSBメモリを認識するようOSを設定する必要があります。\n\n詳しくは、GitHub上のITGManiaレポジトリのWikiにある'Static mount points for USB pofiles'および hackmycab.com を参照してください。
 CustomSongsMaxCount=1つのUSBプロファイルから読み込めるカスタムソングの曲数に上限を設定します。
 CustomSongsLoadTimeout=USBカスタムソングの読み込み時間に制限時間を指定します。もし読み込みにこの秒数以上かかった場合、そのカスタムソングを読み込むことはできません。
 CustomSongsMaxSeconds=USBカスタムソングの最長時間を指定します。この秒数以上のカスタムソングは無視されます。
@@ -642,18 +658,22 @@ ScreenNameEntryMenuTimer=名前入力画面の制限時間を指定します。
 
 # Advanced Options
 DefaultFailType=• Immediate - ライフが無くなった時点でFailedとなり、曲を終了します。\n\n• ImmediateContinue - ライフが無くなった時点でFailedとなりますが、ゲームプレイは曲が終了するまで継続します。\n\n• EndOfSong - 曲が終わった時点でライフが少しでも残っていればクリアとなります。\n\n• Off - Failを無効化します。
-UseUnlockSystem=StepManiaのアンロックシステムを有効化・無効化します。\n\nただ、Simply Loveではアンロックシステムをサポートしていませんし、他のテーマで実装されているのを見たこともありません。
+UseUnlockSystem=ITGmaniaのアンロックシステムを有効化・無効化します。\n\nただ、Simply Loveではアンロックシステムをサポートしていませんし、他のテーマで実装されているのを見たこともありません。
 AllowExtraStage='On'にすると、プレイヤーがある特定の条件を達成したときにエクストラステージに進めるようになります。\n\n他のテーマでは特殊な演出が用意されていたりしますが、Simply Loveには特にありません。\n\nこの設定はEventモードでは無視されます。
 HiddenSongs='On'にすると、 #SELECTABLE:NO; と記述されたSimfileがゲーム内に表示されなくなります。この場合も、コースによってその曲が選択されていれば、そのコースでは遊ぶことができます。\n\n'Off'にすると、この設定に関係なくすべての曲が選曲画面から選択できるようになります。
 EasterEggs=テーマのどこかに隠されたイースターエッグを有効化・無効化します。
+AllowSongDeletion=選曲画面でCtrl + BSキーでこの曲で完全の削除の可能を有効化します。
+ProfileSortOrder=プロファイルの選択画面の順序。
+ProfileSortOrderAscending=プロファイルの順序が昇順か？
 
 # Acknowledgments
 StepMania Credits=StepManiaのクレジットを表示します。
 
 # GrooveStats Options
-EnableGrooveStats=GrooveStatsへの接続を確立します
+EnableGrooveStats=GrooveStatsへの接続を確立します。
 AutoDownloadUnlocks=オンラインイベントの自動ダウンロード解除。\n\nノート：ロック解除を解凍すると、ゲームが途切れる可能性があります。
 SeparateUnlocksByPlayer=プロファイルごとにダウンロードされた分離解除。
+QRLogin=いつQRログイン画面をひょうじする。\n\nAlways - いつも表示する\n\n Sometimes - もしプロファイルが必要あれば表示する\n\n Never - 非表示です。
 
 # ScreenPlayerOptions
 SpeedModType=Speed Modのタイプを変更します。BPM変化に影響します。
@@ -725,7 +745,10 @@ AllowScreenSelectProfile=アーケードで運用するなら、これは'No'に
 AllowDanceSolo=もし筐体がSolo譜面に対応していないのならば、これは'No'にしておくべきでしょう。
 CasualMaxMeter=アーケードで運用するなら、10くらいが適しているでしょう。
 nice='Off'にしておきましょう。
+WriteCustomScores=simply.trainingのサイト使いたいと'On'にしてべきでしょう。
+KeyboardFeatures=もしキーボードが繋がってないと'No'にしてべきでしょう。
 UseImageCache=Casualモードをプレイしないのであれば、これを'On'にする必要はないでしょう。
+RescoreEarlyHits=以前のdecent/way offの行動が欲しいのでなければ、'On'にするべきでしょう。
 
 # Appearance Options
 ShowLyrics=Hide

--- a/Languages/ja.ini
+++ b/Languages/ja.ini
@@ -148,42 +148,42 @@ Double8=Double
 Versus8=Versus
 
 # Test Input overlay in SelectMusic (available from SortMenu)
-FeelingSalty=Feeling salty?
+FeelingSalty=リタイアしたいかい？入力テストしよう
 TestInput=Test Input
 
 # Practice mode
 HardTime=難しすぎる?
-PracticeMode=練習モード
+PracticeMode=Practice Mode
 
 # For displaying the GrooveStats leaderboard (available from SortMenu)
-GrooveStats=GrooveStats
+GrooveStats=GrooveStatsランキング
 Leaderboard=Leaderboard
 
 # Song Search Text
 SongSearch=Song Search
-WhereforeArtThou=Wherefore Art Thou?
+WhereforeArtThou=あなたはどこ
 
 # Switch Profile Text
-NextPlease=Next Please
+NextPlease=次の客さん！
 SwitchProfile=Switch Profile
 
 # Reload Songs Text
 LoadNewSongs=Load New Songs
-TakeABreather=Take a Breather~
+TakeABreather=休憩しよう〜
 
 # Favorites Text
 AddFavorite=Add to Favorites
-ImLovinIt=I'm Lovin' It
+ImLovinIt=気に入る
 Preferred=Favorites
-MixTape=Check Out My Mix Tape
+MixTape=ミクステープ聞いてくれない？
 
 # View Downloads Text
 ViewDownloads=View Downloads
-NeedMoreRam=Need More RAM?
+NeedMoreRam=もっとRAM欲しいか？
 
 # Set Summary Text
 SetSummary=Set Summary
-SetSummaryText=Relive Your Memories
+SetSummaryText=記憶を回復する
 
 # prompt players before exiting via LLRRLLRR
 PromptBeforeExiting=本当に終了しますか？

--- a/Languages/ja.ini
+++ b/Languages/ja.ini
@@ -28,6 +28,11 @@ Dance Mode=Gameplay
 Edit Mode=Edit Mode
 Enter Unlock Code=Enter Unlock Code
 
+# stats for TitleMenu/TitleJoin like "249 songs in 13 groups, 6 courses"
+songs in=曲
+groups=フォルダ数
+courses=コース
+
 # TitleJoin appears in Freeplay/Pay modes
 [ScreenTitleJoin]
 Press Start=Press &START; To Play
@@ -40,7 +45,10 @@ Card=CARD
 MostRecentSong=Most Recent Song
 MostFrequentGrade=Most Frequent Grade
 SingularSongPlayed=%d Song Played
-SeveralSongsPlayed=%d Songs Played
+SeveralSongsPlayed=%d 遊んだ曲数
+LoginInstructions=ORコードスキャンしてログインしてください
+VisitWebsite=www.groovestats.comでアカウント作成できます
+ProfileConnected=プロファイル\nもう繋がっています
 
 [ScreenSelectColor]
 HeaderText=Select A Color
@@ -98,7 +106,20 @@ Options=Options
 # StepArtist
 STEPS=STEPS
 
-# SortMenu
+# SortMenu labels
+SortBy=並び替え
+ChangeMode=モード変更
+ChangeStyle=スタイル変更
+Cancel=PRESS &SELECT; TO CANCEL
+Category=More...
+GoBack=Go Back
+CategorySorts=Sorts...
+#CategoryModes=Modes...
+CategoryStyles=Styles...
+CategoryAdvanced=Options...
+
+# SortMenu choices
+# SortMenu "Sort By" choices
 Group=Group
 Title=Title
 Artist=Artist
@@ -106,28 +127,68 @@ Genre=Genre
 BPM=BPM
 Length=Length
 Recent=Recently Played
-BeginnerMeter=Beginner
-EasyMeter=Easy
-MediumMeter=Medium
-HardMeter=Hard
-ChallengeMeter=Expert
+RecentP1Played= P1 Recently Played
+RecentP2Played= P2 Recently Played
 Popularity=Most Played
+Meter=Level
+TopGrades=Machine Top Scores
+TopP1Grades=P1 Clear Rank
+TopP2Grades=P2 Clear Rank
 
-SortBy=並び替え
-ChangeMode=モード変更
-ChangeStyle=スタイル変更
+# SortMenu "Change Style To" choices
+Single=Single
+Double=Double
+Versus=Versus
+Routine=Routine
+Solo=Solo
+# technomotion's styles include "8" behind the scenes
+# present technomtion style choices to players without the "8"
+Single8=Single
+Double8=Double
+Versus8=Versus
 
-Cancel=PRESS &SELECT; TO CANCEL
-
-PromptBeforeExiting=本当に終了しますか？
+# Test Input overlay in SelectMusic (available from SortMenu)
+FeelingSalty=Feeling salty?
+TestInput=Test Input
 
 # Practice mode
 HardTime=難しすぎる?
 PracticeMode=練習モード
 
-Double=Double
-Single=Single
-Versus=Versus
+# For displaying the GrooveStats leaderboard (available from SortMenu)
+GrooveStats=GrooveStats
+Leaderboard=Leaderboard
+
+# Song Search Text
+SongSearch=Song Search
+WhereforeArtThou=Wherefore Art Thou?
+
+# Switch Profile Text
+NextPlease=Next Please
+SwitchProfile=Switch Profile
+
+# Reload Songs Text
+LoadNewSongs=Load New Songs
+TakeABreather=Take a Breather~
+
+# Favorites Text
+AddFavorite=Add to Favorites
+ImLovinIt=I'm Lovin' It
+Preferred=Favorites
+MixTape=Check Out My Mix Tape
+
+# View Downloads Text
+ViewDownloads=View Downloads
+NeedMoreRam=Need More RAM?
+
+# Set Summary Text
+SetSummary=Set Summary
+SetSummaryText=Relive Your Memories
+
+# prompt players before exiting via LLRRLLRR
+PromptBeforeExiting=本当に終了しますか？
+YesInfo=I'm finished.
+NoInfo=Keep playing.
 
 [SongDescription]
 Artist=Artist
@@ -183,7 +244,21 @@ MaxError=極値
 
 QRInstructions=QRコードを読み取ってGrooveStatsアカウントにスコアをアップロードしよう！
 
-PressStartToContinue=Press &START; To Continue
+QRInvalidScore1=❌GrooveStatsはDANCEモードのスコアだけ受け入れる。
+QRInvalidScore2=❌GrooveStatsはSOLO(六パネル)モードのスコアが受け入れません。
+QRInvalidScore3=❌GrooveStatsはランキングのマラソン曲のQRコードのスコアが受け入れません。
+QRInvalidScore4=❌GrooveStatsはこの%sモードのスコアがランキングできません。
+QRInvalidScore5=❌TimingWindowScaleの設定は４（標準）以上です。
+QRInvalidScore6=❌LifeDifficultyScaleの設定は４（標準）以上です。
+QRInvalidScore7=❌ITG Metrics/Preferencesが正しくないです。
+QRInvalidScore8=❌Rate Mod (MusicRate)は１から３まで設定する必要あります。
+QRInvalidScore9=❌矢印を削除されました。
+QRInvalidScore10=❌矢印が追加されました。
+QRInvalidScore11=❌FailTypeの設定は"Immediate"とか"ImmediateContinue"必要あります。
+QRInvalidScore12=❌AutoPlay使いました。
+QRInvalidScore13=❌MinTNSToScoreNotesの設定はGreatと以下になる必要です。
+
+PressStartToContinue=&START;を押してください
 
 [GraphDisplay]
 Barely=Barely!
@@ -580,7 +655,6 @@ Center1Player='On'にした場合、1プレイヤーモードのときにnotefie
 ShowDancingCharacters=もしdancing charactersがあれば、プレイヤーは2つ目のPlayerOptionsからキャラクターを選択することができます。\n\n他のテーマでは、これを"Select"にすればキャラクターを選択する画面が出せたかもしれませんが、Simply Loveではできません。\n\nもしキャラクターがインストールされていなければ、この項目は効力を持ちません。
 
 # Arcade Options
-EventMode=• Off - Play a specific number of songs per game.\n\n• On - Play as many songs as you want per game.  Play all day if you want; I'm not your mom. 🤷
 EventMode=• Off - NORMALモードにする。•onに設定すると、設定曲数プレイしても終わらなくなります。
 CoinMode=• Home - タイトル画面にOptionやEditなどの選択肢が表示されます。\n\n• Pay - タイトル画面の選択肢は表示されません。プレイヤーは遊ぶ前にクレジットを入れる必要があります。PayモードはEvent Modeが'Off'のときのみ有効です。\n\n• Free Play - タイトル画面の選択肢は表示されません。プレイヤーはクレジットを入れる必要はありません。
 CoinsPerCredit=1クレジットに必要なコインの枚数を指定します。

--- a/Languages/ja.ini
+++ b/Languages/ja.ini
@@ -1,5 +1,6 @@
 [Common]
-WindowTitle=シンプリィ・ライブ(itgmania)
+WindowTitle=Simply Love
+PopupDismissText=&START; を押して、通知を閉じる
 
 ##############################################
 # Screens typically encountered during "normal use"
@@ -413,9 +414,10 @@ Test Input=🤍  入力テスト
 AppearanceOptions=🤍  外観設定
 VisualOptions=🤍  見た目の設定
 Overscan Correction=🤍  画面位置の調整
+CRT Test Patterns=🤍  ブラウン管のテストパトーン
 Timing Window Options=🤍  判定の設定
 ThemeOptions=🤍  Simply Love固有の設定
-TournamentModeOptions=🤍  試合の設定
+TournamentModeOptions=🤍  大会の設定
 MenuTimerOptions=🤍  メニュータイマーの設定
 USBProfileOptions=🤍  USBカスタムソングの設定
 Set BG Fit Mode=🤍  背景サイズの設定
@@ -487,7 +489,7 @@ CustomTimingWindow=Timing Window
 MusicWheelSpeed=MusicWheel\nScroll Speed
 
 # Acknowledgments Menu
-StepMania Credits=🤍  ITGMania の貢献者
+StepMania Credits=🤍  ITGMania のクレジット
 
 # ScreenPlayerOptions
 Perspective=Perspective
@@ -529,12 +531,15 @@ SystemOptions=ゲームタイプ・テーマ・言語 (Language) など、基本
 Key Joy Mappings=キーボードやジョイパッドなどのボタンを\n操作に割り当てます。
 Test Input=キーボードやジョイパッドの割り当てを確認できます。
 ArcadeOptions=クレジット・曲数・スコアの記録など、アーケードに関わる設定です。
+GraphicsSoundOptions=ディスプレイ解像度・アスペクト比・画質・音などに関わる設定です。
 VisualOptions=歌詞・背景・画面位置など、見た目に関する設定です。
-AppearanceOptions=ゲームプレイ中に、歌詞や背景などがどう表示されるかを設定します。
 ThemeOptions=Simply Love固有の設定です。いろいろあります。
+AdvancedOptions=困難スケーリング・クリアーの条件・曲削除、などなど
 USBProfileOptions=USBカスタムソングに関する設定です。そもそもUSBカスタムソングを許可するか否かもこちらから。
+Profiles=プロファイルを制作、編集、管理できます。管理するには、キーボードが必要です。
 MenuTimerOptions=メニュータイマーのオンオフ・それぞれの画面における制限時間の設定ができます。
 InputOptions=ジョイスティックのオートマップ、メニューでのパッド入力の可否、パッドの調整など、入力に関する設定です。
+TournamentModeOptions=トーナメント中に一貫する設定ができます。
 AcknowledgmentsMenu=Simply LoveおよびStepManiaのクレジットおよび謝辞、などなど
 Clear Credits=入力されたクレジットを0にリセットします。
 GrooveStatsOptions=GrooveStatsオプションを管理します。
@@ -548,10 +553,13 @@ Announcer=アナウンサーを変更します。
 DefaultNoteSkin=デフォルトで使うノートスキンを変更します。\n\nプレイヤーは、もしプレイヤーが望めば、楽曲選択後のオプションからこれ以外のものに変更することもできます。
 EditorNoteSkin=Editモードでデフォルトで使うノートスキンを変更します。
 
-# Display/Sound Options
+# Visual Options
+AppearanceOptions=ゲームプレイ中に、歌詞や背景などがどう表示されるかを設定します。
 Set BG Fit Mode=ゲームプレイ中に、楽曲の背景がどのように表示されるか（スケール・切り抜きなど）を設定します。
+Overscan Correction=ブラウン管のオーバースキャンの調査設定です.\n\nキーボードが必要あります。
+CRT Test Patterns=ブラウン管調査と試験用のテストパトーンです。
 
-#Graphics/Sound Options
+# Graphics/Sound Options
 SmoothLines=テーマのアンチエイリアスを有効にするかを選択します。\n\nActorMultiVertexに'LineStrip'を使用しているテーマおよび楽曲がこの設定の影響を受けます。
 FastNoteRendering='On'にした場合、Zバッファが各ノートの描画毎にクリアされなくなります。これによって、3Dのノートスキンの表示がおかしくなる場合がありますが、パフォーマンスはけっこう改善されるはずです。
 VisualDelaySeconds=画面表示の遅延を調整します。LCDのレイテンシをなんとかするために、一応残っている設定項目らしいです。


### PR DESCRIPTION
For those of you still on English, the Japanese version has badly lagged behind since the introduction of many new English strings. Sure, perhaps we can assume that a degree of Japanese users can read English but the incomplete state of the QR Code feature, the new Sorting Menu along with missing options Explanations strings left much to be desired. I attacked mostly strings that were mostly visible to user (gameplay / gameplay preferences / option explanations) for better usability towards a japanese native.

Although I am not a native speaker, I tried my best to stick to the existing tone and style. Even went on to borrow some DDR terminology from some blogs. I am 100% Open to suggestions or improvements! This will be my first localization project so please tell me how I could make this PR more digestible or cleaner.

This is my doing as much of the `jp.ini` file as possible, taking some cues from the `en.ini` and some from the ITGmania `_fallback/Languages/jp.ini`. I also took the liberty to modify some of the lua code that was hard coding English strings to make them more localizable!

### Changelog (largely based on commit history)
- Complete most `[OptionsExplanations]` along with some missing `[RecommendedOptionExplanations]`
- Localize the QRCode new scanner feature merged into beta two weeks ago 
- Localize GrooveStat QRInvalidScore reasons
- Localize the new sorting wheel (favorites, style changes, test pad input)
- Some `[ScreenEvaluation]` metrics (the statistictics)
- New GrooveRadar terms along with proper tech and PeakNPS strings

Will add screenshots!

let me know if commits need to be squashed.

### References (external links showing where I borrowed some terminology)
- https://w.atwiki.jp/iamkenzen/pages/202.html
- https://w.atwiki.jp/asigami/pages/31.html#id_70402f62
- https://note.com/iuyoka/n/n651e0fed4b32
