### PR TITLE
Localize Some strings in Groovestats

### DIFF
--- a/BGAnimations/ScreenEvaluation common/Shared/AutoSubmitScore.lua
+++ b/BGAnimations/ScreenEvaluation common/Shared/AutoSubmitScore.lua
@@ -221,7 +221,7 @@ local AutoSubmitRequestProcessor = function(res, overlay)
 						end
 
 						QRPane:GetChild("QRCode"):queuecommand("Hide")
-						QRPane:GetChild("HelpText"):settext("Score has already been submitted :)")
+						QRPane:GetChild("HelpText"):settext(THEME:GetText("Groovestats", "ScoreAlreadySubmitted"))
 						if i == 1 and P1SubmitText then
 							P1SubmitText:queuecommand("Submit")
 						elseif i == 2 and P2SubmitText then
@@ -248,13 +248,13 @@ local AutoSubmitRequestProcessor = function(res, overlay)
 								GSIcon:visible(true)
 								recordText:diffuseshift():effectcolor1(Color.White):effectcolor2(Color.Yellow):effectperiod(3)
 								if personalRank == 1 then
-									local worldRecordText = "World Record!"
+									local worldRecordText = THEME:GetString("Groovestats", "WorldRecord")
 									if showExScore then
 										worldRecordText = worldRecordText .. " (EX)"
 									end
 									recordText:settext(worldRecordText)
 								else
-									recordText:settext("Personal Best!")
+									recordText:settext(THEME:GetString("Groovestats", "PersonalBest"))
 								end
 								local recordTextXStart = recordText:GetX() - recordText:GetWidth()*recordText:GetZoom()/2
 								local GSIconWidth = GSIcon:GetWidth()*GSIcon:GetZoom()
@@ -393,9 +393,10 @@ local af = Def.ActorFrame {
 			-- Only send the request if it's applicable.
 			if sendRequest then
 				-- Unjoined players won't have the text displayed.
-				self:GetParent():GetChild("P1SubmitText"):settext("Submitting ...")
-				self:GetParent():GetChild("P2SubmitText"):settext("Submitting ...")
-
+             
+                self:GetParent():GetChild("P1SubmitText"):settext(THEME:GetString("Groovestats", "Submitting"))
+				self:GetParent():GetChild("P2SubmitText"):settext(THEME:GetString("Groovestats", "Submitting"))
+					
 				self:playcommand("MakeGrooveStatsRequest", {
 					endpoint="score-submit.php?"..NETWORK:EncodeQueryParameters(query),
 					method="POST",
@@ -403,7 +404,7 @@ local af = Def.ActorFrame {
 					body=JsonEncode(body),
 					timeout=30,
 					callback=AutoSubmitRequestProcessor,
-					args=SCREENMAN:GetTopScreen():GetChild("Overlay"):GetChild("ScreenEval Common"),
+				args=SCREENMAN:GetTopScreen():GetChild("Overlay"):GetChild("ScreenEval Common"),
 				})
 			end
 		end
@@ -427,14 +428,14 @@ af[#af+1] = LoadFont("Common Normal").. {
 		self:visible(GAMESTATE:IsSideJoined(PLAYER_1))
 	end,
 	SubmitCommand=function(self)
-		self:settext("Submitted!")
+		self:settext(THEME:GetString("Groovestats", "Submitted"))
 	end,
 	SubmitFailedCommand=function(self)
-		self:settext("Submit Failed 😞")
+		self:settext(THEME:GetString("Groovestats", "SubmitFailed"))
 		DiffuseEmojis(self)
 	end,
 	TimedOutCommand=function(self)
-		self:settext("Timed Out")
+		self:settext(THEME:GetString("Groovestats", "TimedOut"))
 	end
 }
 
@@ -449,14 +450,14 @@ af[#af+1] = LoadFont("Common Normal").. {
 		self:visible(GAMESTATE:IsSideJoined(PLAYER_2))
 	end,
 	SubmitCommand=function(self)
-		self:settext("Submitted!")
+		self:settext(THEME:GetString("Groovestats", "Submitted"))
 	end,
 	SubmitFailedCommand=function(self)
-		self:settext("Submit Failed 😞")
+		self:settext(THEME:GetString("Groovestats", "SubmitFailed"))
 		DiffuseEmojis(self)
 	end,
 	TimedOutCommand=function(self)
-		self:settext("Timed Out")
+		self:settext(THEME:GetString("Groovestats", "TimedOut"))
 	end
 }
 

--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/StepStatistics/Scorebox.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/StepStatistics/Scorebox.lua
@@ -293,7 +293,7 @@ local af = Def.ActorFrame{
 			-- both players will have their own individual scoreboxes.
 			-- Should be fine though.
 			if sendRequest then
-				self:GetParent():GetChild("Name1"):settext("Loading...")
+				self:GetParent():GetChild("Name1"):settext(THEME:GetString("Groovestats", "Loading"))
 				self:playcommand("MakeGrooveStatsRequest", {
 					endpoint="player-leaderboards.php?"..NETWORK:EncodeQueryParameters(query),
 					method="GET",

--- a/BGAnimations/ScreenGameplay underlay/Shared/BPMDisplay.lua
+++ b/BGAnimations/ScreenGameplay underlay/Shared/BPMDisplay.lua
@@ -8,6 +8,8 @@ local bpmDisplay, SongPosition
 
 -- -----------------------------------------------------------------------
 
+local xRateText = THEME:GetStrings("OptionsTitles", "MusicRateMultiplier")
+
 -- the update function when a single BPM Display is in use
 local UpdateSingleBPM = function(af)
 	-- BPM stuff first
@@ -21,7 +23,7 @@ local UpdateSingleBPM = function(af)
 
 	-- MusicRate Display
 	MusicRate = string.format("%.2f", MusicRate )
-	MusicRateDisplay:settext( MusicRate ~= "1.00" and MusicRate.."x rate" or "" )
+	MusicRateDisplay:settext( MusicRate ~= "1.00" and MusicRate..xRateText or "" )
 end
 
 -- the update function when two BPM Displays are needed for divergent TimingData (split BPMs)
@@ -36,7 +38,7 @@ local Update2PBPM = function(self)
 	end
 
 	MusicRate = string.format("%.2f", MusicRate )
-	MusicRateDisplay:settext( MusicRate ~= "1.00" and MusicRate.."x rate" or "" )
+	MusicRateDisplay:settext( MusicRate ~= "1.00" and MusicRate..xRateText or "" )
 end
 
 

--- a/BGAnimations/ScreenSelectColor underlay.lua
+++ b/BGAnimations/ScreenSelectColor underlay.lua
@@ -205,7 +205,7 @@ local t = Def.ActorFrame{
 if style == "SRPG8" then
 	t[#t+1] = Def.BitmapText{
 		Font="Common Normal",
-		Text="Choose your faction!",
+		Text=THEME:GetStrings("SRPG", "SelectFaction"),
 		InitCommand=function(self)
 			self:xy(_screen.cx, 80)
 			self:zoom(1.5)

--- a/BGAnimations/ScreenSelectMusic overlay/Leaderboard.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/Leaderboard.lua
@@ -537,7 +537,7 @@ for player in ivalues( PlayerNumber ) do
 
 			LoadFont("Common Normal").. {
 				Name="Name",
-				Text=(i==1 and "Loading" or ""),
+				Text=(i==1 and THEME:GetString("GrooveStats", "Loading") or ""),
 				InitCommand=function(self)
 					self:horizalign(center)
 					self:maxwidth(130)
@@ -545,7 +545,7 @@ for player in ivalues( PlayerNumber ) do
 					self:diffuse(Color.White)
 				end,
 				ResetEntryMessageCommand=function(self)
-					self:settext(i==1 and "Loading" or "")
+					self:settext(i==1 and THEME:GetString("GrooveStats", "Loading") or "")
 					self:diffuse(Color.White)
 				end
 			},

--- a/BGAnimations/ScreenSelectMusic overlay/Leaderboard.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/Leaderboard.lua
@@ -481,7 +481,7 @@ for player in ivalues( PlayerNumber ) do
 
 			LoadFont("Common Normal").. {
 				Name="Text",
-				Text="More Leaderboards",
+				Text=THEME:GetStrings("Groovestats", "MoreLeaderboards"),
 				InitCommand=function(self)
 					self:diffuse(Color.White)
 				end,

--- a/BGAnimations/ScreenSelectMusic overlay/PaneDisplay.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/PaneDisplay.lua
@@ -203,15 +203,15 @@ local GetScoresRequestProcessor = function(res, params)
 			if data and data[playerStr] then
 				if foundLeaderboard then
 					if SL["P"..i].ActiveModifiers.ShowEXScore then
-						loadingText:settext("EX Score")
+						loadingText:settext(THEME:GetString("Groovestats", "EXScore"))
 					else
-						loadingText:settext("GrooveStats")
+						loadingText:settext(THEME:GetString("Groovestats", "GrooveStats"))
 					end
 				else
 					if SL["P"..i].ActiveModifiers.ShowEXScore then
-						loadingText:settext("No EX Data")
+						loadingText:settext(THEME:GetString("Groovestats", "NoEXData"))
 					else
-						loadingText:settext("No Data")
+						loadingText:settext(THEME:GetString("Groovestats", "NoData"))
 					end
 				end
 			else
@@ -303,7 +303,7 @@ af[#af+1] = RequestResponseActor(17, 50)..{
 				requestCacheKey = requestCacheKey .. SL[pn].Streams.Hash .. SL[pn].ApiKey .. pn
 				local loadingText = master:GetChild("PaneDisplayP"..i):GetChild("Loading")
 				loadingText:visible(true)
-				loadingText:settext("Loading ...")
+				loadingText:settext(THEME:GetString("Groovestats", "Loading"))
 				sendRequest = true
 			end
 		end
@@ -557,7 +557,7 @@ for player in ivalues(PlayerNumber) do
 
 	af2[#af2+1] = LoadFont("Common Normal")..{
 		Name="Loading",
-		Text="Loading ... ",
+		Text=THEME:GetString("Groovestats", "Loading"),
 		InitCommand=function(self)
 			self:zoom(text_zoom):diffuse(Color.Black)
 			self:x(pos.col[3]-15)
@@ -565,7 +565,7 @@ for player in ivalues(PlayerNumber) do
 			self:visible(false)
 		end,
 		SetCommand=function(self)
-			self:settext("Loading ...")
+			self:settext(THEME:GetString("Groovestats", "Loading"))
 			self:visible(false)
 		end
 	}

--- a/BGAnimations/ScreenSelectMusic overlay/PaneDisplay.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/PaneDisplay.lua
@@ -279,7 +279,7 @@ af[#af+1] = RequestResponseActor(17, 50)..{
 				-- If we disable the service from a previous request, surface it to the user here.
 				for i=1,2 do
 					local loadingText = master:GetChild("PaneDisplayP"..i):GetChild("Loading")
-					loadingText:settext("Disabled")
+					loadingText:settext(THEME:GetStrings("Groovestats", "Disabled"))
 					loadingText:visible(true)
 				end
 			end

--- a/BGAnimations/ScreenSelectMusic overlay/PerPlayer/DensityGraph.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/PerPlayer/DensityGraph.lua
@@ -248,11 +248,13 @@ local layout = {
 
 local colSpacing = 150
 local rowSpacing = 20
+local noneText = THEME:GetStrings("SLPlayerOptions", "None")
+local totalStreamText = THEME:GetStrings("ScreenSelectMusic", "TotalStream")
 
 for i, row in ipairs(layout) do
 	for j, col in pairs(row) do
 		af3[#af3+1] = LoadFont("Common normal")..{
-			Text=col ~= "Total Stream" and "0" or "None (0.0%)",
+			Text=col ~= totalStreamText and "0" or noneText" (0.0%)",
 			Name=col .. "Value",
 			InitCommand=function(self)
 				local textHeight = 17
@@ -269,7 +271,7 @@ for i, row in ipairs(layout) do
 				if col ~= "Total Stream" then
 					self:settext("0")
 				else
-					self:settext("None (0.0%)")
+					self:settext(noneText.." (0.0%)")
 				end
 			end,
 			RedrawCommand=function(self)
@@ -279,7 +281,7 @@ for i, row in ipairs(layout) do
 					local streamMeasures, breakMeasures = GetTotalStreamAndBreakMeasures(pn)
 					local totalMeasures = streamMeasures + breakMeasures
 					if streamMeasures == 0 then
-						self:settext("None (0.0%)")
+						self:settext(noneText.." (0.0%)")
 					else
 						self:settext(string.format("%d/%d (%0.1f%%)", streamMeasures, totalMeasures, streamMeasures/totalMeasures*100))
 					end

--- a/BGAnimations/ScreenSelectProfile underlay/PlayerFrame.lua
+++ b/BGAnimations/ScreenSelectProfile underlay/PlayerFrame.lua
@@ -148,7 +148,7 @@ return Def.ActorFrame{
 			SelectedProfileMessageCommand=function(self, params)
 				if params.PlayerNumber ~= player then return end
 
-				self:settext("Waiting...")
+				self:settext(THEME:GetString("ScreenSelectProfile", "Waiting"))
 			end,
 			CoinsChangedMessageCommand=function(self)
 				if IsArcade() and GAMESTATE:EnoughCreditsToJoin() then

--- a/BGAnimations/ScreenSystemLayer overlay.lua
+++ b/BGAnimations/ScreenSystemLayer overlay.lua
@@ -300,7 +300,7 @@ local NewSessionRequestProcessor = function(res, gsInfo)
 			groovestats:settext("❌ GrooveStats")
 
 			DiffuseEmojis(service1:ClearAttributes())
-		end
+        end
 		DiffuseEmojis(groovestats:ClearAttributes())
 		return
 	end

--- a/BGAnimations/ScreenSystemLayer overlay.lua
+++ b/BGAnimations/ScreenSystemLayer overlay.lua
@@ -300,7 +300,7 @@ local NewSessionRequestProcessor = function(res, gsInfo)
 			groovestats:settext("❌ GrooveStats")
 
 			DiffuseEmojis(service1:ClearAttributes())
-        end
+		end
 		DiffuseEmojis(groovestats:ClearAttributes())
 		return
 	end

--- a/BGAnimations/ScreenViewDownloads overlay/default.lua
+++ b/BGAnimations/ScreenViewDownloads overlay/default.lua
@@ -68,7 +68,7 @@ af[#af+1] = Def.BitmapText{
 
 af[#af+1] = Def.BitmapText{
 	Name="NoDownloads",
-	Text="No Downloads to View",
+	Text=THEME:GetStrings("Groovestats", "NoDownloads"),
 	Font="Common Normal",
 	InitCommand=function(self) self:visible(false):zoom(2) end,
 }

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -523,7 +523,8 @@ NoExData=No EX Data
 NoData=No Data
 Loading=Loading ...
 Disabled=GS Disabled
-Failed=Failed
+MoreLeaderboards=More Leaderboards
+NoDownloads=No Downloads to view
 
 # auto QR submission
 ScoreAlreadySubmitted=Score has already been submitted :)

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -523,6 +523,18 @@ Loading=Loading ...
 Disabled=GS Disabled
 Failed=Failed
 
+# auto QR submission
+ScoreAlreadySubmitted=Score has already been submitted :)
+WorldRecord=World Record!
+PersonalBest=Personal Best!
+Submitting=Submitting ...
+Submitted=Submitted!
+SubmitFailed=Submit Failed 😞
+SubmitDisabled=Submit Disabled
+
+# ScreenSystemLayer Statuses
+FailedToLoad=Failed to Load 😞
+
 [TapNoteScore]
 W1=Fantastic
 W2=Excellent

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -239,6 +239,8 @@ None=N/A
 [ScreenViewDownloads]
 HeaderText=View Downloads
 
+[SRPG]
+SelectFaction=Choose your faction!
 
 [SongDescription]
 Artist=Artist
@@ -530,7 +532,6 @@ PersonalBest=Personal Best!
 Submitting=Submitting ...
 Submitted=Submitted!
 SubmitFailed=Submit Failed 😞
-SubmitDisabled=Submit Disabled
 
 # ScreenSystemLayer Statuses
 FailedToLoad=Failed to Load 😞
@@ -759,6 +760,7 @@ BackgroundFilter=Background Filter
 NoteFieldOffsetX=NoteField Offset X
 NoteFieldOffsetY=NoteField Offset Y
 MusicRate=Music Rate
+MusicRateMultiplier=x rate
 Stepchart=Stepchart
 FaPlus=FA+ Options
 ScreenAfterPlayerOptions=What comes next?
@@ -1155,6 +1157,7 @@ ErrorBarMultiTick=Multi-Tick
 MeasureCounterLeft=Move Left
 MeasureCounterUp=Move Up
 HideLookahead=Hide Lookahead
+TotalStream=TotalStream
 
 # TimingWindowOptions
 HideEarlyDecentWayOffJudgments=Hide Judgments

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -57,6 +57,7 @@ MostRecentSong=Most Recent Song
 MostFrequentGrade=Most Frequent Grade
 SingularSongPlayed=%d Song Played
 SeveralSongsPlayed=%d Songs Played
+Waiting=Waiting ...
 
 [ScreenSelectColor]
 HeaderText=Select A Color
@@ -510,6 +511,17 @@ Random=RANDOM
 
 [RadarCategory]
 Taps=Steps
+
+[Groovestats]
+Loading=Loading
+TimedOut=Timed Out
+EXScore=EX Score
+GrooveStats=GrooveStats
+NoExData=No EX Data
+NoData=No Data
+Loading=Loading ...
+Disabled=GS Disabled
+Failed=Failed
 
 [TapNoteScore]
 W1=Fantastic

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -1158,7 +1158,7 @@ ErrorBarMultiTick=Multi-Tick
 MeasureCounterLeft=Move Left
 MeasureCounterUp=Move Up
 HideLookahead=Hide Lookahead
-TotalStream=TotalStream
+TotalStream=Total Stream
 
 # TimingWindowOptions
 HideEarlyDecentWayOffJudgments=Hide Judgments


### PR DESCRIPTION
Closes #598 

I'm not sure if I did this correctly. I just discovered the existence of the ScreenString() function which seems to be a cleaner version to get strings... although it is just a wrapper for my disgusting THEME::GetString() 

If some maintainer can give me advice that would be much appreciated! I think this is very important in language localization efforts. :earth_asia: :earth_africa: :earth_americas: 