### PR TITLE
Reset DefaultLocalProfile after each session so late joining players are Guests*

### DIFF
--- a/Scripts/SL_Init.lua
+++ b/Scripts/SL_Init.lua
@@ -485,6 +485,17 @@ function InitializeSimplyLove()
 	SL.P1:initialize()
 	SL.P2:initialize()
 	SL.Global:initialize()
+	
+	-- Temporary fix so late joining players aren't getting the last person's profile.
+	-- This obsoletes the handling for defaulting to the DefaultLocalProfile in SelectProfile
+	-- However, the addition of the ProfileSortOrder_Recent will ensure the last used profile is
+	-- always at the top of the list anyways
+	-- If the SelectProfile screen is not being used, we should continue to use the default profiles
+	if ThemePrefs.Get("AllowScreenSelectProfile") then
+		PREFSMAN:SetPreference("DefaultLocalProfileIDP1", "")
+		PREFSMAN:SetPreference("DefaultLocalProfileIDP2", "")
+	else
+
 end
 
 InitializeSimplyLove()


### PR DESCRIPTION
In regards to these: https://github.com/itgmania/itgmania/issues/132 and https://github.com/itgmania/itgmania/issues/28 

> Temporary fix so late joining players aren't getting the last person's profile.
> This obsoletes the handling for defaulting to the DefaultLocalProfile in SelectProfile
> However, the addition of the ProfileSortOrder_Recent will ensure the last used profile is
> always at the top of the list anyways
> If the SelectProfile screen is not being used, we should continue to use the default profiles

DefaultLocalProfile gets updated every time a profile is selected, the value does not get unset unless a player selects Guest. As a result, if anyone late joins they'll get the last used profile on that side. This has become pretty problematic on our public cab where people are late joining very frequently. I phrased this as a temporary fix as I think handling could be changed in engine eventually regarding this mayhaps but this solves it theme-side. 