### PR TITLE
Fix active_pane initialization

### DIFF
--- a/BGAnimations/ScreenEvaluation common/InputHandler.lua
+++ b/BGAnimations/ScreenEvaluation common/InputHandler.lua
@@ -44,13 +44,19 @@ for controller=1,2 do
 			-- and the other side as their profile's EvalPaneSecondary
 			if #players==1 then
 				if ("P"..controller)==ToEnumShortString(mpn) then
-					pane:visible(i == primary_i)
-					active_pane[controller] = primary_i
-
+					if i == primary_i then
+						pane:visible(true)
+						active_pane[controller] = #panes[controller] + 1
+					else
+						pane:visible(false)
+					end
 				elseif ("P"..controller)==ToEnumShortString(OtherPlayer[mpn]) then
-					pane:visible(i == secondary_i)
-					active_pane[controller] = secondary_i
-
+					if i == secondary_i then
+						pane:visible(true)
+						active_pane[controller] = #panes[controller] + 1
+					else
+						pane:visible(false)
+					end
 				end
 
 			-- versus

--- a/Scripts/SL-OperatorMenuOptions.lua
+++ b/Scripts/SL-OperatorMenuOptions.lua
@@ -264,8 +264,8 @@ function offsetMS(pref, low, high)
 end
 
 OperatorMenuOptionRows.GlobalOffsetSeconds = function()
-	-- 100ms should be sufficient to accomodate for audio delay
-	return offsetMS("GlobalOffsetSeconds", -100, 100)
+	-- up to 1s of audio delay (via HDMI), because some TVs are really slow
+	return offsetMS("GlobalOffsetSeconds", -1000, 1000)
 end
 
 OperatorMenuOptionRows.VisualDelaySeconds = function()


### PR DESCRIPTION
`active_pane` is supposed to index into panes, and `panes` only contains non-nil panes. However, `active_panes` is initialized based on the total number of possible panes rather than the actual list of panes in `panes`, which causes #597.

Fixes #597