### PR TITLE
99 SL-ThemePrefs.lua - Fix parentheses before DefaultFailType

### DIFF
--- a/Scripts/99 SL-ThemePrefs.lua
+++ b/Scripts/99 SL-ThemePrefs.lua
@@ -75,6 +75,7 @@ SL_CustomPrefs.Get = function()
 				THEME:GetString("ScreenSelectPlayMode", "ITG"),
 			},
 			Values = { "Casual", "ITG" }
+		},
 		DefaultFailType =
 		{
 			Default = "Immediate",


### PR DESCRIPTION
As the title, after merge the last edit about DefaultFailType a parentheses is missing causing a broken object