### PR TITLE
Ensure vertical lifebar doesn't overlap with step stats on doubles

### DIFF
--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/LifeMeter/Vertical.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/LifeMeter/Vertical.lua
@@ -9,7 +9,7 @@ local _x = _screen.cx + (player==PLAYER_1 and -1 or 1) * SL_WideScale(302, 400)
 if GAMESTATE:GetCurrentStyle():GetStyleType() == "StyleType_OnePlayerTwoSides"
 -- or center1player preference is enabled and only one player is playing
 or PREFSMAN:GetPreference("Center1Player") and #GAMESTATE:GetHumanPlayers() == 1 then
-	_x =  _screen.cx + ((GetNotefieldWidth()/2 + 30) * (player==PLAYER_1 and -1 or 1))
+	_x =  _screen.cx + ((GetNotefieldWidth()/2 + 10) * (player==PLAYER_1 and -1 or 1))
 
 -- for the highly-specific scenario where aspect ratio is ultrawide or wider
 -- and both players are joined, and this player wants both a vertical lifemeter


### PR DESCRIPTION
Previous:
![image](https://github.com/user-attachments/assets/ec9e3a75-a5b0-4d7d-b34f-4f8cb2e21438)

Proposed:

![image](https://github.com/user-attachments/assets/ca2add78-4c15-4a61-8953-bc62bbbf0382)
