### PR TITLE
Make sure Rolls to holds is reset properly

### DIFF
--- a/metrics.ini
+++ b/metrics.ini
@@ -630,7 +630,7 @@ Scroll,4="mod,cross;name,Cross"
 Scroll,5="mod,centered;name,Centered"
 
 Holds="5;selectmultiple"
-HoldsDefault="mod,no planted,no floored,no twister,no holdrolls"
+HoldsDefault="mod,no planted,no floored,no twister,no norolls,no holdrolls"
 Holds,1="mod,planted;name,Planted"
 Holds,2="mod,floored;name,Floored"
 Holds,3="mod,twister;name,Twister"


### PR DESCRIPTION
Turning on Rolls -> Holds would lock you in to the setting until changing profiles or restarting. This adds ``no norolls`` to the default modifiers list so its reset as it appears to have been missing.