### PR TITLE
Ensure Artist is updated on translit of current song

### DIFF
--- a/BGAnimations/ScreenSelectMusic overlay/SongDescription/SongDescription.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SongDescription/SongDescription.lua
@@ -8,7 +8,7 @@ local af = Def.ActorFrame{
 	OnCommand=function(self)
 		self:xy(_screen.cx - (IsUsingWideScreen() and 170 or 165), _screen.cy - 55)
 	end,
-
+	DisplayLanguageChangedMessageCommand=function(self) self:playcommand("Set") end,
 	CurrentSongChangedMessageCommand=function(self)    self:playcommand("Set") end,
 	CurrentCourseChangedMessageCommand=function(self)  self:playcommand("Set") end,
 	CurrentStepsP1ChangedMessageCommand=function(self) self:playcommand("Set") end,


### PR DESCRIPTION
When the translit key bind is pressed it sends the DisplayLanguageChanged message. Make sure that the artist field is re-set when this is called to update accordingly