### PR TITLE
Fix soft lock when using SwitchProfile w/ AutoStyle set to 1Player and two players joined

### DIFF
--- a/BGAnimations/ScreenSelectProfile underlay/Input.lua
+++ b/BGAnimations/ScreenSelectProfile underlay/Input.lua
@@ -41,7 +41,6 @@ for profile in ivalues(profile_data) do
 end
 
 local AutoStyle = ThemePrefs.Get("AutoStyle")
-local mpn = GAMESTATE:GetMasterPlayerNumber()
 
 local Handle = {}
 
@@ -232,7 +231,13 @@ Handle.Back = function(event)
 		-- unjoin a player from a 2-player setup
 		if SL.Global.FastProfileSwitchInProgress and GAMESTATE:GetNumSidesJoined() == 1 then
 			GAMESTATE:SetCurrentStyle("single")
-			SCREENMAN:GetTopScreen():playcommand("Update")
+			-- If AutoStyle is single then someone had joined during gameplay
+			-- We need to explicitly remove this player's join frame
+			if (AutoStyle=="single") then
+				SCREENMAN:GetTopScreen():playcommand("Update", {player=event.PlayerNumber})
+			else
+				SCREENMAN:GetTopScreen():playcommand("Update")
+			end
 		end
 
 	end
@@ -243,7 +248,7 @@ Handle.Select = Handle.Back
 local InputHandler = function(event)
 	if finished then return false end
 	if not event or not event.button then return false end
-	if (AutoStyle=="single" or AutoStyle=="double") and event.PlayerNumber ~= mpn then return false	end
+	if (((AutoStyle=="single" or AutoStyle=="double") and #GAMESTATE:GetHumanPlayers() == 1) and event.PlayerNumber ~= GAMESTATE:GetMasterPlayerNumber()) then return false	end
 
 	if event.type ~= "InputEventType_Release" then
 		if Handle[event.GameButton] then Handle[event.GameButton](event) end

--- a/BGAnimations/ScreenSelectProfile underlay/default.lua
+++ b/BGAnimations/ScreenSelectProfile underlay/default.lua
@@ -4,11 +4,6 @@
 -- SelectProfileFrames for both PLAYER_1 and PLAYER_2, but only the MasterPlayerNumber
 local AutoStyle = ThemePrefs.Get("AutoStyle")
 
--- retrieve the MasterPlayerNumber now, at initialization, so that if AutoStyle is set
--- to "single" or "double" and that singular player unjoins, we still have a handle on
--- which PlayerNumber they're supposed to be...
-local mpn = GAMESTATE:GetMasterPlayerNumber()
-
 -- a table of profile data (highscore name, most recent song, mods, etc.)
 -- indexed by "ProfileIndex" (provided by engine)
 local profile_data = LoadActor("./PlayerProfileData.lua")
@@ -22,7 +17,6 @@ local readyPlayers = {
 	["P1"] = false,
 	["P2"] = false,
 }
-
 -- ----------------------------------------------------
 
 local HandleStateChange = function(self, Player)
@@ -171,7 +165,7 @@ local t = Def.ActorFrame {
 
 	CodeMessageCommand=function(self, params)
 
-		if (AutoStyle=="single" or AutoStyle=="double") and params.PlayerNumber ~= mpn then return end
+		if (AutoStyle=="single" or AutoStyle=="double" or #GAMESTATE:GetHumanPlayers() > 1 ) and params.PlayerNumber ~= GAMESTATE:GetMasterPlayerNumber()  then return end
 
 		-- Don't allow players to unjoin from SelectProfile in CoinMode_Pay.
 		-- 1 credit has already been deducted from ScreenTitleJoin, so allowing players
@@ -224,11 +218,11 @@ local t = Def.ActorFrame {
 			return
 		end
 
-		if AutoStyle=="none" or AutoStyle=="versus" then
+		if AutoStyle=="none" or AutoStyle=="versus" or #GAMESTATE:GetHumanPlayers() > 1 then
 			HandleStateChange(self, PLAYER_1)
 			HandleStateChange(self, PLAYER_2)
 		else
-			HandleStateChange(self, mpn)
+			HandleStateChange(self, GAMESTATE:GetMasterPlayerNumber())
 		end
 	end,
 
@@ -281,12 +275,12 @@ if SL.Global.FastProfileSwitchInProgress then
 end
 
 -- load PlayerFrames for both
-if AutoStyle=="none" or AutoStyle=="versus" then
+if AutoStyle=="none" or AutoStyle=="versus" or #GAMESTATE:GetHumanPlayers() > 1 then
 	t[#t+1] = LoadActor("PlayerFrame.lua", {Player=PLAYER_1, Scroller=scrollers[PLAYER_1], ProfileData=profile_data, Avatars=avatars})
 	t[#t+1] = LoadActor("PlayerFrame.lua", {Player=PLAYER_2, Scroller=scrollers[PLAYER_2], ProfileData=profile_data, Avatars=avatars})
 -- load only for the MasterPlayerNumber
 else
-	t[#t+1] = LoadActor("PlayerFrame.lua", {Player=mpn, Scroller=scrollers[mpn], ProfileData=profile_data, Avatars=avatars})
+	t[#t+1] = LoadActor("PlayerFrame.lua", {Player=GAMESTATE:GetMasterPlayerNumber(), Scroller=scrollers[GAMESTATE:GetMasterPlayerNumber()], ProfileData=profile_data, Avatars=avatars})
 end
 
 LoadActor("./JudgmentGraphicPreviews.lua", {af=t, profile_data=profile_data})


### PR DESCRIPTION
Fix soft lock when using SwitchProfile w/ AutoStyle set to 1Player and two players joined

See: https://github.com/Simply-Love/Simply-Love-SM5/issues/592 and https://github.com/Simply-Love/Simply-Love-SM5/issues/462


There were a couple issues here.

Changed all usage of mpn to directly calling GAMESTATE:GetMasterPlayerNumber() as the master player number can change if two players are joined. Using the initialized value would soft lock you if you changed master players.

Several checks mostly for input looked at your AutoStyle but we also want to consider number of players as in this case AutoStyle is single and there are two players joined. This allows the second player to provide input while they are joined.

If the non master player unjoins so we're back to one player joined and AutoStyle is set to 1Player then the PlayerFrame for the other player will remain hidden. (The second player's join frame will only show up if they are already joined in the game so from late joining in the music wheel)