### PR TITLE
Use OperatorMenuOptionRow.DefaultFailType() for DefaultFailType over ThemePref

### DIFF
--- a/Scripts/99 SL-ThemePrefs.lua
+++ b/Scripts/99 SL-ThemePrefs.lua
@@ -76,20 +76,7 @@ SL_CustomPrefs.Get = function()
 			},
 			Values = { "Casual", "ITG" }
 		},
-		DefaultFailType =
-		{
-			Default = "Immediate",
-			Choices = {
-					"Immediate",
-					"ImmediateContinue",
-					"Off",
-			},
-			Values = {
-					"Immediate",
-					"ImmediateContinue",
-					"Off",
-			},
-		},
+
 		AutoStyle =
 		{
 			Default = "none",
@@ -312,6 +299,7 @@ SL_CustomPrefs.Get = function()
 			Choices =  { THEME:GetString("ThemePrefs","Yes"), THEME:GetString("ThemePrefs", "No") },
 			Values  = { true, false }
 		},
+
 		QRLogin = {
 			Default = "Sometimes",
 			Choices = {

--- a/metrics.ini
+++ b/metrics.ini
@@ -1198,7 +1198,7 @@ LineCustomSongsMaxMegabytes="lua,OperatorMenuOptionRows.CustomSongsMaxMegabytes(
 [ScreenAdvancedOptions]
 Fallback="ScreenOptionsServiceChild"
 LineNames="DefaultFailType,TimingWindowScale,LifeDifficulty,HiddenSongs,EasterEggs,AllowExtraStage,UseUnlockSystem,AutogenSteps,AutogenGroupCourses,FastLoad,SongDeletion,ProfileSortOrder,ProfileSortOrderAscending"
-LineDefaultFailType="conf,DefaultFailType"
+LineDefaultFailType="lua,OperatorMenuOptionRows.DefaultFailType()"
 LineTimingWindowScale="conf,TimingWindowScale"
 LineLifeDifficulty="conf,LifeDifficulty"
 LineHiddenSongs="conf,HiddenSongs"

--- a/metrics.ini
+++ b/metrics.ini
@@ -1198,7 +1198,7 @@ LineCustomSongsMaxMegabytes="lua,OperatorMenuOptionRows.CustomSongsMaxMegabytes(
 [ScreenAdvancedOptions]
 Fallback="ScreenOptionsServiceChild"
 LineNames="DefaultFailType,TimingWindowScale,LifeDifficulty,HiddenSongs,EasterEggs,AllowExtraStage,UseUnlockSystem,AutogenSteps,AutogenGroupCourses,FastLoad,SongDeletion,ProfileSortOrder,ProfileSortOrderAscending"
-LineDefaultFailType="lua,ThemePrefsRows.GetRow('DefaultFailType')"
+LineDefaultFailType="conf,DefaultFailType"
 LineTimingWindowScale="conf,TimingWindowScale"
 LineLifeDifficulty="conf,LifeDifficulty"
 LineHiddenSongs="conf,HiddenSongs"


### PR DESCRIPTION
This commit reverts the Add DefaultFailType as a ThemePrefs commits and instead adds the OperatorMenuOptionRows.DefaultFailType() function to handle DefaultFailType's options. 

DefaultFailType needs to be both set in ``DefaultModifiers`` and in the players' ``PlayerOptions``. Using a ThemePref would not perform these operations. (See: https://github.com/itgmania/itgmania/blob/17864f83e778101f82a22784b98b17e58b4a919d/src/ScreenOptionsMasterPrefs.cpp#L378)

 The function modifies DefaultModifiers based on the selected failtype. We need to do some mapping in here because the values in defaultmodifiers don't line up 1:1 to the exact names of the FailType enum.

See notes from quietly regarding implementation of GetDefaultFailType() which already handles applying the failtype to current PlayerOptions: https://github.com/Simply-Love/Simply-Love-SM5/blob/e9418b7cf1b68abbecbf11aba3964bc9a6cf8155/Scripts/SL-Helpers.lua#L226 
