### PR TITLE
Fix a typo in PaneDisplay.lua

### DIFF
--- a/BGAnimations/ScreenSelectMusic overlay/PaneDisplay.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/PaneDisplay.lua
@@ -209,7 +209,7 @@ local GetScoresRequestProcessor = function(res, params)
 					end
 				else
 					if SL["P"..i].ActiveModifiers.ShowEXScore then
-						loadingText:settext(THEME:GetString("Groovestats", "NoEXData"))
+						loadingText:settext(THEME:GetString("Groovestats", "NoExData"))
 					else
 						loadingText:settext(THEME:GetString("Groovestats", "NoData"))
 					end


### PR DESCRIPTION
Should be `NoExData`, instead of `NoEXData`