### PR TITLE
Minor bump on Japanese Translation

### DIFF
--- a/Languages/ja.ini
+++ b/Languages/ja.ini
@@ -419,7 +419,7 @@ HeaderText=Script Attack Modifiers
 [MusicWheel]
 Random=RANDOM
 
-[Groovestats]
+[GrooveStats]
 Loading=読み込み中...
 TimedOut=中断
 ExScore=EXスコア

--- a/Languages/ja.ini
+++ b/Languages/ja.ini
@@ -234,7 +234,7 @@ Rolls=ロール
 Max Combo=Max Combo
 Held=HELD
 HeaderText=Evaluation
-Disqualified=Disqualified From Ranking
+Disqualified=ランキング失格
 
 Early=Early
 Late=Late
@@ -299,16 +299,16 @@ FormatStages=%i Stages
 
 
 [ScreenGameOver]
-LastUsedHighScoreName=High Score Name
-CaloriesBurned=Calories Burned Today
-TotalSongsPlayed=Total Songs Played
-SongsPlayedThisGame=Songs Played This Game
-NotesHitThisGame=Notes Hit This Game
-TimeSpentThisGame=Time Spent This Game
-Hours=hr.
-Minutes=min.
-Seconds=sec.
-NoCard=No Card
+LastUsedHighScoreName=ランキング名前
+CaloriesBurned=今日の燃焼カロリー
+TotalSongsPlayed=全体の遊んだ曲数:w
+SongsPlayedThisGame=今回の曲数
+NotesHitThisGame=今回の踏んだノーツ数
+TimeSpentThisGame=今回の合計時間
+Hours=時間
+Minutes=分
+Seconds=秒
+NoCard=カートなし
 
 ##############################################
 # Overlay Screens

--- a/Languages/ja.ini
+++ b/Languages/ja.ini
@@ -391,6 +391,23 @@ RecordModeHelpText=Control + R: 記録モードを開始\nQ/W: Holdノートと�
 KeyMappingHelpText=F1: キー配置のヘルプ
 MiscHelpText=Space: 範囲選択\nT: タイミング調整の範囲を切り替え
 
+[ScreenPractice]
+PlayRecordHelpText=
+EditHelpText=
+
+Main title=曲名
+
+# Help Section Headers
+NavigationHelpLabel=Navigating
+MenuHelpLabel=Available Menus
+KeyMappingHelpLabel=KeyMappings
+MiscHelpLabel=Misc.
+
+# Explanations
+NavigationHelpText=↑/↓:\n     1単位移動\n;/':\n     1小節移動\nHome/End:\n    最初・最後に移動
+MenuHelpText=Escape/Enter: メインメニュー\n
+KeyMappingHelpText=F1: キー配置のヘルプ
+MiscHelpText=Space: 範囲選択\n
 
 [ScreenAttackMenu]
 HeaderText=Script Attack Modifiers
@@ -927,13 +944,13 @@ Danger=Danger
 ComboExplosions=Combo Explosions
 
 # DataVisualizations
-Disabled=Disabled
+Disabled=なし
 Target Score Graph=ターゲートグラフ表示
 Step Statistics=判定の数リアルタイム表示
 
 # TargetScore
-Machine best=Machine best
-Personal best=Personal best
+Machine best=筐体ベスト
+Personal best=自己ベスト
 
 # ActionOnMissedTarget
 Nothing=Nothing

--- a/Languages/ja.ini
+++ b/Languages/ja.ini
@@ -422,7 +422,7 @@ Random=RANDOM
 [Groovestats]
 Loading=読み込み中...
 TimedOut=中断
-EXScore=EXスコア
+ExScore=EXスコア
 GrooveStats=GrooveStats
 NoExData=EXデーダなし
 NoData=データなし

--- a/Languages/ja.ini
+++ b/Languages/ja.ini
@@ -39,7 +39,7 @@ Press Start=Press &START; To Play
 
 [ScreenSelectProfile]
 HeaderText=Select Profile
-PressStartToJoin=Press &START; to join!
+PressStartToJoin=&START;を押してください
 NoProfile=No Profile
 GuestProfile=[ゲスト]
 Card=CARD
@@ -47,6 +47,7 @@ MostRecentSong=Most Recent Song
 MostFrequentGrade=Most Frequent Grade
 SingularSongPlayed=%d 遊んだ曲
 SeveralSongsPlayed=%d 遊んだ曲数
+Waiting=待つ ...
 LoginInstructions=ORコードスキャンしてログインしてください
 VisitWebsite=www.groovestats.comでアカウント作成できます
 ProfileConnected=プロファイル\nもう繋がっています
@@ -80,16 +81,16 @@ Loading Profiles...=Loading
 
 [ScreenSelectMusicCasual]
 HeaderText=Choose Your Group
-CloseThisFolder=Close This Folder
-PressStartToLateJoin=Press &START; To Join!
+CloseThisFolder=フォルダーを閉じる
+PressStartToLateJoin=&START;を押してください
 
-SelectDifficulty=SELECT YOUR DIFFICULTY
-SelectSpeedMod=SELECT YOUR ARROW SPACING
-Normal=Normal
-MoreSpace=More Space
-LessSpace=Less Space
+SelectDifficulty=難易度選択
+SelectSpeedMod=矢印速度選択
+Normal=普通
+MoreSpace=間隔が広い
+LessSpace=間隔が狭い
 
-Press=PRESS
+Press=押す
 Start=START
 
 FooterTextGroups=&MENULEFT; &MENURIGHT; でグループを選択          &START; で決定
@@ -301,7 +302,7 @@ FormatStages=%i Stages
 [ScreenGameOver]
 LastUsedHighScoreName=ランキング名前
 CaloriesBurned=今日の燃焼カロリー
-TotalSongsPlayed=全体の遊んだ曲数:w
+TotalSongsPlayed=全体の遊んだ曲数
 SongsPlayedThisGame=今回の曲数
 NotesHitThisGame=今回の踏んだノーツ数
 TimeSpentThisGame=今回の合計時間
@@ -384,7 +385,7 @@ KeyMappingHelpLabel=KeyMappings
 MiscHelpLabel=Misc.
 
 # Explanations
-NavigationHelpText=↑/↓:\n     1単位移動\n;/':\n     1小節移動\nHome/End:\n    最初・最後に移動
+NavigationHelpText=↑/↓:\n     1小節移動\n;/':\n     1小節移動\nHome/End:\n    最初・最後に移動
 NoteWritingHelpText=数字キー:\n     矢印を配置・削除\n←/→:\n     配置単位を選択\n数字 + ↑/↓:\n    Holdノートを配置\nShift + 数字 + ↑/↓:\n    Rollを配置\nN/M: ノートタイプを変更
 MenuHelpText=Escape: メインメニュー\nEnter: 範囲メニュー\nA: アレンジメニュー\nF4: タイミングメニュー
 RecordModeHelpText=Control + R: 記録モードを開始\nQ/W: Holdノートとして記録する時間を変更\nE/R: Holdノートの記録の有効化・無効化
@@ -425,7 +426,7 @@ EXScore=EXスコア
 GrooveStats=GrooveStats
 NoExData=EXデーダなし
 NoData=データなし
-Disabled=GS無
+Disabled=GS無効
 MoreLeaderboards=もっと見る
 NoDownloads=ダウンロードなし
 
@@ -438,6 +439,7 @@ Submitted=投稿成功!
 SubmitFailed=投稿失敗😞
 
 # ScreenSystemLayer Statuses
+FailedToLoad=読み込みに失敗 😞
 
 [RadarCategory]
 Hands=3つ押し
@@ -642,12 +644,16 @@ TimingWindows=Disable Timing Windows
 GameplayExtras=Gameplay Extras
 GameplayExtrasB=Gameplay Extras
 GameplayExtrasC=Gameplay Extras
+TiltMultiplier=Judgment Tilt Intensity
 ErrorBar=Error Bar
 ErrorBarOptions=Error Bar Options
 MeasureCounterOptions=Measure Counter\nOptions
 MeasureCounter=Measure Counter
 LifeMeterType=LifeMeter Type
 ScreenAfterPlayerOptions2=次は?
+
+# ScreenPlayerOptions3
+ScreenAfterPlayerOptions3=次は?
 
 # ScreenPlayAgain
 Yes=Yes
@@ -839,6 +845,7 @@ ActionOnMissedTarget=目標スコアが達成できなくなったときの挙�
 GameplayExtras=ゲームプレイ中の様々な情報を表示することができます。
 GameplayExtrasB=ゲームプレイ中の様々な情報を表示することができます。
 GameplayExtrasC=ゲームプレイ中の様々な情報を表示することができます。
+TiltMultiplier=「判定を傾ける」の設定が有効時、斜めさの強度を調製ができます。
 ErrorBar=判定エラーバーのスタイルを選択・もしくは無効にします。
 ErrorBarTrim=エラーバーの極端の範囲を表示することが出来ます。
 ErrorBarOptions=エラーバーの見た目を調整します。\nデフォルトでは、判定文字の真下に表示されます。Multi-TickはTextには反映されません。
@@ -847,9 +854,12 @@ MeasureLines=ガイドラインの表示を設定します。
 MeasureCounter=滝の小節数を表示することができます。
 TimingWindowOptions=早めに踏んでしまったDecentsとかWay Offsの視覚的の行動。
 TimingWindows=一部の判定を無効化します。
-ScreenAfterPlayerOptions2=他の曲を選択するか、一つ前のオプション画面に戻ります。
+ScreenAfterPlayerOptions2=他の曲を選択するとか、前のオプション画面に戻ります。
 LifeMeterType="Surround": ライフゲージが背景に縦向きに表示されます。\n"Vertical": ライフゲージがPlayField横に縦向きに表示されます。
 VisualDelay=プライヤー固有の画面表示の遅延を調整します。負の値は矢印が上に移動しますが、正の値が矢印が下に移動します。
+
+# ScreenPlayerOptions3
+ScreenAfterPlayerOptions3=他の曲を選択するとか、前のオプション画面に戻ります。
 
 # Screen Profiles
 Select Profile=このプロファイルを使用または編集します。

--- a/Languages/ja.ini
+++ b/Languages/ja.ini
@@ -401,6 +401,27 @@ HeaderText=Script Attack Modifiers
 [MusicWheel]
 Random=RANDOM
 
+[Groovestats]
+Loading=読み込み中...
+TimedOut=中断
+EXScore=EXスコア
+GrooveStats=GrooveStats
+NoExData=EXデーダなし
+NoData=データなし
+Disabled=GS無
+MoreLeaderboards=もっと見る
+NoDownloads=ダウンロードなし
+
+# auto QR submission
+ScoreAlreadySubmitted=このスコアも登校したことある :)
+WorldRecord=世界記録！
+PersonalBest=自己ベスト
+Submitting=投稿中...
+Submitted=投稿成功!
+SubmitFailed=投稿失敗😞
+
+# ScreenSystemLayer Statuses
+
 [RadarCategory]
 Hands=3つ押し
 Holds=フリーズ


### PR DESCRIPTION
- Casual Mode
- Practice Mode
- Some Groovestats strings * (see future work)
- Evaluation Screen (calories burned and song lengths)


 ## Future Work
 - Some Groovestats Error Handling Strings still hardcoded but it should not seriously interfere with most core gameplay. However given the frequent network timeouts could still be informative to user?
 - the QRcode results screen text sometimes overflows (does not wrap) ... as does the profile options (some options are particularly lengthy) need to check box boundaries? 
 