### PR TITLE
Fix QR login screen showing

### DIFF
--- a/Scripts/SL-Branches.lua
+++ b/Scripts/SL-Branches.lua
@@ -59,7 +59,7 @@ Branch.AllowScreenSelectProfile = function()
 	if ThemePrefs.Get("AllowScreenSelectProfile") then
 		return "ScreenSelectProfile"
 	else
-			return Branch.AfterSelectProfile()
+		return Branch.AfterSelectProfile()
 	end
 end
 

--- a/Scripts/SL-Branches.lua
+++ b/Scripts/SL-Branches.lua
@@ -59,18 +59,14 @@ Branch.AllowScreenSelectProfile = function()
 	if ThemePrefs.Get("AllowScreenSelectProfile") then
 		return "ScreenSelectProfile"
 	else
-		if SL.GrooveStats.IsConnected then
-			return "ScreenGrooveStatsLogin"
-		else
 			return Branch.AfterSelectProfile()
-		end
 	end
 end
 
 Branch.AfterSelectProfile = function()
 	-- If we only want to sometimes display QR Login, only do so if at least one
 	-- of the chosen profiles doesn't already have an API key saved.
-	local allApiKeys = false
+	local allApiKeys = true
 	for player in ivalues(GAMESTATE:GetHumanPlayers()) do
 		local pn = ToEnumShortString(player)
 		if SL[pn].ApiKey == "" then


### PR DESCRIPTION
Fixes 2 issues:
- QR login screen showing when `QRLogin` is set to `Sometimes` and all selected profiles have an API key saved
- QR login screen setting not respected when `AllowScreenSelectProfile` is `false`