### PR TITLE
Fix crash when changing DefaultfailType

### DIFF
--- a/Scripts/SL-OperatorMenuOptions.lua
+++ b/Scripts/SL-OperatorMenuOptions.lua
@@ -101,17 +101,17 @@ OperatorMenuOptionRows.DefaultFailType = function()
 		SaveSelections = function(self, list, pn)
 			for i = 1, #failTypes do
 				if list[i] then
-					local default_mods = PREFSMAN:GetPreference("DefaultModifiers")
+					local default_mods = PREFSMAN:GetPreference("DefaultModifiers") or "failimmediate"
 					local selected_fail = failTypes[i]
 					local default_fail = "" -- An empty string means Immediate fail
-					local new_fail = "failimmediatecontinue"
+					local new_fail = "failimmediate"
 					local fail_strings = {}
 				
 					for mod in string.gmatch(default_mods, "%w+") do
 						if mod:lower():find("fail") then
 							-- we found something matches "fail", so set our default_fail variable
 							-- if we don't find anything that means the fail type is Immediate
-							default_fail = mod:lower()
+							default_fail = mod
 							break;
 						end
 					end
@@ -122,7 +122,6 @@ OperatorMenuOptionRows.DefaultFailType = function()
 					fail_strings.failimmediatecontinue = "ImmediateContinue"
 					fail_strings.failoff               = "Off"
 					fail_strings.failatend             = "EndOfSong"
-
 					-- Map the selected fail type to the failtype string for DefaultModifiers
 					for k, v in pairs(fail_strings) do
 						if selected_fail == v then


### PR DESCRIPTION
Add null check on GetPreference when SavingSelection for DefaultFailType (default to ImmediateContinue if the preference isn't set yet)