### PR TITLE
Revert "Reset DefaultLocalProfile after each session..."  in favor of future engine patch

### DIFF
--- a/Scripts/SL_Init.lua
+++ b/Scripts/SL_Init.lua
@@ -486,16 +486,7 @@ function InitializeSimplyLove()
 	SL.P1:initialize()
 	SL.P2:initialize()
 	SL.Global:initialize()
-	
-	-- Temporary fix so late joining players aren't getting the last person's profile.
-	-- This obsoletes the handling for defaulting to the DefaultLocalProfile in SelectProfile
-	-- However, the addition of the ProfileSortOrder_Recent will ensure the last used profile is
-	-- always at the top of the list anyways
-	-- If the SelectProfile screen is not being used, we should continue to use the default profiles
-	if ThemePrefs.Get("AllowScreenSelectProfile") then
-		PREFSMAN:SetPreference("DefaultLocalProfileIDP1", "")
-		PREFSMAN:SetPreference("DefaultLocalProfileIDP2", "")
-	end
+
 end
 
 InitializeSimplyLove()


### PR DESCRIPTION
DefaultLocalProfile is used in way more places than it should be. It essentially operates as both the currently and last selected player. This resulted in any late joining players getting last used profile on that respective side. The original commit was an attempted temporary fix for this problem. Reverting this commit (and its subsequent typo patch) for now in favor of exploring solutions via engine.

This reverts commit 075fb47e1a7f7bb362d65a287ae4ca2a945362a5.