### PR TITLE
Add a subtle red highlight to NULL synced songs in the Music Wheel to aid with identifying songs of different sync.

### DIFF
--- a/Graphics/MusicWheelItem Course NormalPart.lua
+++ b/Graphics/MusicWheelItem Course NormalPart.lua
@@ -5,13 +5,35 @@ local num_visible_items = num_items - 2
 
 local item_width = _screen.w / 2.125
 
-return Def.ActorFrame{
-	-- the MusicWheel is centered via metrics under [ScreenSelectMusic]; offset by a slight amount to the right here
-	InitCommand=function(self) self:x(WideScale(28,33)) end,
+return Def.ActorFrame {
+    -- the MusicWheel is centered via metrics under [ScreenSelectMusic]; offset by a slight amount to the right here
+    InitCommand = function(self) self:x(WideScale(28, 33)) end,
 
-	Def.Quad{ InitCommand=function(self) self:horizalign(left):diffuse(0, 10/255, 17/255, 0.5):zoomto(item_width, _screen.h/num_visible_items) end },
-	Def.Quad{ InitCommand=function(self)
-		self:horizalign(left):diffuse(DarkUI() and {1,1,1,0.5} or {10/255, 20/255, 27/255, 1}):zoomto(item_width, (_screen.h/num_visible_items)-1)
-		if ThemePrefs.Get("VisualStyle") == "SRPG8" or ThemePrefs.Get("VisualStyle") == "Technique" then self:diffusealpha(0.5) end
-	end }
+    Def.Quad {
+        InitCommand = function(self)
+            self:horizalign(left):diffuse(0, 10 / 255, 17 / 255, 0.5):zoomto(item_width, _screen.h / num_visible_items)
+        end
+    },
+    Def.Quad {
+        InitCommand = function(self)
+            self:horizalign(left):diffuse(DarkUI() and {1, 1, 1, 0.5} or {10 / 255, 20 / 255, 27 / 255, 1}):zoomto(item_width, (_screen.h / num_visible_items) - 1)
+            if ThemePrefs.Get("VisualStyle") == "SRPG8" or ThemePrefs.Get("VisualStyle") == "Technique" then
+                self:diffusealpha(0.5)
+            end
+        end,
+		SetCommand=function(self, params)
+			if params.Song then
+				local song = params.Song
+				local offset = round(SONGMAN:GetGroup(song):GetSyncOffset(), 3)
+				if offset == -0.009 then
+					self:diffuserightedge(DarkUI() and {1, 1, 1, 0.5} or {10 / 255, 20 / 255, 27 / 255, 1})
+				else
+					self:diffuserightedge(DarkUI() and {1, 0.5, 0.5, 0.5} or {80 / 255, 20 / 255, 27 / 255, 1})
+				end
+				if ThemePrefs.Get("VisualStyle") == "SRPG8" or ThemePrefs.Get("VisualStyle") == "Technique" then
+					self:diffusealpha(0.5)
+				end
+			end
+		end,
+    }
 }


### PR DESCRIPTION
Add a subtle red highlight to NULL synced songs in the Music Wheel to aid with identifying songs of different sync.
This will help with troubleshooting potential sync issues and also operate as a visual indicator of the sync offset on each song. (Useful if changing DefaultSyncOffset on the machine)

![image](https://github.com/user-attachments/assets/1b0d553a-16ab-4706-bb86-918f5e475859)
![image](https://github.com/user-attachments/assets/0d390275-9a04-4396-95a8-07c2acab5b50)
