### PR TITLE
Add another navigation tip for next/previous arrow in practice mode.

### DIFF
--- a/BGAnimations/ScreenPractice underlay.lua
+++ b/BGAnimations/ScreenPractice underlay.lua
@@ -25,8 +25,8 @@ local t = Def.ActorFrame{
 
 local sections = {
 	NavigationHelp = 0,
-	MenuHelp = 100,
-	MiscHelp = 136
+	MenuHelp = 130,
+	MiscHelp = 166
 }
 
 for section, offset in pairs(sections) do

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -505,7 +505,7 @@ KeyMappingHelpLabel=KeyMappings
 MiscHelpLabel=Misc.
 
 # Explanations
-NavigationHelpText=Up/Down:\n     Move One Measure\nSemicolon/Apostrophe:\n     Move One Measure\nHome/End:\n    Move to Start/End of Steps
+NavigationHelpText=Comma/Period:\n     Move To Next/Previous Arrow\nUp/Down:\n     Move One Measure\nSemicolon/Apostrophe:\n     Move One Measure\nHome/End:\n    Move to Start/End of Steps
 MenuHelpText=Escape\Enter: Main Menu
 KeyMappingHelpText=F1: Keymappings Help
 MiscHelpText=Space: Set area marker


### PR DESCRIPTION
It's a bit hard to navigate dense charts in practice mode, and we can't change the note snap atm. Going to the next note is a decent workaround for now, so add it into the NavigationHelp string.