### PR TITLE
Count missed holds in ex_counts

### DIFF
--- a/BGAnimations/ScreenGameplay overlay/TrackExScoreJudgments.lua
+++ b/BGAnimations/ScreenGameplay overlay/TrackExScoreJudgments.lua
@@ -63,6 +63,10 @@ return Def.Actor{
 		local count_updated = false
 		if params.HoldNoteScore then
 			local HNS = ToEnumShortString(params.HoldNoteScore)
+			-- Missed holds are scored the same way as let go holds, so count them as such
+			if HNS == "MissedHold" then
+				HNS = "LetGo"
+			end
 			-- Only track the HoldNoteScores we care about
 			if valid_hns[HNS] then
 				if not stats:GetFailed() then


### PR DESCRIPTION
Since missed holds aren't worth any points, count them together with let go holds. This won't change any score calculations but it fixes a bug with subtractive scoring where missing a hold causes the calculated score to desync.