### PR TITLE
Reload the Music Wheel on the profile select screen when a USB profile is joined

### DIFF
--- a/BGAnimations/ScreenSelectMusic overlay/SortMenu/SortMenu_InputHandler.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SortMenu/SortMenu_InputHandler.lua
@@ -105,7 +105,11 @@ local input = function(event)
 					SCREENMAN:SetNewScreen("ScreenViewDownloads")
 				elseif focus.new_overlay == "SwitchProfile" then
 					SL.Global.FastProfileSwitchInProgress = true
-
+					-- If a memory card is inserted we can't be on that profile's songs when switching profiles
+					-- as the profile is temporarily unloaded when finishing the screen.
+					if MEMCARDMAN:GetCardState(PLAYER_1) ~= 'MemoryCardState_none' or MEMCARDMAN:GetCardState(PLAYER_2) ~= 'MemoryCardState_none' then
+						SCREENMAN:GetTopScreen():GetMusicWheel():SetOpenSection("");
+					end
 					-- Make sure we save any currently active profiles before potentially switching
 					-- to different ones.
 					GAMESTATE:SaveProfiles()

--- a/BGAnimations/ScreenSelectMusic overlay/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/default.lua
@@ -32,6 +32,15 @@ local af = Def.ActorFrame{
 			addOrRemoveFavorite(params.PlayerNumber)
 		end
 	end,
+	ReloadScreenForMemoryCardsMessageCommand=function(self, params)
+		-- Wait some time for the profile screen to finish transitioning
+		-- before reloading the screen.
+		self:sleep(0.10):queuecommand("Reload")
+	end,
+	ReloadCommand=function(self)
+		SCREENMAN:GetTopScreen():SetNextScreenName("ScreenReloadSSM")
+		SCREENMAN:GetTopScreen():StartTransitioningScreen("SM_GoToNextScreen")
+	end,
 	-- ---------------------------------------------------
 	--  first, load files that contain no visual elements, just code that needs to run
 

--- a/BGAnimations/ScreenSelectProfile underlay/default.lua
+++ b/BGAnimations/ScreenSelectProfile underlay/default.lua
@@ -157,6 +157,12 @@ local t = Def.ActorFrame {
 
 		if SL.Global.FastProfileSwitchInProgress then
 			SL.Global.FastProfileSwitchInProgress = false
+			-- Check if one of the players has a memory card
+			-- If so, we need to reload the screen to update the profile data
+			-- Otherwise, we can just finish the screen
+			if MEMCARDMAN:GetCardState(PLAYER_1) ~= 'MemoryCardState_none' or MEMCARDMAN:GetCardState(PLAYER_2) ~= 'MemoryCardState_none' then
+				MESSAGEMAN:Broadcast("ReloadScreenForMemoryCards")
+			end
 		end
 		SCREENMAN:GetTopScreen():Finish()
 	end,


### PR DESCRIPTION
The game crashes if the player has USB songs and enters+exits the fast ScreenSelectProfile screen in the music wheel. This is because the player's songs are unloaded and then reloaded however the MusicWheel has not been rebuilt to account for this.