### PR TITLE
Add inline tech notation and EX scores to the Music Wheel

### DIFF
--- a/BGAnimations/ScreenEvaluation common/PerPlayer/ItlFile.lua
+++ b/BGAnimations/ScreenEvaluation common/PerPlayer/ItlFile.lua
@@ -3,7 +3,7 @@ local player = ...
 if (SL.Global.GameMode == "Casual" or
 		GAMESTATE:IsCourseMode() or
 		not IsItlActive() or
-		not IsItlSong(player) or
+		not IsItlSong(GAMESTATE:GetCurrentSong(), player) or
 		GAMESTATE:GetCurrentGame():GetName() ~= "dance") then
 	return
 end

--- a/BGAnimations/ScreenSelectMusic overlay/PerPlayer/DensityGraph.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/PerPlayer/DensityGraph.lua
@@ -128,11 +128,11 @@ af2[#af2+1] = LoadFont("Common Normal")..{
 	Name="NPS",
 	Text=peakNPSText..": ",
 	InitCommand=function(self)
-		self:horizalign(left):zoom(0.8)
+		self:horizalign(left):zoom(0.8):maxwidth(133)
 		if player == PLAYER_1 then
-			self:addx(60):addy(-41)
+			self:addx(36):addy(-41)
 		else
-			self:addx(-136):addy(-41)
+			self:addx(-143):addy(-41)
 		end
 		-- We want black text in Rainbow mode except during HolidayCheer(), white otherwise.
 		self:diffuse((ThemePrefs.Get("RainbowMode") and not HolidayCheer()) and {0, 0, 0, 1} or {1, 1, 1, 1})
@@ -142,8 +142,15 @@ af2[#af2+1] = LoadFont("Common Normal")..{
 		self:visible(false)
 	end,
 	RedrawCommand=function(self)
+		local streamMeasures, breakMeasures = GetTotalStreamAndBreakMeasures(pn)
+		local totalMeasures = streamMeasures + breakMeasures
+		local percentageText = "" 
+		if streamMeasures ~= 0 then
+			percentageText = string.format(" (%0.1f%%)", --[[streamMeasures, totalMeasures,]] streamMeasures/totalMeasures*100)
+		end
+
 		if SL[pn].Streams.PeakNPS ~= 0 then
-			self:settext((peakNPSText..": %.1f"):format(SL[pn].Streams.PeakNPS * SL.Global.ActiveModifiers.MusicRate))
+			self:settext((peakNPSText..": %.1f"):format(SL[pn].Streams.PeakNPS * SL.Global.ActiveModifiers.MusicRate) .. percentageText)
 			self:visible(not showPatternInfo)
 		end
 	end,
@@ -187,6 +194,7 @@ af2[#af2+1] = Def.ActorFrame{
 		end,
 		RedrawCommand=function(self)
 			local textZoom = 0.8
+
 			self:settext(GenerateBreakdownText(pn, 0))
 			local minimization_level = 1
 			while self:GetWidth() > (width/textZoom) and minimization_level < 4 do
@@ -227,6 +235,32 @@ af2[#af2+1] = Def.ActorFrame{
 		self:visible(showPatternInfo)
 	end,
 
+	-- Tech notation, identical placement as the Peak NPS text
+	LoadFont("Common Normal") .. {
+		Text = "",
+		InitCommand=function(self)
+			self:horizalign(left):zoom(0.8)
+
+			if GAMESTATE:GetNumSidesJoined() == 1 then
+				self:maxwidth(width)
+			else
+				self:maxwidth(133)
+			end
+			
+			if player == PLAYER_1 then
+				self:addx(36):addy(-41)
+			else
+				self:addx(-143):addy(-41)
+			end
+
+			-- We want black text in Rainbow mode except during HolidayCheer(), white otherwise.
+			self:diffuse((ThemePrefs.Get("RainbowMode") and not HolidayCheer()) and {0, 0, 0, 1} or {1, 1, 1, 1})
+		end,
+		RedrawCommand=function(self)
+			self:settext(SL[pn].Streams.TechNotation)
+		end
+	},
+
 	-- Background for the additional chart info.
 	-- Only shown in 1 Player mode
 	Def.Quad{
@@ -244,49 +278,30 @@ local af3 = af2[#af2]
 local layout = {
 	{"Crossovers", "Footswitches"},
 	{"Sideswitches", "Jacks"},
-	{"Brackets", "Total Stream"},
+	{"Brackets", "Doublesteps"},
 }
 
 local colSpacing = 150
 local rowSpacing = 20
-local noneText = THEME:GetString("SLPlayerOptions", "None")
-local totalStreamText = THEME:GetString("SLPlayerOptions", "TotalStream")
 
 for i, row in ipairs(layout) do
 	for j, col in pairs(row) do
 		af3[#af3+1] = LoadFont("Common normal")..{
-			Text=(col ~= totalStreamText and "0" or noneText).." (0.0%)",
+			Text="0",
 			Name=col .. "Value",
 			InitCommand=function(self)
-				local textHeight = 17
+				local textHeight = 17 -- TODO: remove? This is unused
 				local textZoom = 0.8
 				self:zoom(textZoom):horizalign(right)
-				if col == "Total Stream" then
-					self:maxwidth(100)
-				end
 				self:xy(-width/2 + 40, -height/2 + 13)
 				self:addx((j-1)*colSpacing)
 				self:addy((i-1)*rowSpacing)
 			end,
 			HideCommand=function(self)
-				if col ~= "Total Stream" then
-					self:settext("0")
-				else
-					self:settext(noneText.." (0.0%)")
-				end
+				self:settext("0")
 			end,
 			RedrawCommand=function(self)
-				if col ~= "Total Stream" then
-					self:settext(SL[pn].Streams[col])
-				else
-					local streamMeasures, breakMeasures = GetTotalStreamAndBreakMeasures(pn)
-					local totalMeasures = streamMeasures + breakMeasures
-					if streamMeasures == 0 then
-						self:settext(noneText.." (0.0%)")
-					else
-						self:settext(string.format("%d/%d (%0.1f%%)", streamMeasures, totalMeasures, streamMeasures/totalMeasures*100))
-					end
-				end
+				self:settext(SL[pn].Streams[col])
 			end
 		}
 
@@ -294,7 +309,7 @@ for i, row in ipairs(layout) do
 			Text=THEME:GetString("TechCategory", col),
 			Name=col,
 			InitCommand=function(self)
-				local textHeight = 17
+				local textHeight = 17 -- TODO: remove? This is unused
 				local textZoom = 0.8
 				self:maxwidth(width/textZoom):zoom(textZoom):horizalign(left)
 				self:xy(-width/2 + 50, -height/2 + 13)

--- a/Graphics/MusicWheelItem Grades/default.lua
+++ b/Graphics/MusicWheelItem Grades/default.lua
@@ -39,9 +39,7 @@ local function IsQuint(hsl)
 	return false
 end
 
-return Def.ActorFrame{
-	LoadActor("GetLamp.lua"),
-
+local af = Def.ActorFrame {
 	Def.Sprite{
 		Texture=THEME:GetPathG("MusicWheelItem","Grades/grades 1x19.png"),
 		InitCommand=function(self) self:zoom( SL_WideScale(0.18, 0.3) ):animate(false) end,
@@ -55,7 +53,7 @@ return Def.ActorFrame{
 		--     NumTimesPlayed (number)
 		--     HighScoreList (as of ITGmania 1.0.1 -- NOTE: can be removed in a future version)
 		SetGradeCommand=function(self, params)
-			if not params.Grade then
+			if not params.Grade or ThemePrefs.Get("MusicWheelEXScore") then
 				self:visible(false)
 				return
 			end
@@ -75,3 +73,9 @@ return Def.ActorFrame{
 		end
 	},
 }
+
+if not ThemePrefs.Get("MusicWheelEXScore") then
+	af[#af + 1] = LoadActor("GetLamp.lua")
+end
+
+return af

--- a/Graphics/MusicWheelItem Song NormalPart/EXScore.lua
+++ b/Graphics/MusicWheelItem Song NormalPart/EXScore.lua
@@ -1,0 +1,161 @@
+-- Display best EX from stored highscores
+local player = ...
+
+local function CalculateExScoreFromHighscoreAndSteps(hs, steps, pn)
+   	-- white fa count is stored in score 🤯
+    -- https://discord.com/channels/292111865658474496/958039182327029840/1156796786061606972
+	local score = hs:GetScore()
+	local ex_counts = {
+        W0 = hs:GetTapNoteScore(ToEnumShortString("TNS_W1")) - score,
+		W1 = score,
+		W2 = hs:GetTapNoteScore(ToEnumShortString("TNS_W2")),
+		W3 = hs:GetTapNoteScore(ToEnumShortString("TNS_W3")),
+		W4 = hs:GetTapNoteScore(ToEnumShortString("TNS_W4")),
+		W5 = hs:GetTapNoteScore(ToEnumShortString("TNS_W5")),
+		Miss = hs:GetTapNoteScore(ToEnumShortString("TNS_Miss")),
+		Held = hs:GetHoldNoteScore(ToEnumShortString("HNS_Held")),
+		LetGo = hs:GetHoldNoteScore(ToEnumShortString("HNS_LetGo")),
+		HitMine = hs:GetTapNoteScore(ToEnumShortString("TNS_HitMine"))
+	}
+
+    local use_actual_w0_weight = true
+    local po_NoMines = false -- can't determine from highscore?
+	return CalculateExScoreNoGlobalState(steps, pn, po_NoMines, ex_counts, use_actual_w0_weight)
+end
+
+-- Based on GetLamp
+-- Colors in SL.JudgementColors["FA+"]:
+-- 1: blue    (FFC)
+-- 2: white   (normal)
+-- 3: gold    (FEC)
+-- 4: green   (FC)
+-- 5: purple  (FBFC)
+-- 6: red     (fail)
+-- Still called AwardMap since it's mostly based on the awards...
+local AwardMap = {
+	["StageAward_FullComboW1"] = 1,
+	["StageAward_FullComboW2"] = 3,
+	["StageAward_SingleDigitW2"] = 3,
+	["StageAward_OneW2"] = 3,
+	["StageAward_FullComboW3"] = 4,
+	["StageAward_SingleDigitW3"] = 4,
+	["StageAward_OneW3"] = 4,
+	["StageAward_100PercentW3"] = 4,
+	-- The StageAwards below technically doesn't exist, but we create them on the
+	-- fly below.
+	["StageAward_FullComboW0"] = 5,
+    ["normal"] = 2,
+    ["fail"] = 6
+}
+
+-- Based on GetLamp
+local function EXColorForHighScore(score)
+	local award = score:GetStageAward()
+    local grade = score:GetGrade()
+
+    -- quint
+	if grade == "Grade_Tier01" then
+		if score:GetPercentDP() == 1.0 and score:GetScore() < score:GetTapNoteScore("TapNoteScore_W1") and score:GetScore() == 0 then
+			award = "StageAward_FullComboW0"
+		end
+	end
+
+    if grade == "Grade_Failed" then
+        award = "fail"
+    end
+
+    if award == nil then
+        award = "normal"
+    end
+
+    local aw_res = AwardMap[award]
+	return SL.JudgmentColors["FA+"][aw_res]
+end
+
+-- Add EX scores to the song wheel as well.
+-- It will be centered to the item if only one player is enabled, and stacked otherwise.
+return Def.BitmapText{
+    Font="Wendy/_wendy monospace numbers",
+    Text="",
+    InitCommand=function(self)
+        self:visible(false)
+        self:zoom(0.2)
+        self:x(32)
+    end,
+    PlayerJoinedMessageCommand=function(self)
+        self:visible(GAMESTATE:IsPlayerEnabled(player))
+    end,
+    PlayerUnjoinedMessageCommand=function(self)
+        self:visible(GAMESTATE:IsPlayerEnabled(player))
+    end,
+    SetCommand=function(self, params)
+        -- Only display EX score if a profile is found for an enabled player.
+        self:visible(false):settext("")
+        if not GAMESTATE:IsPlayerEnabled(player) or not PROFILEMAN:IsPersistentProfile(player) then
+            return
+        end
+
+        if GAMESTATE:GetNumSidesJoined() == 2 then
+            if player == PLAYER_1 then
+                self:y(-11)
+            else
+                self:y(4)
+            end
+        else
+            self:y(-4)
+        end
+
+        local pn = ToEnumShortString(player)
+        if params.Song ~= nil then
+            local song = params.Song
+            local steps = SongUtil.GetPlayableSteps(song)
+
+            local currentSteps = GAMESTATE:GetCurrentSteps(player)
+            if currentSteps == nil then
+                -- SM("currentSteps nil")
+                return
+            end
+
+            local currentDifficulty = currentSteps:GetDifficulty()
+
+            -- Like grades, show tech that matches the currently selected difficulty.
+            local stepsToCheck = nil
+            if #steps == 1 then
+                -- If there's only a single difficulty, don't try to match the difficulty. Just show the only one.
+                stepsToCheck = steps[1]
+            else
+                -- TODO: Match the engine (or theme?) behaviour on which difficulty will be autoselected from this chart
+                for k, v in ipairs(steps) do
+                    if v:GetDifficulty() == currentDifficulty then
+                        stepsToCheck = v
+                    end
+                end
+            end
+
+            if stepsToCheck == nil then
+                return
+            end
+
+            local highscores = PROFILEMAN:GetProfile(pn):GetHighScoreList(song, stepsToCheck):GetHighScores()
+
+            local best_ex = nil
+            local hs_for_best_ex = nil
+			for hs in ivalues(highscores) do
+				local ex = CalculateExScoreFromHighscoreAndSteps(hs, stepsToCheck, pn)
+				if ex ~= nil and best_ex == nil then
+					best_ex = ex
+                    hs_for_best_ex = hs
+				elseif ex ~= nil and ex > best_ex then
+					best_ex = ex
+                    hs_for_best_ex = hs
+				end
+			end
+
+			if best_ex ~= nil then
+				self:settext(("%05.2f"):format(best_ex))
+                self:diffuse(EXColorForHighScore(hs_for_best_ex))
+				self:visible(true)
+			end
+        end
+    end,
+}

--- a/Graphics/MusicWheelItem Song NormalPart/ITL_EXScore.lua
+++ b/Graphics/MusicWheelItem Song NormalPart/ITL_EXScore.lua
@@ -1,0 +1,56 @@
+local player = ...
+
+-- Add ITL EX scores to the song wheel as well.
+-- It will be centered to the item if only one player is enabled, and stacked otherwise.
+return Def.BitmapText{
+    Font="Wendy/_wendy monospace numbers",
+    Text="",
+    InitCommand=function(self)
+        self:visible(false)
+        self:zoom(0.2)
+        self:x(32)
+        self:x(_screen.w/(WideScale(2.15, 2.14)) - self:GetWidth()*self:GetZoom() - 40)
+        self:diffuse(SL.JudgmentColors["FA+"][1])
+    end,
+    PlayerJoinedMessageCommand=function(self)
+        self:visible(GAMESTATE:IsPlayerEnabled(player))
+    end,
+    PlayerUnjoinedMessageCommand=function(self)
+        self:visible(GAMESTATE:IsPlayerEnabled(player))
+    end,
+    SetCommand=function(self, params)
+        -- Only display EX score if a profile is found for an enabled player.
+        if not GAMESTATE:IsPlayerEnabled(player) or not PROFILEMAN:IsPersistentProfile(player) then
+            self:visible(false)
+            return
+        end
+
+        if GAMESTATE:GetNumSidesJoined() == 2 then
+            if player == PLAYER_1 then
+                self:y(-11)
+            else
+                self:y(4)
+            end
+        else
+            self:y(-4)
+        end
+        self:settext("00.00"):visible(true)
+        local pn = ToEnumShortString(player)
+        if params.Song ~= nil then
+            local song = params.Song
+            local song_dir = song:GetSongDir()
+            if song_dir ~= nil and #song_dir ~= 0 then
+                if SL[pn].ITLData["pathMap"][song_dir] ~= nil then
+                    local hash = SL[pn].ITLData["pathMap"][song_dir]
+                    if SL[pn].ITLData["hashMap"][hash] ~= nil then
+                        local ex = SL[pn].ITLData["hashMap"][hash]["ex"] / 100
+                        self:settext(("%.2f"):format(ex))
+                        self:visible(true)
+                        return
+                    end
+                end
+            end
+        end
+        self:visible(false)
+    end,
+}

--- a/Graphics/MusicWheelItem Song NormalPart/TechNotation.lua
+++ b/Graphics/MusicWheelItem Song NormalPart/TechNotation.lua
@@ -3,87 +3,6 @@
 local player = ...
 local pn = ToEnumShortString(player)
 
--- array style to keep ordering in ipairs
-local techtypes = {
-	{
-		tcc = "TechCountsCategory_Brackets",
-		Condensed = {
-			symbol_light  = "b",
-			symbol_medium = "B",
-			symbol_heavy  = "B+"
-		},
-		Verbose = {
-			symbol_light  = "BR- ",
-			symbol_medium = "BR ",
-			symbol_heavy  = "BR+ "
-		}
-	},
-	{
-		tcc = "TechCountsCategory_Crossovers",
-		Condensed = {
-			symbol_light  = "x",
-			symbol_medium = "X",
-			symbol_heavy  = "X+"
-		},
-		Verbose = {
-			symbol_light  = "XO- ",
-			symbol_medium = "XO ",
-			symbol_heavy  = "XO+ "
-		}
-	},
-	{
-		tcc = "TechCountsCategory_Footswitches",
-		Condensed = {
-			symbol_light  = "f",
-			symbol_medium = "F",
-			symbol_heavy  = "F+"
-		},
-		Verbose = {
-			symbol_light  = "FS- ",
-			symbol_medium = "FS ",
-			symbol_heavy  = "FS+ "
-		}
-	},
-	{
-		tcc = "TechCountsCategory_Sideswitches",
-		Condensed = {
-			symbol_light  = "s",
-			symbol_medium = "S",
-			symbol_heavy  = "S+"
-		},
-		Verbose = {
-			symbol_light  = "SS ",
-			symbol_medium = "SS ",
-			symbol_heavy  = "SS+ "
-		}
-	},
-	{
-		tcc = "TechCountsCategory_Jacks",
-		Condensed = {
-			symbol_light  = "j",
-			symbol_medium = "J",
-			symbol_heavy  = "J+"
-		},
-		Verbose = {
-			symbol_light  = "JS- ",
-			symbol_medium = "JS ",
-			symbol_heavy  = "JS+ "
-		}
-	},
-	{
-		tcc = "TechCountsCategory_Doublesteps",
-		Condensed = {
-			symbol_light  = "d",
-			symbol_medium = "D",
-			symbol_heavy  = "D+"
-		},
-		Verbose = {
-			symbol_light  = "DS- ",
-			symbol_medium = "DS ",
-			symbol_heavy  = "DS+ "
-		}
-	}
-}
 
 -- TODO: 2 actors, one for each player. Could this be one actor that draws both players?
 local af = Def.BitmapText {
@@ -139,10 +58,6 @@ local af = Def.BitmapText {
 			self:y(0)
 		end
 
-		-- Minimum occurrence of tech to be counted.
-		-- Static in sense that it doesn't depend on other chart properties, like its length / stepcount
-		local static_threshold = 2
-
 		local currentSteps = GAMESTATE:GetCurrentSteps(player)
 		if currentSteps == nil then
 			-- SM("currentSteps nil")
@@ -165,48 +80,9 @@ local af = Def.BitmapText {
 			end
 		end
 
-		if stepsToCheck == nil then
-			-- SM("No steps to check")
-			return
-		end
-
-		-- Modern tech parser output
-		local tech = stepsToCheck:GetTechCounts(pn)
-
-		-- Legacy radar values, we only currently need this for the step count. In the future could have jumps / rolls?
-		local radar = stepsToCheck:GetRadarValues(pn)
-
-		local found_techtypes = {}
-
-		-- Total steps in the difficulty
-		local stepcount = radar:GetValue("RadarCategory_Notes")
-
-		local light_threshold = 0.005 * stepcount
-		local normal_threshold = 0.02 * stepcount
-		local heavy_threshold = 0.05 * stepcount
-
-		-- The beef, convert the tech parser results into textual notation
-		for key, t in ipairs(techtypes) do
-			local tech_amount = tech:GetValue(t.tcc)
-			local symbol = ""
-			local t_symbols = t[ThemePrefs.Get("MusicWheelTechNotation")]
-
-			if tech_amount > heavy_threshold then
-				symbol = t_symbols.symbol_heavy
-			elseif tech_amount > normal_threshold then
-				symbol = t_symbols.symbol_medium
-			elseif tech_amount > static_threshold and tech_amount > light_threshold then
-				symbol = t_symbols.symbol_light
-			end
-
-			found_techtypes[#found_techtypes + 1] = symbol
-		end
-
-		local text = ""
-
-		for key, value in ipairs(found_techtypes) do
-			text = text .. value
-		end
+		--- @type string
+		local preferred_tech_style = ThemePrefs.Get("MusicWheelTechNotation")
+		local text = SLTechNotation_Format(stepsToCheck, pn, preferred_tech_style)
 
 		self:settext(text)
 		self:visible(true)

--- a/Graphics/MusicWheelItem Song NormalPart/TechNotation.lua
+++ b/Graphics/MusicWheelItem Song NormalPart/TechNotation.lua
@@ -1,9 +1,5 @@
 -- Song wheel tech analysis
 
-if not ThemePrefs.Get("MusicWheelTechNotation") then
-	return
-end
-
 local player = ...
 local pn = ToEnumShortString(player)
 
@@ -58,7 +54,7 @@ local af = Def.BitmapText {
 		self:visible(false)
 		self:horizalign(left)
 		self:zoom(0.6)
-		self:x(_screen.w / (WideScale(2.15, 2.14)) - self:GetWidth() * self:GetZoom() - 120)
+		self:x(_screen.w / (WideScale(2.15, 2.14)) - self:GetWidth() * self:GetZoom() - 100)
 		if DarkUI() then self:diffuse(0, 0, 0, 1) end
 	end,
 	-- Set is called by MusicWheelItem::HandleMessage. There are a bunch of messages that can trigger it.

--- a/Graphics/MusicWheelItem Song NormalPart/TechNotation.lua
+++ b/Graphics/MusicWheelItem Song NormalPart/TechNotation.lua
@@ -1,0 +1,171 @@
+-- Song wheel tech analysis
+
+if not ThemePrefs.Get("MusicWheelTechNotation") then
+	return
+end
+
+local player = ...
+local pn = ToEnumShortString(player)
+
+-- array style to keep ordering in ipairs
+local techtypes = {
+	{
+		tcc = "TechCountsCategory_Brackets",
+		symbol_light = "b",
+		symbol_medium= "B",
+		symbol_heavy = "B+"
+	},
+	{
+		tcc = "TechCountsCategory_Crossovers",
+		symbol_light = "x",
+		symbol_medium= "X",
+		symbol_heavy = "X+"
+	},
+	{
+		tcc = "TechCountsCategory_Footswitches",
+		symbol_light = "f",
+		symbol_medium= "F",
+		symbol_heavy = "F+"
+	},
+	{
+		tcc = "TechCountsCategory_Sideswitches",
+		symbol_light = "s",
+		symbol_medium= "S",
+		symbol_heavy = "S+"
+	},
+	{
+		tcc = "TechCountsCategory_Jacks",
+		symbol_light = "j",
+		symbol_medium= "J",
+		symbol_heavy = "J+"
+	},
+	{
+		tcc = "TechCountsCategory_Doublesteps",
+		symbol_light = "d",
+		symbol_medium= "D",
+		symbol_heavy = "D+"
+	}
+}
+
+-- TODO: 2 actors, one for each player. Could this be one actor that draws both players?
+local af = Def.BitmapText {
+	Font = "Common Normal",
+	Text = "",
+	InitCommand = function(self)
+		-- TODO: is this a good position? wide screen should have space to make the music wheel wider
+		-- position on right side of the song title, left of ITL EX
+		-- fits the maximum 6 techs
+		self:visible(false)
+		self:horizalign(left)
+		self:zoom(0.6)
+		self:x(_screen.w / (WideScale(2.15, 2.14)) - self:GetWidth() * self:GetZoom() - 120)
+		if DarkUI() then self:diffuse(0, 0, 0, 1) end
+	end,
+	-- Set is called by MusicWheelItem::HandleMessage. There are a bunch of messages that can trigger it.
+	SetCommand = function(self, params)
+		-- default to invisible, if we fail to process something, we just return immediately and stay hidden
+		self:visible(false)
+
+		-- params is null sometimes for some reason?
+		-- this seems to happen when changing songs and the previous diff doesn't exist for the new one
+		-- we eventually do seem to get valid params
+		if not params or not params.Song then
+			-- SM("Null params")
+			return
+		end
+
+		-- song of _this_ actor (every song on the music wheel)
+		local song = params.Song
+		if song == nil then
+			-- SM("Song is nil")
+			return
+		end
+
+		-- steps of _this_ actor
+		local steps = SongUtil.GetPlayableSteps(song)
+
+		-- visual vertical position depending on if 1 / 2 players are playing
+		if GAMESTATE:GetNumSidesJoined() == 2 then
+			if player == PLAYER_1 then
+				self:y(-6)
+			else
+				self:y(6)
+			end
+		else
+			self:y(0)
+		end
+
+		-- Minimum occurrence of tech to be counted.
+		-- Static in sense that it doesn't depend on other chart properties, like its length / stepcount
+		local static_threshold = 2
+
+		local currentSteps = GAMESTATE:GetCurrentSteps(player)
+		if currentSteps == nil then
+			-- SM("currentSteps nil")
+			return
+		end
+
+		local currentDifficulty = currentSteps:GetDifficulty()
+
+		-- Like grades, show tech that matches the currently selected difficulty.
+		local stepsToCheck = nil
+		if #steps == 1 then
+			-- If there's only a single difficulty, don't try to match the difficulty. Just show the only one.
+			stepsToCheck = steps[1]
+		else
+			-- TODO: Match the engine (or theme?) behaviour on which difficulty will be autoselected from this chart
+			for k, v in ipairs(steps) do
+				if v:GetDifficulty() == currentDifficulty then
+					stepsToCheck = v
+				end
+			end
+		end
+
+		if stepsToCheck == nil then
+			-- SM("No steps to check")
+			return
+		end
+
+		-- Modern tech parser output
+		local tech = stepsToCheck:GetTechCounts(pn)
+
+		-- Legacy radar values, we only currently need this for the step count. In the future could have jumps / rolls?
+		local radar = stepsToCheck:GetRadarValues(pn)
+
+		local found_techtypes = {}
+
+		-- Total steps in the difficulty
+		local stepcount = radar:GetValue("RadarCategory_Notes")
+
+		local light_threshold = 0.005 * stepcount
+		local normal_threshold = 0.02 * stepcount
+		local heavy_threshold = 0.05 * stepcount
+
+		-- The beef, convert the tech parser results into textual notation
+		for key, t in ipairs(techtypes) do
+			local tech_amount = tech:GetValue(t.tcc)
+			local symbol = ""
+
+			if tech_amount > heavy_threshold then
+				symbol = t.symbol_heavy
+			elseif tech_amount > normal_threshold then
+				symbol = t.symbol_medium
+			elseif tech_amount > static_threshold and tech_amount > light_threshold then
+				symbol = t.symbol_light
+			end
+
+			found_techtypes[#found_techtypes + 1] = symbol
+		end
+
+		local text = ""
+
+		for key, value in ipairs(found_techtypes) do
+			text = text .. value
+		end
+
+		self:settext(text)
+		self:visible(true)
+	end,
+}
+
+return af

--- a/Graphics/MusicWheelItem Song NormalPart/TechNotation.lua
+++ b/Graphics/MusicWheelItem Song NormalPart/TechNotation.lua
@@ -7,39 +7,81 @@ local pn = ToEnumShortString(player)
 local techtypes = {
 	{
 		tcc = "TechCountsCategory_Brackets",
-		symbol_light = "b",
-		symbol_medium= "B",
-		symbol_heavy = "B+"
+		Condensed = {
+			symbol_light  = "b",
+			symbol_medium = "B",
+			symbol_heavy  = "B+"
+		},
+		Verbose = {
+			symbol_light  = "BR- ",
+			symbol_medium = "BR ",
+			symbol_heavy  = "BR+ "
+		}
 	},
 	{
 		tcc = "TechCountsCategory_Crossovers",
-		symbol_light = "x",
-		symbol_medium= "X",
-		symbol_heavy = "X+"
+		Condensed = {
+			symbol_light  = "x",
+			symbol_medium = "X",
+			symbol_heavy  = "X+"
+		},
+		Verbose = {
+			symbol_light  = "XO- ",
+			symbol_medium = "XO ",
+			symbol_heavy  = "XO+ "
+		}
 	},
 	{
 		tcc = "TechCountsCategory_Footswitches",
-		symbol_light = "f",
-		symbol_medium= "F",
-		symbol_heavy = "F+"
+		Condensed = {
+			symbol_light  = "f",
+			symbol_medium = "F",
+			symbol_heavy  = "F+"
+		},
+		Verbose = {
+			symbol_light  = "FS- ",
+			symbol_medium = "FS ",
+			symbol_heavy  = "FS+ "
+		}
 	},
 	{
 		tcc = "TechCountsCategory_Sideswitches",
-		symbol_light = "s",
-		symbol_medium= "S",
-		symbol_heavy = "S+"
+		Condensed = {
+			symbol_light  = "s",
+			symbol_medium = "S",
+			symbol_heavy  = "S+"
+		},
+		Verbose = {
+			symbol_light  = "SS ",
+			symbol_medium = "SS ",
+			symbol_heavy  = "SS+ "
+		}
 	},
 	{
 		tcc = "TechCountsCategory_Jacks",
-		symbol_light = "j",
-		symbol_medium= "J",
-		symbol_heavy = "J+"
+		Condensed = {
+			symbol_light  = "j",
+			symbol_medium = "J",
+			symbol_heavy  = "J+"
+		},
+		Verbose = {
+			symbol_light  = "JS- ",
+			symbol_medium = "JS ",
+			symbol_heavy  = "JS+ "
+		}
 	},
 	{
 		tcc = "TechCountsCategory_Doublesteps",
-		symbol_light = "d",
-		symbol_medium= "D",
-		symbol_heavy = "D+"
+		Condensed = {
+			symbol_light  = "d",
+			symbol_medium = "D",
+			symbol_heavy  = "D+"
+		},
+		Verbose = {
+			symbol_light  = "DS- ",
+			symbol_medium = "DS ",
+			symbol_heavy  = "DS+ "
+		}
 	}
 }
 
@@ -52,9 +94,8 @@ local af = Def.BitmapText {
 		-- position on right side of the song title, left of ITL EX
 		-- fits the maximum 6 techs
 		self:visible(false)
-		self:horizalign(left)
+		self:horizalign(right)
 		self:zoom(0.6)
-		self:x(_screen.w / (WideScale(2.15, 2.14)) - self:GetWidth() * self:GetZoom() - 100)
 		if DarkUI() then self:diffuse(0, 0, 0, 1) end
 	end,
 	-- Set is called by MusicWheelItem::HandleMessage. There are a bunch of messages that can trigger it.
@@ -76,6 +117,13 @@ local af = Def.BitmapText {
 			-- SM("Song is nil")
 			return
 		end
+
+		-- TODO: is there a better way of laying this out?
+		local x_offset = 10
+		if IsItlSong(song, player) then
+			x_offset = 60
+		end
+		self:x(_screen.w / (WideScale(2.15, 2.14)) - x_offset)
 
 		-- steps of _this_ actor
 		local steps = SongUtil.GetPlayableSteps(song)
@@ -141,13 +189,14 @@ local af = Def.BitmapText {
 		for key, t in ipairs(techtypes) do
 			local tech_amount = tech:GetValue(t.tcc)
 			local symbol = ""
+			local t_symbols = t[ThemePrefs.Get("MusicWheelTechNotation")]
 
 			if tech_amount > heavy_threshold then
-				symbol = t.symbol_heavy
+				symbol = t_symbols.symbol_heavy
 			elseif tech_amount > normal_threshold then
-				symbol = t.symbol_medium
+				symbol = t_symbols.symbol_medium
 			elseif tech_amount > static_threshold and tech_amount > light_threshold then
-				symbol = t.symbol_light
+				symbol = t_symbols.symbol_light
 			end
 
 			found_techtypes[#found_techtypes + 1] = symbol

--- a/Graphics/MusicWheelItem Song NormalPart/default.lua
+++ b/Graphics/MusicWheelItem Song NormalPart/default.lua
@@ -21,7 +21,7 @@ af[#af+1] = Def.Sprite{
 
 -- Player-specific actors
 for player in ivalues(PlayerNumber) do
-	if ThemePrefs.Get("MusicWheelTechNotation") then
+	if ThemePrefs.Get("MusicWheelTechNotation") ~= "No" then
 		af[#af + 1] = LoadActor("TechNotation.lua", player)
 	end
 	if ThemePrefs.Get("MusicWheelEXScore") then

--- a/Graphics/MusicWheelItem Song NormalPart/default.lua
+++ b/Graphics/MusicWheelItem Song NormalPart/default.lua
@@ -4,6 +4,7 @@ local af = LoadActor("../MusicWheelItem Course NormalPart.lua")
 
 local stepstype = GAMESTATE:GetCurrentStyle():GetStepsType()
 
+-- "Has Edit" indicator sprite
 -- using a png in a Sprite ties the visual to a specific rasterized font (currently Miso),
 -- but Sprites are cheaper than BitmapTexts, so we should use them where dynamic text is not needed
 af[#af+1] = Def.Sprite{
@@ -20,6 +21,7 @@ af[#af+1] = Def.Sprite{
 }
 
 for player in ivalues(PlayerNumber) do
+	af[#af+1] = LoadActor("TechNotation.lua", player)
 	af[#af+1] = LoadActor("Favorites.lua", player)
 
 	-- Add ITL EX scores to the song wheel as well.

--- a/Graphics/MusicWheelItem Song NormalPart/default.lua
+++ b/Graphics/MusicWheelItem Song NormalPart/default.lua
@@ -4,7 +4,6 @@ local af = LoadActor("../MusicWheelItem Course NormalPart.lua")
 
 local stepstype = GAMESTATE:GetCurrentStyle():GetStepsType()
 
--- "Has Edit" indicator sprite
 -- using a png in a Sprite ties the visual to a specific rasterized font (currently Miso),
 -- but Sprites are cheaper than BitmapTexts, so we should use them where dynamic text is not needed
 af[#af+1] = Def.Sprite{
@@ -20,62 +19,17 @@ af[#af+1] = Def.Sprite{
 	end
 }
 
+-- Player-specific actors
 for player in ivalues(PlayerNumber) do
-	af[#af+1] = LoadActor("TechNotation.lua", player)
-	af[#af+1] = LoadActor("Favorites.lua", player)
-
-	-- Add ITL EX scores to the song wheel as well.
-	-- It will be centered to the item if only one player is enabled, and stacked otherwise.
-	af[#af+1] = Def.BitmapText{
-		Font="Wendy/_wendy monospace numbers",
-		Text="",
-		InitCommand=function(self)
-			self:visible(false)
-			self:zoom(0.2)
-			self:x( _screen.w/(WideScale(2.15, 2.14)) - self:GetWidth()*self:GetZoom() - 40 )
-			self:diffuse(SL.JudgmentColors["FA+"][1])
-		end,
-		PlayerJoinedMessageCommand=function(self)
-			self:visible(GAMESTATE:IsPlayerEnabled(player))
-		end,
-		PlayerUnjoinedMessageCommand=function(self)
-			self:visible(GAMESTATE:IsPlayerEnabled(player))
-		end,
-		SetCommand=function(self, params)
-			-- Only display EX score if a profile is found for an enabled player.
-			if not GAMESTATE:IsPlayerEnabled(player) or not PROFILEMAN:IsPersistentProfile(player) then
-				self:visible(false)
-				return
-			end
-
-			if GAMESTATE:GetNumSidesJoined() == 2 then
-				if player == PLAYER_1 then
-					self:y(-11)
-				else
-					self:y(4)
-				end
-			else
-				self:y(-4)
-			end
-			local pn = ToEnumShortString(player)
-			if params.Song ~= nil then
-				local song = params.Song
-				local song_dir = song:GetSongDir()
-				if song_dir ~= nil and #song_dir ~= 0 then
-					if SL[pn].ITLData["pathMap"][song_dir] ~= nil then
-						local hash = SL[pn].ITLData["pathMap"][song_dir]
-						if SL[pn].ITLData["hashMap"][hash] ~= nil then
-							local ex = SL[pn].ITLData["hashMap"][hash]["ex"] / 100
-							self:settext(("%.2f"):format(ex))
-							self:visible(true)
-							return
-						end
-					end
-				end
-			end
-			self:visible(false)
-		end,
-	}
+	if ThemePrefs.Get("MusicWheelTechNotation") then
+		af[#af + 1] = LoadActor("TechNotation.lua", player)
+	end
+	if ThemePrefs.Get("MusicWheelEXScore") then
+		af[#af + 1] = LoadActor("EXScore.lua", player)
+	end
+	af[#af + 1] = LoadActor("Favorites.lua", player)
+	-- TODO: Don't display separate ITL EX score if MusicWheelEXScore is enabled?
+	af[#af + 1] = LoadActor("ITL_EXScore.lua", player)
 end
 
 return af

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -555,6 +555,7 @@ Footswitches=Footswitches
 Sideswitches=Sideswitches
 Jacks=Jacks
 Brackets=Brackets
+Doublesteps=Doublesteps
 Total Stream=Total Stream
 
 [TapNoteScore]

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -731,8 +731,8 @@ SampleMusicLoops=Preview Music Loops
 RescoreEarlyHits=Enable Rescoring Early Hits
 UseImageCache=Use ImageCache
 AnimateBanners=Animate Song Banners
-MusicWheelTechNotation=Song Wheel\nTech Notation
-MusicWheelEXScore=Song wheel\nEX Score
+MusicWheelTechNotation=Music Wheel\nTech Notation
+MusicWheelEXScore=Music Wheel\nEX Score
 
 # Tournament Mode Options
 EnableTournamentMode=Enable Tournament Mode
@@ -951,8 +951,8 @@ SampleMusicLoops=Whether or not the preview music should loop during the music s
 RescoreEarlyHits=Allow early hits of Decents ands Way Offs to be rescored to better judgments.\n\nChanging this setting will require a game restart to take effect.
 UseImageCache=Casual Mode will run more smoothly with the ImageCache system on, but StepMania will use a LOT more RAM as a consequence. It is recommended that you have at least 8GB of RAM to use the ImageCache system.\n\nYou will need to restart StepMania after turning this setting on for it to take effect.
 AnimateBanners=Toggle whether to animate song banners in the theme.
-MusicWheelTechNotation=Display automatically calculated tech notation directly in the song wheel.
-MusicWheelEXScore=Replace letter grades and the "lamp" effect color with a colored EX score in the song wheel.
+MusicWheelTechNotation=Display automatically calculated tech notation directly in the music wheel.\n\nExample for Verbose:\nBR+ XO FS-\n\nExample for Condensed:\nB+Xf
+MusicWheelEXScore=Replace letter grades and the "lamp" effect color with a colored EX score in the music wheel.
 
 # Tournament Mode Options
 EnableTournamentMode=Whether or not to enable Tournament Mode.

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -731,6 +731,7 @@ SampleMusicLoops=Preview Music Loops
 RescoreEarlyHits=Enable Rescoring Early Hits
 UseImageCache=Use ImageCache
 AnimateBanners=Animate Song Banners
+MusicWheelTechNotation=Songwheel tech
 
 # Tournament Mode Options
 EnableTournamentMode=Enable Tournament Mode
@@ -949,6 +950,7 @@ SampleMusicLoops=Whether or not the preview music should loop during the music s
 RescoreEarlyHits=Allow early hits of Decents ands Way Offs to be rescored to better judgments.\n\nChanging this setting will require a game restart to take effect.
 UseImageCache=Casual Mode will run more smoothly with the ImageCache system on, but StepMania will use a LOT more RAM as a consequence. It is recommended that you have at least 8GB of RAM to use the ImageCache system.\n\nYou will need to restart StepMania after turning this setting on for it to take effect.
 AnimateBanners=Toggle whether to animate song banners in the theme.
+MusicWheelTechNotation=Display automatically calculated tech notation directly in the song wheel.
 
 # Tournament Mode Options
 EnableTournamentMode=Whether or not to enable Tournament Mode.

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -1267,6 +1267,8 @@ OnWithSound=On with Sound
 Always=Always
 Sometimes=Sometimes
 Never=Never
+Verbose=Verbose
+Condensed=Condensed
 
 ##############################################
 # These months are used by the custom Screenshot system

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -731,7 +731,8 @@ SampleMusicLoops=Preview Music Loops
 RescoreEarlyHits=Enable Rescoring Early Hits
 UseImageCache=Use ImageCache
 AnimateBanners=Animate Song Banners
-MusicWheelTechNotation=Songwheel tech
+MusicWheelTechNotation=Song Wheel\nTech Notation
+MusicWheelEXScore=Song wheel\nEX Score
 
 # Tournament Mode Options
 EnableTournamentMode=Enable Tournament Mode
@@ -951,6 +952,7 @@ RescoreEarlyHits=Allow early hits of Decents ands Way Offs to be rescored to bet
 UseImageCache=Casual Mode will run more smoothly with the ImageCache system on, but StepMania will use a LOT more RAM as a consequence. It is recommended that you have at least 8GB of RAM to use the ImageCache system.\n\nYou will need to restart StepMania after turning this setting on for it to take effect.
 AnimateBanners=Toggle whether to animate song banners in the theme.
 MusicWheelTechNotation=Display automatically calculated tech notation directly in the song wheel.
+MusicWheelEXScore=Replace letter grades and the "lamp" effect color with a colored EX score in the song wheel.
 
 # Tournament Mode Options
 EnableTournamentMode=Whether or not to enable Tournament Mode.

--- a/Scripts/99 SL-ThemePrefs.lua
+++ b/Scripts/99 SL-ThemePrefs.lua
@@ -326,6 +326,12 @@ SL_CustomPrefs.Get = function()
 				THEME:GetString("ThemePrefs", "Never"),
 			},
 			Values = { "Always", "Sometimes", "Never" }
+		},
+
+		MusicWheelTechNotation = {
+			Default = false,
+			Choices =  { THEME:GetString("ThemePrefs","Yes"), THEME:GetString("ThemePrefs", "No") },
+			Values = { true, false }
 		}
 	}
 end

--- a/Scripts/99 SL-ThemePrefs.lua
+++ b/Scripts/99 SL-ThemePrefs.lua
@@ -329,9 +329,13 @@ SL_CustomPrefs.Get = function()
 		},
 
 		MusicWheelTechNotation = {
-			Default = false,
-			Choices =  { THEME:GetString("ThemePrefs","Yes"), THEME:GetString("ThemePrefs", "No") },
-			Values = { true, false }
+			Default = "No",
+			Choices = {
+				THEME:GetString("ThemePrefs", "Verbose"),
+				THEME:GetString("ThemePrefs", "Condensed"),
+				THEME:GetString("ThemePrefs", "No")
+			},
+			Values = { "Verbose", "Condensed", "No" }
 		},
 
 		MusicWheelEXScore = {

--- a/Scripts/99 SL-ThemePrefs.lua
+++ b/Scripts/99 SL-ThemePrefs.lua
@@ -332,6 +332,12 @@ SL_CustomPrefs.Get = function()
 			Default = false,
 			Choices =  { THEME:GetString("ThemePrefs","Yes"), THEME:GetString("ThemePrefs", "No") },
 			Values = { true, false }
+		},
+
+		MusicWheelEXScore = {
+			Default = false,
+			Choices =  { THEME:GetString("ThemePrefs","Yes"), THEME:GetString("ThemePrefs", "No") },
+			Values = { true, false }
 		}
 	}
 end

--- a/Scripts/SL-ChartParser.lua
+++ b/Scripts/SL-ChartParser.lua
@@ -428,6 +428,8 @@ local MaybeCopyFromOppositePlayer = function(pn, filename, stepsType, difficulty
 		SL[pn].Streams.Sideswitches = SL[opposite_player].Streams.Sideswitches
 		SL[pn].Streams.Jacks = SL[opposite_player].Streams.Jacks
 		SL[pn].Streams.Brackets = SL[opposite_player].Streams.Brackets
+		SL[pn].Streams.Doublesteps = SL[opposite_player].Streams.Doublesteps
+		SL[pn].Streams.TechNotation = SL[opposite_player].Streams.TechNotation
 
 		SL[pn].Streams.Filename = SL[opposite_player].Streams.Filename
 		SL[pn].Streams.StepsType = SL[opposite_player].Streams.StepsType
@@ -504,6 +506,9 @@ ParseChartInfo = function(steps, pn)
 				SL[pn].Streams.Sideswitches = techCounts:GetValue("TechCountsCategory_Sideswitches")
 				SL[pn].Streams.Jacks = techCounts:GetValue("TechCountsCategory_Jacks")
 				SL[pn].Streams.Brackets = techCounts:GetValue("TechCountsCategory_Brackets")
+				SL[pn].Streams.Doublesteps = techCounts:GetValue("TechCountsCategory_Doublesteps")
+
+				SL[pn].Streams.TechNotation = SLTechNotation_Format(steps, pn, TechNotationVerboseKey)
 
 				SL[pn].Streams.Filename = filename
 				SL[pn].Streams.StepsType = stepsType
@@ -527,6 +532,7 @@ ParseChartInfo = function(steps, pn)
 			SL[pn].Streams.Sideswitches = 0
 			SL[pn].Streams.Jacks = 0
 			SL[pn].Streams.Brackets = 0
+			SL[pn].Streams.Doublesteps = 0
 
 			SL[pn].Streams.Filename = filename
 			SL[pn].Streams.StepsType = stepsType

--- a/Scripts/SL-Helpers.lua
+++ b/Scripts/SL-Helpers.lua
@@ -724,6 +724,40 @@ GetExJudgmentCounts = function(player)
 	return counts
 end
 
+-- Pure version of CalculateExScore that does not rely on any global state
+CalculateExScoreNoGlobalState = function(StepsOrTrail, player, po_NoMines, ex_counts, use_actual_w0_weight)
+	local totalSteps = StepsOrTrail:GetRadarValues(player):GetValue( "RadarCategory_TapsAndHolds" )
+	local totalHolds = StepsOrTrail:GetRadarValues(player):GetValue( "RadarCategory_Holds" )
+	local totalRolls = StepsOrTrail:GetRadarValues(player):GetValue( "RadarCategory_Rolls" )
+
+	local W0Weight = use_actual_w0_weight and 3.5 or SL.ExWeights["W0"]
+	local total_possible = totalSteps * W0Weight + (totalHolds + totalRolls) * SL.ExWeights["Held"]
+
+	local total_points = 0
+
+	-- If mines are disabled, they should still be accounted for in EX Scoring based on the weight assigned to it.
+	-- Stamina community does often play with no-mines on, but because EX scoring is more timing centric where mines
+	-- generally have a negative weight, it's a better experience to make sure the EX score reflects that.
+	if po_NoMines then
+		local totalMines = StepsOrTrail:GetRadarValues(player):GetValue( "RadarCategory_Mines" )
+		total_points = total_points + totalMines * SL.ExWeights["HitMine"];
+	end
+
+	local counts = ex_counts
+	-- Just for validation, but shouldn't happen in normal gameplay.
+	if counts == nil then return 0 end
+
+	local keys = { "W0", "W1", "W2", "W3", "W4", "W5", "Miss", "Held", "LetGo", "HitMine" }
+	for key in ivalues(keys) do
+		local value = counts[key]
+		if value ~= nil then
+			total_points = total_points + value * SL.ExWeights[key]
+		end
+	end
+
+	return math.max(0, math.floor(total_points/total_possible * 10000) / 100), total_points, total_possible
+end
+
 -- -----------------------------------------------------------------------
 -- Calculate the EX score given for a given player.
 --
@@ -749,39 +783,12 @@ CalculateExScore = function(player, ex_counts, use_actual_w0_weight)
 	-- No EX scores in Casual mode, just return some dummy number early.
 	if SL.Global.GameMode == "Casual" then return 0 end
 	local StepsOrTrail = (GAMESTATE:IsCourseMode() and GAMESTATE:GetCurrentTrail(player)) or GAMESTATE:GetCurrentSteps(player)
-
-	local totalSteps = StepsOrTrail:GetRadarValues(player):GetValue( "RadarCategory_TapsAndHolds" )
-	local totalHolds = StepsOrTrail:GetRadarValues(player):GetValue( "RadarCategory_Holds" )
-	local totalRolls = StepsOrTrail:GetRadarValues(player):GetValue( "RadarCategory_Rolls" )
-
-	local W0Weight = use_actual_w0_weight and 3.5 or SL.ExWeights["W0"]
-	local total_possible = totalSteps * W0Weight + (totalHolds + totalRolls) * SL.ExWeights["Held"]
-
-	local total_points = 0
-
 	local po = GAMESTATE:GetPlayerState(player):GetPlayerOptions("ModsLevel_Preferred")
-
-	-- If mines are disabled, they should still be accounted for in EX Scoring based on the weight assigned to it.
-	-- Stamina community does often play with no-mines on, but because EX scoring is more timing centric where mines
-	-- generally have a negative weight, it's a better experience to make sure the EX score reflects that.
-	if po:NoMines() then
-		local totalMines = StepsOrTrail:GetRadarValues(player):GetValue( "RadarCategory_Mines" )
-		total_points = total_points + totalMines * SL.ExWeights["HitMine"];
-	end
-
-	local keys = { "W0", "W1", "W2", "W3", "W4", "W5", "Miss", "Held", "LetGo", "HitMine" }
 	local counts = ex_counts or SL[ToEnumShortString(player)].Stages.Stats[SL.Global.Stages.PlayedThisGame + 1].ex_counts
 	-- Just for validation, but shouldn't happen in normal gameplay.
 	if counts == nil then return 0 end
 
-	for key in ivalues(keys) do
-		local value = counts[key]
-		if value ~= nil then
-			total_points = total_points + value * SL.ExWeights[key]
-		end
-	end
-
-	return math.max(0, math.floor(total_points/total_possible * 10000) / 100), total_points, total_possible
+	return CalculateExScoreNoGlobalState(StepsOrTrail, player, po:NoMines(), counts, use_actual_w0_weight)
 end
 
 -- -----------------------------------------------------------------------
@@ -952,7 +959,7 @@ GetPlayerOptionsString = function(player, modsLevel)
 	for i,option in ipairs(PlayerOptions) do
 
 		-- these don't need to show up in the mods list
-		if option ~= "FailAtEnd" and option ~= "FailImmediateContinue" and option ~= "FailImmediate" and 
+		if option ~= "FailAtEnd" and option ~= "FailImmediateContinue" and option ~= "FailImmediate" and
 			not string.find(option, "Lights") then
 			-- 100% Mini will be in the PlayerOptions as just "Mini" so use the value from the SL table instead
 			if option:match("Mini") then

--- a/Scripts/SL-TechNotation.lua
+++ b/Scripts/SL-TechNotation.lua
@@ -63,9 +63,9 @@ local tech_categories = {
 			symbol_heavy  = "J+"
 		},
 		[TechNotationVerboseKey] = {
-			symbol_light  = "JS- ",
-			symbol_medium = "JS ",
-			symbol_heavy  = "JS+ "
+			symbol_light  = "JA- ",
+			symbol_medium = "JA ",
+			symbol_heavy  = "JA+ "
 		}
 	},
 	{

--- a/Scripts/SL-TechNotation.lua
+++ b/Scripts/SL-TechNotation.lua
@@ -1,0 +1,152 @@
+TechNotationVerboseKey = "Verbose"
+TechNotationCondensedKey = "Condensed"
+
+-- array style to keep ordering in ipairs
+local tech_categories = {
+	{
+		tcc = "TechCountsCategory_Brackets",
+		[TechNotationCondensedKey] = {
+			symbol_light  = "b",
+			symbol_medium = "B",
+			symbol_heavy  = "B+"
+		},
+		[TechNotationVerboseKey] = {
+			symbol_light  = "BR- ",
+			symbol_medium = "BR ",
+			symbol_heavy  = "BR+ "
+		}
+	},
+	{
+		tcc = "TechCountsCategory_Crossovers",
+		[TechNotationCondensedKey] = {
+			symbol_light  = "x",
+			symbol_medium = "X",
+			symbol_heavy  = "X+"
+		},
+		[TechNotationVerboseKey] = {
+			symbol_light  = "XO- ",
+			symbol_medium = "XO ",
+			symbol_heavy  = "XO+ "
+		}
+	},
+	{
+		tcc = "TechCountsCategory_Footswitches",
+		[TechNotationCondensedKey] = {
+			symbol_light  = "f",
+			symbol_medium = "F",
+			symbol_heavy  = "F+"
+		},
+		[TechNotationVerboseKey] = {
+			symbol_light  = "FS- ",
+			symbol_medium = "FS ",
+			symbol_heavy  = "FS+ "
+		}
+	},
+	{
+		tcc = "TechCountsCategory_Sideswitches",
+		[TechNotationCondensedKey] = {
+			symbol_light  = "s",
+			symbol_medium = "S",
+			symbol_heavy  = "S+"
+		},
+		[TechNotationVerboseKey] = {
+			symbol_light  = "SS ",
+			symbol_medium = "SS ",
+			symbol_heavy  = "SS+ "
+		}
+	},
+	{
+		tcc = "TechCountsCategory_Jacks",
+		[TechNotationCondensedKey] = {
+			symbol_light  = "j",
+			symbol_medium = "J",
+			symbol_heavy  = "J+"
+		},
+		[TechNotationVerboseKey] = {
+			symbol_light  = "JS- ",
+			symbol_medium = "JS ",
+			symbol_heavy  = "JS+ "
+		}
+	},
+	{
+		tcc = "TechCountsCategory_Doublesteps",
+		[TechNotationCondensedKey] = {
+			symbol_light  = "d",
+			symbol_medium = "D",
+			symbol_heavy  = "D+"
+		},
+		[TechNotationVerboseKey] = {
+			symbol_light  = "DS- ",
+			symbol_medium = "DS ",
+			symbol_heavy  = "DS+ "
+		}
+	}
+}
+
+--- Use tech counts provided by the game engine to generate a string describing techiques used in the steps.
+--- Example output: "BR+ XO+ FS DS-"
+--- @param steps table? to generate notation for.
+--- @param pn string by `ToEnumShortString(player)`, steps could have different values for different player.
+--- @param style string -- either `TechNotationCondensedKey` or `TechNotationVerboseKey`
+--- @return string techString A string describing the tech used.
+SLTechNotation_Format = function(steps, pn, style)
+    if steps == nil then
+        -- SM("No steps to check")
+        return ""
+    end
+
+    style = style or TechNotationVerboseKey
+
+    -- Modern tech parser output
+    local tech = steps:GetTechCounts(pn)
+
+    -- Legacy radar values, we only currently need this for the step count. In the future could have jumps / rolls?
+    local radar = steps:GetRadarValues(pn)
+
+    -- Total steps in the difficulty
+    local stepcount = radar:GetValue("RadarCategory_Notes")
+
+    -- Minimum occurrence of tech to be counted.
+    -- Static in sense that it doesn't depend on other chart properties, like its length / stepcount
+    local static_threshold = 2
+
+    local light_threshold = 0.005 * stepcount
+    local normal_threshold = 0.02 * stepcount
+    local heavy_threshold = 0.05 * stepcount
+
+    -- The beef, convert the tech parser results into text
+    local found_tech_categories = {}
+    for key, t in ipairs(tech_categories) do
+        local tech_amount = tech:GetValue(t.tcc)
+        local symbol = ""
+        local tech_symbols = t[style]
+
+        if tech_amount > heavy_threshold then
+            symbol = tech_symbols.symbol_heavy
+        elseif tech_amount > normal_threshold then
+            symbol = tech_symbols.symbol_medium
+        elseif tech_amount > static_threshold and tech_amount > light_threshold then
+            symbol = tech_symbols.symbol_light
+        end
+
+        -- store both the tech amount and the symbol to be able to sort the table once we've gone through all the tech categories
+        found_tech_categories[#found_tech_categories + 1] = {
+            symbol = symbol,
+            tech_amount = tech_amount
+        }
+    end
+
+    -- sort by in descending order, heaviest tech should be listed first
+    -- > function that receives two list elements and returns true when the first element must come before the second in the final order
+    table.sort(found_tech_categories, function (a, b)
+        return a.tech_amount > b.tech_amount
+    end)
+
+    local text = ""
+
+    for key, value in ipairs(found_tech_categories) do
+        text = text .. value.symbol
+    end
+
+    return text
+end

--- a/Scripts/SL_ITL.lua
+++ b/Scripts/SL_ITL.lua
@@ -1,12 +1,10 @@
 -- -----------------------------------------------------------------------
-IsItlSong = function(player)
-	local song = GAMESTATE:GetCurrentSong()
+IsItlSong = function(song, player)
 	local song_dir = song:GetSongDir()
 	local group = string.lower(song:GetGroupName())
 	local pn = ToEnumShortString(player)
 	return string.find(group, "itl online 2025") or string.find(group, "itl 2025") or SL[pn].ITLData["pathMap"][song_dir] ~= nil
 end
-
 
 IsItlActive = function()
 	-- The file is only written to while the event is active.
@@ -68,7 +66,7 @@ WriteItlFile = function(player)
 		[PLAYER_1] = "ProfileSlot_Player1",
 		[PLAYER_2] = "ProfileSlot_Player2"
 	}
-	
+
 	local dir = PROFILEMAN:GetProfileDir(profile_slot[player])
 	-- We require an explicit profile to be loaded.
 	if not dir or #dir == 0 then return end
@@ -90,14 +88,14 @@ ReadItlFile = function(player)
 		[PLAYER_1] = "ProfileSlot_Player1",
 		[PLAYER_2] = "ProfileSlot_Player2"
 	}
-	
+
 	local dir = PROFILEMAN:GetProfileDir(profile_slot[player])
 	local pn = ToEnumShortString(player)
 	-- We require an explicit profile to be loaded.
 	if not dir or #dir == 0 then return end
 
 	local path = dir .. itlFilePath
-	local itlData = { 
+	local itlData = {
 		["pathMap"] = {},
 		["hashMap"] = {},
 	}
@@ -235,7 +233,7 @@ local DataForSong = function(player, prevData)
 			noCmod = prevData["noCmod"]
 		end
 	end
-	
+
 	local year = Year()
 	local month = MonthOfYear()+1
 	local day = DayOfMonth()
@@ -246,7 +244,7 @@ local DataForSong = function(player, prevData)
 	local points = GetITLPointsForSong(passingPoints, maxScoringPoints, ex)
 	local usedCmod = GAMESTATE:GetPlayerState(pn):GetPlayerOptions("ModsLevel_Preferred"):CMod() ~= nil
 	local date = ("%04d-%02d-%02d"):format(year, month, day)
-	
+
 	return {
 		["judgments"] = judgments,
 		["ex"] = ex * 100,
@@ -267,7 +265,7 @@ end
 UpdateItlData = function(player)
 	local pn = ToEnumShortString(player)
 	local stats = STATSMAN:GetCurStageStats():GetPlayerStageStats(player)
-		
+
 	-- Do the same validation as GrooveStats.
 	-- This checks important things like timing windows, addition/removal of arrows, etc.
 	local _, valid = ValidForGrooveStats(player)
@@ -314,7 +312,7 @@ UpdateItlData = function(player)
 			local pathMap = SL[pn].ITLData["pathMap"]
 			pathMap[song_dir] = hash
 		end
-		
+
 		-- Then maybe update the hashMap.
 		local updated = false
 		if hashMap[hash] == nil then
@@ -336,7 +334,7 @@ UpdateItlData = function(player)
 			if data["ex"] >= hashMap[hash]["ex"] then
 				hashMap[hash]["ex"] = data["ex"]
 				-- hashMap[hash]["points"] = data["points"]
-				
+
 				if data["ex"] > hashMap[hash]["ex"] then
 					-- EX count is strictly better, copy the judgments over.
 					hashMap[hash]["judgments"] = DeepCopy(data["judgments"])
@@ -362,7 +360,7 @@ UpdateItlData = function(player)
 						updated = true
 					end
 				end
-			end	
+			end
 
 			if data["clearType"] > hashMap[hash]["clearType"] then
 				hashMap[hash]["clearType"] = data["clearType"]

--- a/metrics.ini
+++ b/metrics.ini
@@ -1164,7 +1164,7 @@ LineNames=(function() \
 	if ThemePrefs.Get("VisualStyle") ~= "SRPG8" then lines = lines .. ",RainbowMode" end \
 	lines = lines.. ",,MusicWheelSpeed,,MusicWheelStyle,AutoStyle,DefaultGameMode,AllowFailingOutOfSet,NumberOfContinuesAllowed,CasualMaxMeter,SelectProfile,SelectColor,SelectPlayMode,SelectPlayMode2,EvalSummary,NameEntry,GameOver,HideStockNoteSksins,DanceSolo,Nice,WriteCustomScores,KeyboardFeatures,SampleMusicLoops,RescoreEarlyHits,AnimateBanners" \
 	if Sprite.LoadFromCached ~= nil then lines = lines .. ",UseImageCache" end \
-	lines = lines .. ",MusicWheelTechNotation" \
+	lines = lines .. ",MusicWheelTechNotation,MusicWheelEXScore" \
 	return lines \
 end)()
 LineCasualMaxMeter="lua,ThemePrefsRows.GetRow('CasualMaxMeter')"
@@ -1200,6 +1200,7 @@ LineSampleMusicLoops="lua,ThemePrefsRows.GetRow('SampleMusicLoops')"
 LineRescoreEarlyHits="lua,ThemePrefsRows.GetRow('RescoreEarlyHits')"
 LineAnimateBanners="lua,ThemePrefsRows.GetRow('AnimateBanners')"
 LineMusicWheelTechNotation="lua,ThemePrefsRows.GetRow('MusicWheelTechNotation')"
+LineMusicWheelEXScore="lua,ThemePrefsRows.GetRow('MusicWheelEXScore')"
 
 
 [ScreenMenuTimerOptions]

--- a/metrics.ini
+++ b/metrics.ini
@@ -1025,7 +1025,7 @@ AllTimeY=SCREEN_HEIGHT
 AllTimeOnCommand=zoom,0.5;diffuseshift;effectcolor1,0.5,0.5,0.5,1
 TitleX=SCREEN_CENTER_X
 TitleY=58
-TitleOnCommand=zoom,0.7 
+TitleOnCommand=zoom,0.7
 DataX=
 DataY=SCREEN_CENTER_Y+25
 
@@ -1164,6 +1164,7 @@ LineNames=(function() \
 	if ThemePrefs.Get("VisualStyle") ~= "SRPG8" then lines = lines .. ",RainbowMode" end \
 	lines = lines.. ",,MusicWheelSpeed,,MusicWheelStyle,AutoStyle,DefaultGameMode,AllowFailingOutOfSet,NumberOfContinuesAllowed,CasualMaxMeter,SelectProfile,SelectColor,SelectPlayMode,SelectPlayMode2,EvalSummary,NameEntry,GameOver,HideStockNoteSksins,DanceSolo,Nice,WriteCustomScores,KeyboardFeatures,SampleMusicLoops,RescoreEarlyHits,AnimateBanners" \
 	if Sprite.LoadFromCached ~= nil then lines = lines .. ",UseImageCache" end \
+	lines = lines .. ",MusicWheelTechNotation" \
 	return lines \
 end)()
 LineCasualMaxMeter="lua,ThemePrefsRows.GetRow('CasualMaxMeter')"
@@ -1198,6 +1199,7 @@ LineKeyboardFeatures="lua,ThemePrefsRows.GetRow('KeyboardFeatures')"
 LineSampleMusicLoops="lua,ThemePrefsRows.GetRow('SampleMusicLoops')"
 LineRescoreEarlyHits="lua,ThemePrefsRows.GetRow('RescoreEarlyHits')"
 LineAnimateBanners="lua,ThemePrefsRows.GetRow('AnimateBanners')"
+LineMusicWheelTechNotation="lua,ThemePrefsRows.GetRow('MusicWheelTechNotation')"
 
 
 [ScreenMenuTimerOptions]


### PR DESCRIPTION
![Screenshot 2025-03-28 at 19 57 16](https://github.com/user-attachments/assets/40d1b5d0-a080-4e2f-8db9-01a981c1c2a8)

This PR proposes addition of 2 new options to the Music Wheel that aid in visual parsing of charts:

### 1. Tech notation

Uses the new tech parser information calculated & cached by the game engine to automatically format a string representation of the tech included in the song. Currently displayed techs are brackets, crossovers, footswitches, sideswitches, jacks and doublesteps. The notation is right-aligned and offset a bit to the left in ITL packs to display the stored ITL EX score. There are three options: "Condensed" (B+Xf), "Verbose" (BR+ XO FS-) and "Off".

Things to consider:
- The thresholds for different intensities could be tuned a bit more, or use some separate approach. This could be a good start though.
- The notation currently overlaps with the "Has edit" indicator. Should this be offset a bit to the left to give space to it, or perhaps only offset if the "Has edit" indicator is displayed?

### 2. EX scores

Display the best EX score stored locally for all songs, not only ITL scores. It replaces the letter grade and lamp color effect, as the EX score is colored similarly to the lamp effect. It adds a few extra colors, "normal" passes are white and fails are red. This has the options "Yes" or "No".

Things to consider:
- This option does not currently affect the display of ITL EX scores, although it could be considered whether they bring additional information alongside this option.
- I extracted the core logic of EX calculation to another function to be able to pass the timing counts to it directly instead of duplicating the logic. Need to check carefully that nothing changes by accident.
- Moved the ITL EX score display to a separate file to keep the default file a bit cleaner.