### PR TITLE
Clean up the code from FA+ GameMode

### DIFF
--- a/BGAnimations/ScreenEvaluation common/Panes/Pane1/JudgmentLabels.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane1/JudgmentLabels.lua
@@ -85,31 +85,17 @@ end
 
 -- labels: hands/ex, holds, mines, rolls
 for index, label in ipairs(RadarCategories) do
-	-- Replace hands with the EX score only in FA+ mode.
-	-- We have a separate FA+ pane for ITG mode.
-	if index == 1 and SL.Global.GameMode == "FA+" then
-		t[#t+1] = LoadFont("Wendy/_wendy small")..{
-			Text="EX",
-			InitCommand=function(self) self:zoom(0.5):horizalign(right) end,
-			BeginCommand=function(self)
-				self:x( (controller == PLAYER_1 and -160) or 90 )
-				self:y(38)
-				self:diffuse( SL.JudgmentColors[SL.Global.GameMode][1] )
-			end
-		}
-	else
-		local performance = stats:GetRadarActual():GetValue( "RadarCategory_"..firstToUpper(EnglishRadarCategories[label]) )
-		local possible = stats:GetRadarPossible():GetValue( "RadarCategory_"..firstToUpper(EnglishRadarCategories[label]) )
+    local performance = stats:GetRadarActual():GetValue( "RadarCategory_"..firstToUpper(EnglishRadarCategories[label]) )
+    local possible = stats:GetRadarPossible():GetValue( "RadarCategory_"..firstToUpper(EnglishRadarCategories[label]) )
 
-		t[#t+1] = LoadFont("Common Normal")..{
-			Text=label,
-			InitCommand=function(self) self:zoom(0.833):horizalign(right) end,
-			BeginCommand=function(self)
-				self:x( (controller == PLAYER_1 and -160) or 90 )
-				self:y((index-1)*28 + 41)
-			end
-		}
-	end
+    t[#t+1] = LoadFont("Common Normal")..{
+        Text=label,
+        InitCommand=function(self) self:zoom(0.833):horizalign(right) end,
+        BeginCommand=function(self)
+            self:x( (controller == PLAYER_1 and -160) or 90 )
+            self:y((index-1)*28 + 41)
+        end
+    }
 end
 
 return t

--- a/BGAnimations/ScreenEvaluation common/Panes/Pane1/JudgmentNumbers.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane1/JudgmentNumbers.lua
@@ -63,48 +63,33 @@ end
 
 -- then handle hands/ex, holds, mines, rolls
 for index, RCType in ipairs(RadarCategories.Types) do
-	-- Replace hands with the EX score only in FA+ mode.
-	-- We have a separate FA+ pane for ITG mode.
-	if index == 1 and SL.Global.GameMode == "FA+" then
-		t[#t+1] = LoadFont("Wendy/_wendy white")..{
-			Name="Percent",
-			Text=("%.2f"):format(CalculateExScore(player)),
-			InitCommand=function(self)
-				self:horizalign(right):zoom(0.4)
-				self:x( ((controller == PLAYER_1) and -114) or 286 )
-				self:y(47)
-				self:diffuse( SL.JudgmentColors[SL.Global.GameMode][1] )
-			end
-		}
-	else
-		local performance = pss:GetRadarActual():GetValue( "RadarCategory_"..RCType )
-		local possible = pss:GetRadarPossible():GetValue( "RadarCategory_"..RCType )
-		possible = clamp(possible, 0, 999)
+    local performance = pss:GetRadarActual():GetValue( "RadarCategory_"..RCType )
+    local possible = pss:GetRadarPossible():GetValue( "RadarCategory_"..RCType )
+    possible = clamp(possible, 0, 999)
 
-		-- player performance value
-		-- use a RollingNumber to animate the count tallying up for visual effect
-		t[#t+1] = Def.RollingNumbers{
-			Font="Wendy/_ScreenEvaluation numbers",
-			InitCommand=function(self) self:zoom(0.5):horizalign(right):Load("RollingNumbersEvaluationB") end,
-			BeginCommand=function(self)
-				self:x( RadarCategories.x[ToEnumShortString(controller)] )
-				self:y((index-1)*35 + 53)
-				self:targetnumber(performance)
-			end
-		}
+    -- player performance value
+    -- use a RollingNumber to animate the count tallying up for visual effect
+    t[#t+1] = Def.RollingNumbers{
+        Font="Wendy/_ScreenEvaluation numbers",
+        InitCommand=function(self) self:zoom(0.5):horizalign(right):Load("RollingNumbersEvaluationB") end,
+        BeginCommand=function(self)
+            self:x( RadarCategories.x[ToEnumShortString(controller)] )
+            self:y((index-1)*35 + 53)
+            self:targetnumber(performance)
+        end
+    }
 
-		-- slash and possible value
-		t[#t+1] = LoadFont("Wendy/_ScreenEvaluation numbers")..{
-			InitCommand=function(self) self:zoom(0.5):horizalign(right) end,
-			BeginCommand=function(self)
-				self:x( ((controller == PLAYER_1) and -114) or 286 )
-				self:y((index-1)*35 + 53)
-				self:settext(("/%03d"):format(possible))
-				local leadingZeroAttr = { Length=4-tonumber(tostring(possible):len()), Diffuse=color("#5A6166") }
-				self:AddAttribute(0, leadingZeroAttr )
-			end
-		}
-	end
+    -- slash and possible value
+    t[#t+1] = LoadFont("Wendy/_ScreenEvaluation numbers")..{
+        InitCommand=function(self) self:zoom(0.5):horizalign(right) end,
+        BeginCommand=function(self)
+            self:x( ((controller == PLAYER_1) and -114) or 286 )
+            self:y((index-1)*35 + 53)
+            self:settext(("/%03d"):format(possible))
+            local leadingZeroAttr = { Length=4-tonumber(tostring(possible):len()), Diffuse=color("#5A6166") }
+            self:AddAttribute(0, leadingZeroAttr )
+        end
+    }
 end
 
 return t

--- a/BGAnimations/ScreenEvaluation common/Panes/Pane1/Percentage.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane1/Percentage.lua
@@ -15,12 +15,10 @@ return Def.ActorFrame{
 	-- dark background quad behind player percent score
 	Def.Quad{
 		InitCommand=function(self)
-			self:diffuse(color("#101519")):zoomto(158.5, SL.Global.GameMode == "FA+" and 88 or 60)
+			self:diffuse(color("#101519")):zoomto(158.5, 60)
 			self:horizalign(controller==PLAYER_1 and left or right)
 			self:x(150 * (controller == PLAYER_1 and -1 or 1))
-			if SL.Global.GameMode == "FA+" then
-				self:y(14)
-			end
+
 			if ThemePrefs.Get("VisualStyle") == "Technique" then
 				self:diffusealpha(0.5)
 			end

--- a/BGAnimations/ScreenEvaluation common/Panes/Pane2/JudgmentLabels.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane2/JudgmentLabels.lua
@@ -13,22 +13,22 @@ local TapNoteScores = {}
 local TapNoteScores = {
 	Types = { 'W0', 'W1', 'W2', 'W3', 'W4', 'W5', 'Miss' },
 	Names = {
-		THEME:GetString("TapNoteScoreFA+", "W1"),
-		THEME:GetString("TapNoteScoreFA+", "W2"),
-		THEME:GetString("TapNoteScoreFA+", "W3"),
-		THEME:GetString("TapNoteScoreFA+", "W4"),
-		THEME:GetString("TapNoteScoreFA+", "W5"),
-		THEME:GetString("TapNoteScore", "W5"), -- FA+ mode doesn't have a Way Off window. Extract name from the ITG mode.
-		THEME:GetString("TapNoteScoreFA+", "Miss"),
+		THEME:GetString("TapNoteScore", "W1"),
+		THEME:GetString("TapNoteScoreFA+", "W2"), -- Extract the Fantastic White window
+        THEME:GetString("TapNoteScore", "W2"),
+		THEME:GetString("TapNoteScore", "W3"),
+		THEME:GetString("TapNoteScore", "W4"),
+		THEME:GetString("TapNoteScore", "W5"),
+		THEME:GetString("TapNoteScore", "Miss"),
 	},
 	Colors = {
-		SL.JudgmentColors["FA+"][1],
-		SL.JudgmentColors["FA+"][2],
-		SL.JudgmentColors["FA+"][3],
-		SL.JudgmentColors["FA+"][4],
-		SL.JudgmentColors["FA+"][5],
-		SL.JudgmentColors["ITG"][5], -- FA+ mode doesn't have a Way Off window. Extract color from the ITG mode.
-		SL.JudgmentColors["FA+"][6],
+		SL.JudgmentColors["ITG"][1], -- Fantastic Blue
+		SL.JudgmentColors["FA+"][2], -- Just extract the Fantastic white color
+        SL.JudgmentColors["ITG"][2], -- Yellow Excellent
+		SL.JudgmentColors["ITG"][3], -- Green Great
+		SL.JudgmentColors["ITG"][4], -- Purple Decent
+		SL.JudgmentColors["ITG"][5], -- Way Off
+		SL.JudgmentColors["ITG"][6], -- Red Miss
 	},
 	-- x values for P1 and P2
 	x = { P1=64, P2=94 }

--- a/BGAnimations/ScreenEvaluation common/Panes/Pane2/JudgmentNumbers.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane2/JudgmentNumbers.lua
@@ -6,13 +6,13 @@ local pss = STATSMAN:GetCurStageStats():GetPlayerStageStats(player)
 local TapNoteScores = {
 	Types = { 'W0', 'W1', 'W2', 'W3', 'W4', 'W5', 'Miss' },
 	Colors = {
-		SL.JudgmentColors["FA+"][1],
-		SL.JudgmentColors["FA+"][2],
-		SL.JudgmentColors["FA+"][3],
-		SL.JudgmentColors["FA+"][4],
-		SL.JudgmentColors["FA+"][5],
-		SL.JudgmentColors["ITG"][5], -- FA+ mode doesn't have a Way Off window. Extract color from the ITG mode.
-		SL.JudgmentColors["FA+"][6],
+		SL.JudgmentColors["ITG"][1], -- Fantastic Blue
+		SL.JudgmentColors["FA+"][2], -- Just extract the Fantastic white color
+        SL.JudgmentColors["ITG"][2], -- Yellow Excellent
+		SL.JudgmentColors["ITG"][3], -- Green Great
+		SL.JudgmentColors["ITG"][4], -- Purple Decent
+		SL.JudgmentColors["ITG"][5], -- Way Off
+		SL.JudgmentColors["ITG"][6], -- Red Miss
 	},
 	-- x values for P1 and P2
 	x = { P1=64, P2=94 }

--- a/BGAnimations/ScreenEvaluation common/Panes/Pane2/default.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane2/default.lua
@@ -5,7 +5,6 @@ local player = unpack(...)
 local pn = ToEnumShortString(player)
 
 -- We only want to use this in ITG mode.
--- In FA+ mode the data in this pane is handled by Pane 1
 -- We don't want this version in casual mode at all.
 if SL.Global.GameMode ~= "ITG" or not SL[pn].ActiveModifiers.ShowFaPlusPane then
 	return

--- a/BGAnimations/ScreenEvaluation common/Panes/Pane3/JudgmentLabels.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane3/JudgmentLabels.lua
@@ -7,23 +7,23 @@ local Colors = {}
 if mods.ShowFaPlusWindow and mods.ShowFaPlusPane then
 	TapNoteScores.Types = {'W0', 'W1', 'W2', 'W3', 'W4', 'W5', 'Miss'}
 	Colors = {
-		SL.JudgmentColors["FA+"][1],
-		SL.JudgmentColors["FA+"][2],
-		SL.JudgmentColors["FA+"][3],
-		SL.JudgmentColors["FA+"][4],
-		SL.JudgmentColors["FA+"][5],
-		SL.JudgmentColors["ITG"][5], -- FA+ mode doesn't have a Way Off window. Extract color from the ITG mode.
-		SL.JudgmentColors["FA+"][6],
+		SL.JudgmentColors["ITG"][1], -- Fantastic Blue
+		SL.JudgmentColors["FA+"][2], -- Just extract the Fantastic white color
+        SL.JudgmentColors["ITG"][2], -- Yellow Excellent
+		SL.JudgmentColors["ITG"][3], -- Green Great
+		SL.JudgmentColors["ITG"][4], -- Purple Decent
+		SL.JudgmentColors["ITG"][5], -- Way Off
+		SL.JudgmentColors["ITG"][6], -- Red Miss
 	}
 	-- get all TNS names
 	TapNoteScores.Names = {
-		THEME:GetString("TapNoteScoreFA+", "W1"),
-		THEME:GetString("TapNoteScoreFA+", "W2"),
-		THEME:GetString("TapNoteScoreFA+", "W3"),
-		THEME:GetString("TapNoteScoreFA+", "W4"),
-		THEME:GetString("TapNoteScoreFA+", "W5"),
-		THEME:GetString("TapNoteScore", "W5"), -- FA+ mode doesn't have a Way Off window. Extract name from the ITG mode.
-		THEME:GetString("TapNoteScoreFA+", "Miss"),
+		THEME:GetString("TapNoteScore", "W1"),
+		THEME:GetString("TapNoteScoreFA+", "W2"), -- Extract the Fantastic White Window
+		THEME:GetString("TapNoteScore", "W2"),
+		THEME:GetString("TapNoteScore", "W3"),
+		THEME:GetString("TapNoteScore", "W4"),
+		THEME:GetString("TapNoteScore", "W5"),
+		THEME:GetString("TapNoteScore", "Miss"),
 	}
 else
 	TapNoteScores.Types = {'W1', 'W2', 'W3', 'W4', 'W5', 'Miss'}

--- a/BGAnimations/ScreenEvaluation common/Panes/Pane7/default.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane7/default.lua
@@ -28,7 +28,7 @@ else
 
 	for i, passed_check in ipairs(checks) do
 		if passed_check == false then
-			-- the 4th check is GameMode (ITG, FA+, Casual, etc.)
+			-- the 4th check is GameMode (ITG, Casual, etc.)
 			if i==4 then
 				-- that string has a %s token so we can pass in the current SL GameMode
 				text = text .. ScreenString("QRInvalidScore"..i):format(SL.Global.GameMode) .. "\n"

--- a/BGAnimations/ScreenEvaluation common/Shared/AutoSubmitScore.lua
+++ b/BGAnimations/ScreenEvaluation common/Shared/AutoSubmitScore.lua
@@ -201,7 +201,7 @@ local AutoSubmitRequestProcessor = function(res, overlay)
 							-- TODO(teejusb): Determine how we want to easily display EX scores.
 							-- For now just highlight blue because it's simple.
 							if showExScore then
-								entry:GetChild("Score"):diffuse(SL.JudgmentColors["FA+"][1])
+								entry:GetChild("Score"):diffuse(SL.JudgmentColors["ITG"][1])
 							else
 								entry:GetChild("Score"):diffuse(Color.White)
 							end

--- a/BGAnimations/ScreenEvaluationSummary overlay/PlayerStageStats.lua
+++ b/BGAnimations/ScreenEvaluationSummary overlay/PlayerStageStats.lua
@@ -5,13 +5,13 @@ local playerStats
 local steps, meter, difficulty, stepartist, grade, score
 local TNSTypes = { 'W0', 'W1', 'W2', 'W3', 'W4', 'W5', 'Miss' }
 local Colors = {
-			SL.JudgmentColors["FA+"][1],
-			SL.JudgmentColors["FA+"][2],
-			SL.JudgmentColors["FA+"][3],
-			SL.JudgmentColors["FA+"][4],
-			SL.JudgmentColors["FA+"][5],
-			SL.JudgmentColors["ITG"][5], -- FA+ mode doesn't have a Way Off window. Extract color from the ITG mode.
-			SL.JudgmentColors["FA+"][6],
+			SL.JudgmentColors["ITG"][1],
+			SL.JudgmentColors["FA+"][2], -- Get the Fantastic White Window
+			SL.JudgmentColors["ITG"][2],
+			SL.JudgmentColors["ITG"][3],
+			SL.JudgmentColors["ITG"][4],
+			SL.JudgmentColors["ITG"][5], 
+			SL.JudgmentColors["ITG"][6],
 		}
 
 -- variables for positioning and horizalign, dependent on playernumber

--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/LifeMeter/default.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/LifeMeter/default.lua
@@ -3,11 +3,10 @@ if SL[ToEnumShortString(player)].ActiveModifiers.HideLifebar then return end
 
 local lifemeter_actor
 
--- in ITG and FA+, we have the choice a "Standard" LifeMeter (at the top of the screen)
+-- in ITG, we have the choice a "Standard" LifeMeter (at the top of the screen)
 -- a "Surround" LifeMeter, which occupies the space behind the arrows,
 -- or a "Vertical" LifeMeter, which mimics the sizing and positioning used in ITG2.
-if SL.Global.GameMode == "ITG" or SL.Global.GameMode == "FA+" then
-
+if SL.Global.GameMode == "ITG" then
 	local lifemeter_type = SL[ToEnumShortString(player)].ActiveModifiers.LifeMeterType or CustomOptionRow("LifeMeterType").Choices[1]
 	lifemeter_actor = LoadActor(lifemeter_type .. ".lua", player)
 end

--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/NoteField/ErrorBar/Colorful.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/NoteField/ErrorBar/Colorful.lua
@@ -13,7 +13,7 @@ local numTicks = mods.ErrorBarMultiTick and 10 or 1
 local currentTick = 1
 local judgmentToTrim = {
     TapNoteScore_W3 = mods.ErrorBarTrim == "Excellent" and SL.Global.GameMode == "ITG",
-    TapNoteScore_W4 = (mods.ErrorBarTrim ~= "Off" and SL.Global.GameMode == "ITG") or (mods.ErrorBarTrim == "Excellent" and SL.Global.GameMode == "FA+"),
+    TapNoteScore_W4 = mods.ErrorBarTrim ~= "Off" and SL.Global.GameMode == "ITG",
     TapNoteScore_W5 = mods.ErrorBarTrim ~= "Off"
 }
 
@@ -106,14 +106,8 @@ local af = Def.ActorFrame{
             local earlyTns = ToEnumShortString(params.EarlyTapNoteScore)
 
             if earlyTns ~= "None" then
-                if SL.Global.GameMode == "FA+" then
-                    if tns == "W5" then
-                        return
-                    end
-                else
-                    if tns == "W4" or tns == "W5" then
-                        return
-                    end
+                if tns == "W4" or tns == "W5" then
+                    return
                 end
             end
         end

--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/NoteField/ErrorBar/Monochrome.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/NoteField/ErrorBar/Monochrome.lua
@@ -41,7 +41,7 @@ local numTicks = mods.ErrorBarMultiTick and 15 or 1
 local currentTick = 1
 local judgmentToTrim = {
     TapNoteScore_W3 = mods.ErrorBarTrim == "Excellent" and SL.Global.GameMode == "ITG",
-    TapNoteScore_W4 = (mods.ErrorBarTrim ~= "Off" and SL.Global.GameMode == "ITG") or (mods.ErrorBarTrim == "Excellent" and SL.Global.GameMode == "FA+"),
+    TapNoteScore_W4 = mods.ErrorBarTrim ~= "Off" and SL.Global.GameMode == "ITG",
     TapNoteScore_W5 = mods.ErrorBarTrim ~= "Off"
 }
 
@@ -111,14 +111,8 @@ local af = Def.ActorFrame{
             local earlyTns = ToEnumShortString(params.EarlyTapNoteScore)
 
             if earlyTns ~= "None" then
-                if SL.Global.GameMode == "FA+" then
-                    if tns == "W5" then
-                        return
-                    end
-                else
-                    if tns == "W4" or tns == "W5" then
-                        return
-                    end
+                if tns == "W4" or tns == "W5" then
+                    return
                 end
             end
         end

--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/NoteField/ErrorBar/Text.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/NoteField/ErrorBar/Text.lua
@@ -59,14 +59,8 @@ local af = Def.ActorFrame{
                 local earlyTns = ToEnumShortString(params.EarlyTapNoteScore)
     
                 if earlyTns ~= "None" then
-                    if SL.Global.GameMode == "FA+" then
-                        if tns == "W5" then
-                            return
-                        end
-                    else
-                        if tns == "W4" or tns == "W5" then
-                            return
-                        end
+                    if tns == "W4" or tns == "W5" then
+                        return
                     end
                 end
             end

--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/Score.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/Score.lua
@@ -59,9 +59,9 @@ return LoadFont("Wendy/_wendy monospace numbers")..{
 		self:valign(1):horizalign(right)
 		self:zoom(0.5)
 		if IsEX then
-			-- If EX Score, let's diffuse it to be the same as the FA+ top window.
+			-- If EX Score, let's diffuse it to be the same as the ITG top window.
 			-- This will make it consistent with the EX Score Pane.
-			self:diffuse(SL.JudgmentColors["FA+"][1])
+			self:diffuse(SL.JudgmentColors["ITG"][1])
 		end
 	end,
 

--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/StepStatistics/Scorebox.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/StepStatistics/Scorebox.lua
@@ -475,7 +475,7 @@ for i=1,NumEntries do
 			if score.isFail then
 				clr = Color.Red
 			elseif score.isEx then
-				clr = SL.JudgmentColors["FA+"][1]
+				clr = SL.JudgmentColors["ITG"][1]
 			elseif score.isSelf then
 				clr = self_color
 			elseif score.isRival then

--- a/BGAnimations/ScreenGameplay underlay/Shared/VersusStepStatistics.lua
+++ b/BGAnimations/ScreenGameplay underlay/Shared/VersusStepStatistics.lua
@@ -92,9 +92,9 @@ for player in ivalues(Players) do
                     end
 
                     if IsEX then
-                        -- If EX Score, let's diffuse it to be the same as the FA+ top window.
+                        -- If EX Score, let's diffuse it to be the same as th ITG top window.
                         -- This will make it consistent with the EX Score Pane.
-                        self:diffuse(SL.JudgmentColors["FA+"][1])
+                        self:diffuse(SL.JudgmentColors["ITG"][1])
                     end
                 end,
                 JudgmentMessageCommand=function(self, params)

--- a/BGAnimations/ScreenSelectMusic overlay/SortMenu/SortMenu_InputHandler.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SortMenu/SortMenu_InputHandler.lua
@@ -36,7 +36,7 @@ local input = function(event)
 					overlay:queuecommand("DirectInputToEngine")
 					SCREENMAN:GetTopScreen():GetMusicWheel():ChangeSort("SortOrder_Preferred")
 				end
-			-- the player wants to change modes, for example from ITG to FA+
+			-- the player wants to change modes, for example from ITG to Casual
 			elseif focus.kind == "ChangeMode" then
 				SL.Global.GameMode = focus.change
 				for player in ivalues(GAMESTATE:GetHumanPlayers()) do

--- a/BGAnimations/ScreenSelectPlayMode underlay/default.lua
+++ b/BGAnimations/ScreenSelectPlayMode underlay/default.lua
@@ -162,20 +162,12 @@ local t = Def.ActorFrame{
 				if choices[cursor.index+1] == "Casual" then
 					self:stoptweening():linear(0.25):diffusealpha(0)
 				else
-					if choices[cursor.index+1] == "FA+" then
-						self:settext("99.50")
-					else
-						self:settext("77.41")
-					end
+					self:settext("77.41")
 					self:stoptweening():linear(0.25):diffusealpha(1)
 				end
 			else
 				self:diffusealpha(1)
-				if SL.Global.GameMode == "FA+" then
-					self:settext("99.50")
-				else
-					self:settext("77.41")
-				end
+				self:settext("77.41")
 			end
 		end,
 
@@ -187,7 +179,7 @@ local t = Def.ActorFrame{
 		OffCommand=function(self) self:sleep(0.4):linear(0.2):diffusealpha(0) end,
 		UpdateCommand=function(self)
 			if ScreenName == "ScreenSelectPlayMode" then
-				if choices[cursor.index+1] == "ITG" or choices[cursor.index+1] == "FA+" then
+				if choices[cursor.index+1] == "ITG" then
 					self:stoptweening():linear(0.25):diffusealpha(1)
 				else
 					self:stoptweening():linear(0.25):diffusealpha(0)

--- a/BGAnimations/Thonk overlay/default.lua
+++ b/BGAnimations/Thonk overlay/default.lua
@@ -869,7 +869,7 @@ local Update = function(self, delta)
 			end
 		end
 
-		local items = {"IconChoiceCasual","IconChoiceITG","IconChoiceFA+"}
+		local items = {"IconChoiceCasual","IconChoiceITG"}
 		if SCREENMAN:GetTopScreen():GetName() == "ScreenSelectPlayMode2" then
 			items = {"IconChoiceRegular","IconChoiceMarathon"}
 		end

--- a/Graphics/MusicWheelItem Grades/GetLamp.lua
+++ b/Graphics/MusicWheelItem Grades/GetLamp.lua
@@ -31,17 +31,6 @@ local function GetLamp(high_score_list)
 			end
 		end
 
-		-- NOTE: Below is deprecated since FA+ mode no longer really exists.
-		if award == nil and SL.Global.GameMode == "FA+" and score:GetGrade() ~= "Grade_Failed" then
-			-- Dropping a roll/hold breaks the StageAward, but hitting a mine does not.
-			local misses = score:GetTapNoteScore("TapNoteScore_Miss") +
-					score:GetHoldNoteScore("HoldNoteScore_LetGo") +
-					score:GetTapNoteScore("TapNoteScore_CheckpointMiss")
-			if misses + score:GetTapNoteScore("TapNoteScore_W5") == 0 then
-				award = "StageAward_FullComboW4"
-			end
-		end
-
 		if AwardMap[award] ~= nil then
 			best_lamp = math.min(best_lamp and best_lamp or 999, AwardMap[award])
 		end

--- a/Graphics/MusicWheelItem Song NormalPart/default.lua
+++ b/Graphics/MusicWheelItem Song NormalPart/default.lua
@@ -31,7 +31,7 @@ for player in ivalues(PlayerNumber) do
 			self:visible(false)
 			self:zoom(0.2)
 			self:x( _screen.w/(WideScale(2.15, 2.14)) - self:GetWidth()*self:GetZoom() - 40 )
-			self:diffuse(SL.JudgmentColors["FA+"][1])
+			self:diffuse(SL.JudgmentColors["ITG"][1])
 		end,
 		PlayerJoinedMessageCommand=function(self)
 			self:visible(GAMESTATE:IsPlayerEnabled(player))

--- a/Graphics/Player combo.lua
+++ b/Graphics/Player combo.lua
@@ -16,15 +16,6 @@ colors.FullComboW2 = {color("#FDFFC9"), color("#FDDB85")} -- gold combo
 colors.FullComboW3 = {color("#C9FFC9"), color("#94FEC1")} -- green combo
 colors.FullComboW4 = {color("#FFFFFF"), color("#FFFFFF")} -- white combo
 
--- combo colors used in FA+
-if SL.Global.GameMode == "FA+" then
-	colors.FullComboW1 = {color("#C8FFFF"), color("#6BF0FF")} -- blue combo
-	colors.FullComboW2 = {color("#C8FFFF"), color("#6BF0FF")} -- blue combo
-	colors.FullComboW3 = {color("#FDFFC9"), color("#FDDB85")} -- gold combo
-	colors.FullComboW4 = {color("#C9FFC9"), color("#94FEC1")} -- green combo
-end
-
-
 local ShowComboAt = THEME:GetMetric("Combo", "ShowComboAt")
 
 local af = Def.ActorFrame{

--- a/Graphics/Player judgment.lua
+++ b/Graphics/Player judgment.lua
@@ -90,12 +90,10 @@ return Def.ActorFrame{
 					end
 					-- We don't need to adjust the top window otherwise.
 				else
-					-- Everything outside of W1 needs to be shifted down a row if not in FA+ mode.
-					-- Some people might be using 2x7s in FA+ mode (by copying ITG graphics to FA+).
-					-- Don't need to shift in that case.
-					if SL.Global.GameMode ~= "FA+" then
-						frame = frame + 1
-					end
+                    -- Everything outside of W1 needs to be shifted down a row if not in FA+ mode.
+                    -- Some people might be using 2x7s in FA+ mode (by copying ITG graphics to FA+).
+                    -- Don't need to shift in that case.
+					frame = frame + 1
 				end
 			end
 
@@ -132,15 +130,9 @@ return Def.ActorFrame{
 			local earlyTns = ToEnumShortString(param.EarlyTapNoteScore)
 
 			if earlyTns ~= "None" then
-				if SL.Global.GameMode == "FA+" then
-					if tns == "W5" then
-						return
-					end
-				else
-					if tns == "W4" or tns == "W5" then
-						return
-					end
-				end
+				if tns == "W4" or tns == "W5" then
+                    return
+                end
 			end
 		end
 
@@ -175,9 +167,7 @@ return Def.ActorFrame{
 				-- Everything outside of W1 needs to be shifted down a row if not in FA+ mode.
 				-- Some people might be using 2x7s in FA+ mode (by copying ITG graphics to FA+).
 				-- In that case, we need to shift the Way Off down to a Miss
-				if SL.Global.GameMode ~= "FA+" or tns == "Miss" then
-					frame = frame + 1
-				end
+				frame = frame + 1
 			end
 		end
 

--- a/Graphics/ScreenSelectMusic header.lua
+++ b/Graphics/ScreenSelectMusic header.lua
@@ -89,7 +89,7 @@ else
 
 end
 
--- "ITG" or "FA+"; aligned to right of screen
+-- "ITG" aligned to right of screen
 af[#af+1] = LoadFont("Common Header")..{
 	Name="GameModeText",
 	Text=THEME:GetString("ScreenSelectPlayMode", SL.Global.GameMode),

--- a/Graphics/ScreenSelectPlayMode Icon.lua
+++ b/Graphics/ScreenSelectPlayMode Icon.lua
@@ -2,7 +2,7 @@ local gc = Var("GameCommand")
 local index = gc:GetIndex()
 local text = gc:GetName()
 
--- text description of each mode ("Casual", "ITG", "FA+")
+-- text description of each mode ("Casual", "ITG")
 return LoadFont("Common Bold")..{
 	Name="ModeName"..index,
 	Text=ScreenString(text),

--- a/Scripts/SL-Helpers.lua
+++ b/Scripts/SL-Helpers.lua
@@ -208,15 +208,6 @@ GetComboThreshold = function( MaintainOrContinue )
 	-- include dummy values here to prevent Lua errors in case players accidentally switch to lights
 	Combo.lights  = { Maintain = "TapNoteScore_W3", Continue = "TapNoteScore_W3" }
 
-
-	-- handle FA+ for Dance
-	-- should these values change for Pump?  I guess that's up to me.
-	if SL.Global.GameMode=="FA+" then
-		Combo.dance.Maintain = "TapNoteScore_W4"
-		Combo.dance.Continue = "TapNoteScore_W4"
-	end
-
-
 	local game = GAMESTATE:GetCurrentGame():GetName() or "dance"
 	return Combo[game][MaintainOrContinue]
 end
@@ -325,7 +316,7 @@ end
 -- -----------------------------------------------------------------------
 
 SetGameModePreferences = function()
-	-- apply the preferences associated with this SL GameMode (Casual, ITG, FA+)
+	-- apply the preferences associated with this SL GameMode (Casual, ITG)
 	for key,val in pairs(SL.Preferences[SL.Global.GameMode]) do
 		PREFSMAN:SetPreference(key, val)
 	end
@@ -372,10 +363,6 @@ SetGameModePreferences = function()
 	-- this was probably a Bad Decision™ on my part in hindsight  -quietly
 	prefix["ITG"] = ""
 
-	-- "FA+" mode is prefixed with "ECFA-" because the mode was previously known as "ECFA Mode"
-	-- and I don't want to deal with renaming relatively critical files from the theme.
-	-- Thus, scores from FA+ mode will continue to go into ECFA-Stats.xml.
-	prefix["FA+"] = "ECFA-"
 	prefix["Casual"] = "Casual-"
 
 	if PROFILEMAN:GetStatsPrefix() ~= prefix[SL.Global.GameMode] then
@@ -388,7 +375,7 @@ end
 -- manages for you back to their stock SM5 values.
 --
 -- These "managed" Preferences are listed in ./Scripts/SL_Init.lua
--- per-gamemode (Casual, ITG, FA+), and actively applied (and reapplied)
+-- per-gamemode (Casual, ITG), and actively applied (and reapplied)
 -- for each new game using SetGameModePreferences()
 --
 -- SL normally calls ResetPreferencesToStockSM5() from
@@ -601,7 +588,7 @@ IsW0Judgment = function(params, player)
 	if params.HoldNoteScore then return false end
 
 	-- Only check/update FA+ count if we received a TNS in the top window.
-	if params.TapNoteScore == "TapNoteScore_W1" and SL.Global.GameMode == "ITG"  then
+	if params.TapNoteScore == "TapNoteScore_W1" and SL.Global.GameMode == "ITG" then
 		local prefs = SL.Preferences["FA+"]
 		local scale = PREFSMAN:GetPreference("TimingWindowScale")
 		local W0 = prefs["TimingWindowSecondsW1"] * scale + prefs["TimingWindowAdd"]
@@ -650,28 +637,7 @@ GetExJudgmentCounts = function(player)
 
 	local TNS = { "W1", "W2", "W3", "W4", "W5", "Miss" }
 
-	if SL.Global.GameMode == "FA+" then
-		for window in ivalues(TNS) do
-			adjusted_window = window
-			-- In FA+ mode, we need to shift the windows up 1 so that the key we're using is accurate.
-			-- E.g. W1 window becomes W0, W2 becomes W1, etc.
-			if window ~= "Miss" then
-				adjusted_window = "W"..(tonumber(window:sub(-1))-1)
-			end
-
-			-- Get the count.
-			local number = stats:GetTapNoteScores( "TapNoteScore_"..window )
-			-- For the last window (Decent) in FA+ mode...
-			if window == "W5" then
-				-- Only populate if the window is still active.
-				if SL[pn].ActiveModifiers.TimingWindows[5] then
-					counts[adjusted_window] = number
-				end
-			else
-				counts[adjusted_window] = number
-			end
-		end
-	elseif SL.Global.GameMode == "ITG" then
+    if SL.Global.GameMode == "ITG" then
 		for window in ivalues(TNS) do
 			-- Get the count.
 			local number = stats:GetTapNoteScores( "TapNoteScore_"..window )

--- a/Scripts/SL-PlayerOptions.lua
+++ b/Scripts/SL-PlayerOptions.lua
@@ -398,10 +398,6 @@ local Overrides = {
 				return { "ShowFaPlusWindow" }
 			end
 
-			if SL.Global.GameMode == "FA+" then
-				return { "ShowExScore" }
-			end
-
 			return { "ShowFaPlusWindow", "ShowExScore", "ShowFaPlusPane" }
 		end,
 		LoadSelections = function(self, list, pn)
@@ -410,11 +406,6 @@ local Overrides = {
 				list[1] = mods.ShowFaPlusWindow or false
 				return list
 			end
-
-			if SL.Global.GameMode == "FA+" then
-				list[1] = mods.ShowExScore or false
-				return list
-			end		
 
 			list[1] = mods.ShowFaPlusWindow or false
 			list[2] = mods.ShowExScore or false
@@ -431,15 +422,6 @@ local Overrides = {
 				mods.ShowFaPlusPane = true
 				-- Default to FA+ pane in Tournament Mode
 				sl_pn.EvalPanePrimary = 2
-				return
-			end
-
-			if SL.Global.GameMode == "FA+" then
-				-- always disable in FA+ mode since it's handled engine side.
-				mods.ShowFaPlusWindow = false
-				mods.ShowExScore = list[1]
-				-- the main score pane is already the FA+ pane
-				mods.ShowFaPlusPane = false
 				return
 			end
 

--- a/metrics.ini
+++ b/metrics.ini
@@ -188,9 +188,6 @@ IconChoiceCasualY=_screen.cy - 75
 IconChoiceITGX=_screen.cx - 110
 IconChoiceITGY=_screen.cy - 25
 
-IconChoiceFA+X=_screen.cx - 110
-IconChoiceFA+Y=_screen.cy + 25
-
 # there is not a 4th choice for now, so these are commented out
 # IconChoice_unused=_screen.cx - 110
 # IconChoice_unused=_screen.cy + 75
@@ -2219,7 +2216,7 @@ ExtraColorMeter=999999
 # MinStayAlive is only used when the LifeMeterBar has its DrainType set to "SuddenDeath"
 # that is, never in Simply Love, except maybe in some exotic mod-chart yet to be written.
 # see LifeMeterBar.cpp for details regarding the implementation.
-MinStayAlive=(SL.Global.GameMode=="FA+" and "TapNoteScore_W4") or "TapNoteScore_W3"
+MinStayAlive="TapNoteScore_W3"
 
 # InitialValue is a floating-point value between [0,1] inclusive that determines how full
 # the LifeMeter is at the start of Gameplay.  ITG set this to be 0.5.


### PR DESCRIPTION
Time to say 👋🏻 to the old FA+ GameMode...!

Code involved:
* Screen Evaluation Song:
  - Pane 1 ➡️ Score ITG
  - Pane 2 ➡️ Score EX/FA+
  - Pane 3 ➡️ Pad arrows Judgments
  - Pane 7 ➡️ GS QR Code
* Screen Evaluation Summary
* All Error Bar in Screen Gameplay
* Screen Select Play Mode
* Music Wheel Lamp
* Player Judgment
* GrooveStats Validation/Upload
* Player Options ➡️ FA+ Options

_Plus_: renamed all reference to the "blue fantastic" from FA+ to ITG
```
SL.JudgmentColors["FA+"][1] ➡️ SL.JudgmentColors["ITG"][1]
```

Test cases:
- [x] Play a song without FA+ Window enabled
- [x] Play a song with FA+ Window enabled
- [x] Go to Evaluation Song Screen with FA+ enabled
- [x] Go to Evaluation Song Screen without FA+ enabled
- [x] Go to Evaluation Summary from Select Song Options
- [x] Go to Evaluation Summary when session ended
- [x] Play a song connected to GS
- [x] Play a song with Error Bar
- [x] Play a song with a 2x6 Judgment
- [x] Check Casual Mode?