### PR TITLE
improve text legibility on ScreenGrooveStats login

### DIFF
--- a/BGAnimations/ScreenGrooveStatsLogin underlay/default.lua
+++ b/BGAnimations/ScreenGrooveStatsLogin underlay/default.lua
@@ -76,17 +76,27 @@ local af = Def.ActorFrame{
 
   LoadFont("Common Normal")..{
     Text=THEME:GetString("ScreenSelectProfile", "LoginInstructions"),
-    InitCommand=function(self) self:y(-150) end,
+    InitCommand=function(self)
+      self:y(-150)
+      if ThemePrefs.Get("RainbowMode") then
+        self:diffuse(Color.Black)
+      end
+    end,
   },
   LoadFont("Common Normal")..{
     Text=THEME:GetString("ScreenSelectProfile", "VisitWebsite"),
-    InitCommand=function(self) self:y(-120) end,
+    InitCommand=function(self)
+      self:y(-120)
+      if ThemePrefs.Get("RainbowMode") then
+        self:diffuse(Color.Black)
+      end
+    end,
   },
 
-  LoadFont("Common Normal")..{
+  LoadFont("Common Bold")..{
     Text=THEME:GetString("ScreenEvaluation", "PressStartToContinue"),
     InitCommand=function(self)
-      self:y(150)
+      self:zoom(0.55):y(150):shadowlength(1)
     end,
   },
 }
@@ -113,6 +123,11 @@ for player in ivalues(GAMESTATE:GetHumanPlayers()) do
 
     LoadFont("Common Normal")..{
       Text=SL[pn].ApiKey and THEME:GetString("ScreenSelectProfile", "ProfileConnected") or "",
+      InitCommand=function(self)
+        if ThemePrefs.RainbowMode then
+          self:diffuse(Color.Black)
+        end
+      end,
       HideQrMessageCommand=function(self, params)
         if params.pn == pn then
           WriteGrooveStatsIni(player)


### PR DESCRIPTION
1. Conditionally diffuse miso text to black when RainbowMode is in effect to improve contrast + legibility.

2. Change `"Press &START; To Continue"` text to use Wendy, similar to `ScreenEvaluationCasual`.  Short of redesigning this screen for a different UX, I think this is the text we should be making large and bold, since I've seen casual players get confused and walk away from the machine at this screen.
 
---

`"Scan QR code to login..."` text is white in non-RainbowMode, black in RainbowMode.

![Screenshot 2025-04-09 at 12 27 50 AM](https://github.com/user-attachments/assets/6bdc25fb-f132-464b-a3b7-70a00c1c60a1)

![Screenshot 2025-04-09 at 12 28 03 AM](https://github.com/user-attachments/assets/8abd33b7-adec-4d76-8f0a-fbadabfc89e8)
