### PR TITLE
fix TrackFailTime when MeasureCounter is off

### DIFF
--- a/BGAnimations/ScreenGameplay overlay/TrackFailTime.lua
+++ b/BGAnimations/ScreenGameplay overlay/TrackFailTime.lua
@@ -1,5 +1,5 @@
 -- This file will track the time that a player fails and show on the Evaluation screen.
--- Additionally, if the player fails inside a stream (16ths or higher) it will display 
+-- Additionally, if the player fails inside a stream (16ths or higher) it will display
 -- the position in the stream (16ths) that they fail.
 
 -- This does not count if the player holds start to fail
@@ -28,13 +28,13 @@ end
 
 -- Return the current time of the course or song, in seconds
 local CurrentTimeSongOrCourse = function(player)
-    local playerState = GAMESTATE:GetPlayerState(player)	
+    local playerState = GAMESTATE:GetPlayerState(player)
     local seconds = 0
     local rate = SL.Global.ActiveModifiers.MusicRate
 
     if GAMESTATE:IsCourseMode() then
         local cumulativeSeconds = CourseLengthPerSong(player)
-        
+
         -- Find out what song in the course and add up all the previous songs
         local courseIndex = GAMESTATE:GetCourseSongIndex()
         for i = 1, courseIndex do
@@ -82,8 +82,8 @@ end
 local af = Def.Actor{
 	HealthStateChangedMessageCommand=function(self, param)
 		-- Only do something if the player fails
-		if param.PlayerNumber == player and param.HealthState == "HealthState_Dead" then			
-			local playerState = GAMESTATE:GetPlayerState(player)			
+		if param.PlayerNumber == player and param.HealthState == "HealthState_Dead" then
+			local playerState = GAMESTATE:GetPlayerState(player)
 
 			-- These functions already account for rate mod
 			local currentSecond = CurrentTimeSongOrCourse(player)
@@ -95,14 +95,14 @@ local af = Def.Actor{
 			local graphPercentage = 0
             local graphLabel = 0
 
-			if GAMESTATE:IsCourseMode() then 
+			if GAMESTATE:IsCourseMode() then
 				local cumulativeSeconds = CourseLengthPerSong(player)
 				local courseIndex = GAMESTATE:GetCourseSongIndex()
 				local totalSecondsToEndOfSong = cumulativeSeconds[courseIndex+1]
 
 				graphPercentage = deathSecond / totalSecondsToEndOfSong
 				graphLabel = deathSecond / totalSeconds
-			else 
+			else
 				graphPercentage = deathSecond / totalSeconds
 				graphLabel = totalSeconds - deathSecond
 			end
@@ -112,16 +112,19 @@ local af = Def.Actor{
 			local streams = SL[pn].Streams
 			local storage = SL[pn].Stages.Stats[SL.Global.Stages.PlayedThisGame + 1]
 
+            -- streams.NotesPerMeasure will be an empty table if player wasn't using MeasureCounter
+            local currentMeasureWasStream = (type(streams.NotesPerMeasure[currentMeasure+1]) == "number") and (streams.NotesPerMeasure[currentMeasure+1] > 16)
+
 			storage.TotalSeconds = totalSeconds
 			storage.DeathSecond = deathSecond
 			storage.GraphPercentage = graphPercentage
 			storage.GraphLabel = graphLabel
 
 			-- find out if this measure was a stream (16ths or higher)
-			if streams.NotesPerMeasure[currentMeasure+1] >= 16 then
-				-- find out which measure the fail was 
+			if currentMeasureWasStream then
+				-- find out which measure the fail was
 				for i=1,#streams.Measures do
-					if currentMeasure >= streams.Measures[i].streamStart and currentMeasure < streams.Measures[i].streamEnd  then							
+					if currentMeasure >= streams.Measures[i].streamStart and currentMeasure < streams.Measures[i].streamEnd  then
 						local streamRun = currentMeasure - streams.Measures[i].streamStart + 1
 						local streamTotal = streams.Measures[i].streamEnd - streams.Measures[i].streamStart
 						storage.DeathMeasures = string.format("%s/%s", streamRun, streamTotal)

--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/NoteField/MeasureCounter.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/NoteField/MeasureCounter.lua
@@ -2,10 +2,17 @@ local player, layout = ...
 local pn = ToEnumShortString(player)
 local mods = SL[pn].ActiveModifiers
 
+if mods.MeasureCounter == "None" then
+	-- ensure that player's "Streams" table is reset to default values
+	-- in case they e.g. use MeasureCounter on stage1 and then disable it for stage2
+	ResetStreamsData(pn)
+end
+
 -- don't allow MeasureCounter to appear in Casual gamemode via profile settings
 if SL.Global.GameMode == "Casual"
 or not mods.MeasureCounter
 or mods.MeasureCounter == "None" then
+
 	return
 end
 
@@ -18,7 +25,7 @@ local bmt = {}
 
 -- How many streams to "look ahead"
 local lookAhead = mods.HideLookahead and 0 or 3
--- If you want to see more than 2 counts in advance, change the 2 to a larger value.
+-- If you want to see more than 3 counts in advance, change the 3 to a larger value.
 -- Making the value very large will likely impact fps. -quietly
 
 

--- a/Scripts/SL-ChartParserHelpers.lua
+++ b/Scripts/SL-ChartParserHelpers.lua
@@ -1,8 +1,8 @@
 -- ----------------------------------------------------------------
--- This file (SL-ChartParserHelpers.lua) is used to populate auxilliary
+-- This file (SL-ChartParserHelpers.lua) is used to populate auxiliary
 -- data which is oftem based off the data parsed form ChartParseInfo.
 
--- The main use case is when this auxilliary information might depend on 
+-- The main use case is when this auxiliary information might depend on
 -- extra information that isn't available during the Chart Parsing stage.
 
 -- For example, getting the information for the measure counter depends on
@@ -184,7 +184,7 @@ GenerateBreakdownText = function(pn, minimization_level)
 			end
 		end
 	end
-	
+
 	-- Add any trailing segments we haven't accounted for yet.
 	if segment_sum ~= 0 then
 		if minimization_level == 2 then
@@ -220,4 +220,36 @@ GetTotalStreamAndBreakMeasures = function(pn)
 	end
 
 	return totalStream, totalBreak
+end
+
+-- ----------------------------------------------------------------
+-- reset a player's "Streams" table to default values
+-- used if they have MeasureCounter enabled for stage1 and off for stage2
+
+ResetStreamsData = function(pn)
+	SL[pn].Streams = {
+		-- Chart identifiers for caching purposes.
+		Filename = "",
+		StepsType = "",
+		Difficulty = "",
+		Description = "",
+
+		-- Information parsed out from the chart.
+		NotesPerMeasure = {},
+		EquallySpacedPerMeasure = {},
+		PeakNPS = 0,
+		NPSperMeasure = {},
+		columnCues = {},
+		Hash = '',
+
+		Crossovers = 0,
+		Footswitches = 0,
+		Sideswitches = 0,
+		Jacks = 0,
+		Brackets = 0,
+
+		-- Data for measure counter. Populated in ./ScreenGameplay in/MeasureCounterAndMods.lua.
+		-- Uses the notesThreshold option.
+		Measures = {},
+	}
 end


### PR DESCRIPTION
## Steps to reproduce bug
1. choose any course
2. ensure you have _MeasureCounter_ set to `"none"`
3. fail the course
4. observe Lua error thrown from line 121 of TrackFailTime

![Screenshot 2025-04-09 at 3 15 24 PM](https://github.com/user-attachments/assets/68c7b7e5-912e-4833-aacd-068545c82f7a)

## Description of Fix

TrackFailTime.lua checks if the fail occurred during a stream, which requires MeasureCounter to have been enabled for stream data to be parsed and available for comparison.

This PR's first commit changes TrackFailTime to only perform that comparison (did the current measure have at least 16 notes?) if data is available to compare against.

---

Work on that revealed a 2nd issue:  if a player enables _MeasureCounter_ for their first song, then disables it for their 2nd song, the "streams" table isn't reset, and the 2nd song will be played/tracked/evaluated using stale stream data from the 1st song.

I think we should reset the player's streams table when they change their MeasureCounter to "None", if other parts of the theme (e.g. TrackFailTime) rely on parsed stream data.

I did this by copy/pasting the table's default values from SL_Init.lua into a new global function `ResetStreamsData(pn)` in SL-ChartParserHelpers.lua, and calling that function at the start of MeasureCounter.lua if the player's MeasureCounter is set to `"None"`.

I'm open to refactoring this to something with less copy/paste if you have any ideas. :)