### PR TITLE
Restore default behavior to SM() and add support for ``stack`` parameter

### DIFF
--- a/Scripts/06 SL-Utilities.lua
+++ b/Scripts/06 SL-Utilities.lua
@@ -68,7 +68,7 @@ end
 -- in seconds, for how long you want the text to appear on screen.
 -- in Simply Love, the default SystemMessage duration used in ./BGA/ScreenSystemLayer overlay.lua is 3
 
-SM = function( arg, duration )
+SM = function( arg, stack, duration )
 	local msg
 
 	-- if a table has been passed in, recursively stringify the table's keys and values
@@ -84,7 +84,7 @@ SM = function( arg, duration )
 	-- "SystemMessage" with certain parameters.  see: ScreenManager.cpp
 	-- let's broadcast directly using MESSAGEMAN so that we can also pack in a duration
 	-- value (how long to display the SystemMessage for) if so desired
-	MESSAGEMAN:Broadcast("SystemMessage", {Message=msg, Duration=duration})
+	MESSAGEMAN:Broadcast("SystemMessage", {Message=msg, Duration=duration, Stack=stack})
 	Trace(msg)
 end
 

--- a/Scripts/06 SL-Utilities.lua
+++ b/Scripts/06 SL-Utilities.lua
@@ -68,7 +68,7 @@ end
 -- in seconds, for how long you want the text to appear on screen.
 -- in Simply Love, the default SystemMessage duration used in ./BGA/ScreenSystemLayer overlay.lua is 3
 
-SM = function( arg, stack, duration )
+SM = function( arg, duration, stack )
 	local msg
 
 	-- if a table has been passed in, recursively stringify the table's keys and values


### PR DESCRIPTION
System messages w/ the theme by default were always stacking which _technically_ wasn't backwards compatible. I uh ran into quite a few cases playing mod charts that used the messages and the entire screen was covered. This also made it difficult to constantly print the beat which is very useful when writing and debugging mod charts (The entire screen will get covered up). With this PR using SM() without the stack parameter will operate as it did with each message replacing the last. Supplying the stack parameter will cause each systemmessage to stack on the other which is useful for debugging instances where you want to see that history.

(cherry picked from commit bb75e30f5ff0d6cc05f451f5e9cf3e4b79e189d9)