### PR TITLE
fix alignment of P2 ITG label on judgment pane

### DIFF
--- a/BGAnimations/ScreenEvaluation common/Panes/Pane2/JudgmentLabels.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane2/JudgmentLabels.lua
@@ -108,7 +108,7 @@ for index, label in ipairs(RadarCategories) do
 			Text=text,
 			InitCommand=function(self) self:zoom(0.5):horizalign(right) end,
 			BeginCommand=function(self)
-				self:x( (controller == PLAYER_1 and -160) or 90 )
+				self:x( (controller == PLAYER_1 and -160) or 82 )
 				self:y(38)
 
 				if SL[pn].ActiveModifiers.ShowExScore then


### PR DESCRIPTION
it's just been kind of in the middle of nowhere before, this brings it closer to where the P1 label is.

previous:
![image](https://github.com/user-attachments/assets/b8e2f000-0446-4340-b131-62eb2bcb7aea)

now: 
![image](https://github.com/user-attachments/assets/a9c63885-3b32-432e-87d1-943fbe42623f)
