### PR TITLE
Rework help text for practice mode

### DIFF
--- a/BGAnimations/ScreenPractice underlay.lua
+++ b/BGAnimations/ScreenPractice underlay.lua
@@ -26,7 +26,7 @@ local t = Def.ActorFrame{
 local sections = {
 	NavigationHelp = 0,
 	MenuHelp = 130,
-	MiscHelp = 166
+	MiscHelp = 176
 }
 
 for section, offset in pairs(sections) do

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -508,10 +508,9 @@ KeyMappingHelpLabel=KeyMappings
 MiscHelpLabel=Misc.
 
 # Explanations
-NavigationHelpText=Comma/Period:\n     Move To Next/Previous Arrow\nUp/Down:\n     Move One Measure\nSemicolon/Apostrophe:\n     Move One Measure\nHome/End:\n    Move to Start/End of Steps
-MenuHelpText=Escape\Enter: Main Menu
-KeyMappingHelpText=F1: Keymappings Help
-MiscHelpText=Space: Set area marker
+NavigationHelpText=Up/Down:\n     Move One Beat\nSemicolon/Apostrophe:\n     Move One Measure\nHome/End:\n    Move to Start/End of Steps\nLeft/Right:\n     Select Note Snap
+MenuHelpText=Escape\Enter: Main Menu\nF1: Open Help Menu
+MiscHelpText=Space:\n     Set area marker\nShift+Navigate:\n     Select area
 
 
 [ScreenAttackMenu]


### PR DESCRIPTION
For the changes in https://github.com/itgmania/itgmania/pull/807

In ScreenPractice:
![image](https://github.com/user-attachments/assets/ab7992ec-1913-4dff-9ecb-33d2da9f53b1)

The F1 Help Menu:
![image](https://github.com/user-attachments/assets/bcdf9de6-b5db-481a-9916-e077d55b434c)
