### PR TITLE
Scatterplot Course Mode Support

### DIFF
--- a/BGAnimations/ScreenEvaluation common/PerPlayer/Lower/ScatterPlot.lua
+++ b/BGAnimations/ScreenEvaluation common/PerPlayer/Lower/ScatterPlot.lua
@@ -1,6 +1,5 @@
--- if we're in CourseMode, bail now
--- the normal LifeMeter graph (Def.GraphDisplay) will be drawn
-if GAMESTATE:IsCourseMode() then return end
+-- if we're in CourseMode, then we'll have to collect steps per chart
+local iscourse = GAMESTATE:IsCourseMode()
 
 -- arguments passed in from Graphs.lua
 local args = ...
@@ -9,8 +8,6 @@ local pn = ToEnumShortString(player)
 local GraphWidth = args.GraphWidth
 local GraphHeight = args.GraphHeight
 local mods = SL[pn].ActiveModifiers
-
-local pn = ToEnumShortString(player)
 
 -- sequential_offsets gathered in ./BGAnimations/ScreenGameplay overlay/JudgmentOffsetTracking.lua
 local sequential_offsets = SL[pn].Stages.Stats[SL.Global.Stages.PlayedThisGame + 1].sequential_offsets
@@ -23,7 +20,7 @@ local Steps = GAMESTATE:GetCurrentSteps(player)
 local TimingData = Steps:GetTimingData()
 -- FirstSecond and LastSecond are used in scaling the x-coordinates of the AMV's vertices
 local FirstSecond = math.min(TimingData:GetElapsedTimeFromBeat(0), 0)
-local LastSecond = GAMESTATE:GetCurrentSong():GetLastSecond()
+local LastSecond = (not iscourse) and GAMESTATE:GetCurrentSong():GetLastSecond() or TotalCourseLength(player) * SL.Global.ActiveModifiers.MusicRate
 
 -- variables that will be used and re-used in the loop while calculating the AMV's vertices
 local Offset, CurrentSecond, TimingWindow, x, y, c, r, g, b
@@ -113,6 +110,28 @@ end
 
 -- Since we've now split the table into multiples, create an ActorMultiVertex for each table and store them into one ActorFrame.
 local af = Def.ActorFrame{}
+
+-- if this is the score screen for a course, then iterate through each chart and plot them
+if iscourse then
+	local trailEntries = GAMESTATE:GetCurrentTrail(player):GetTrailEntries()
+	local curSecs = 0
+	
+	for i=1,#trailEntries do
+		local endSec = trailEntries[i]:GetSong():GetLastSecond()
+		local startX = (-GraphWidth/2) + (curSecs / LastSecond) * GraphWidth
+		local endX = (endSec / LastSecond) * GraphWidth
+		af[#af+1] = Def.Quad{
+			InitCommand=function(self)
+				self:x(startX):zoomto(endX, GraphHeight):diffuse(LightenColor(LightenColor(color("#101519")))):diffusealpha(0.5):vertalign(top):horizalign(left)
+				if i%2 == 0 then self:visible(false) end
+				if ThemePrefs.Get("VisualStyle") == "Technique" then
+					self:diffusealpha(0.6)
+				end
+			end
+		}
+		curSecs = curSecs + endSec
+	end
+end
 
 for verts in ivalues(vertsTable) do
 	local amv = Def.ActorMultiVertex{

--- a/BGAnimations/ScreenGameplay overlay/JudgmentOffsetTracking.lua
+++ b/BGAnimations/ScreenGameplay overlay/JudgmentOffsetTracking.lua
@@ -20,10 +20,19 @@ return Def.Actor{
 			-- If the judgment was a Miss, store the string "Miss" as offset instead of the number 0.
 			-- For all other judgments, store the offset value provided by the engine as a number.
 			local offset = params.TapNoteScore == "TapNoteScore_Miss" and "Miss" or params.TapNoteOffset
+			local courseOffset = 0
+			if GAMESTATE:IsCourseMode() then
+				local curCourseSong = GAMESTATE:GetCourseSongIndex()
+				local courseEntries = GAMESTATE:GetCurrentTrail(ToEnumShortString(player)):GetTrailEntries()
+				
+				for i=1,curCourseSong do
+					courseOffset = courseOffset + courseEntries[i]:GetSong():GetLastSecond()
+				end
+			end
 
 			-- Store judgment offsets (including misses) in an indexed table as they occur.
 			-- Also store the CurMusicSeconds for Evaluation's scatter plot.
-			sequential_offsets[#sequential_offsets+1] = { GAMESTATE:GetCurMusicSeconds(), offset }
+			sequential_offsets[#sequential_offsets+1] = { courseOffset + GAMESTATE:GetCurMusicSeconds(), offset }
 		end
 	end,
 	OffCommand=function(self)

--- a/BGAnimations/ScreenGameplay overlay/TrackFailTime.lua
+++ b/BGAnimations/ScreenGameplay overlay/TrackFailTime.lua
@@ -18,7 +18,7 @@ local CourseLengthPerSong = function(player)
         if trail then
             local entries = trail:GetTrailEntries()
             for i, entry in ipairs(entries) do
-                seconds = seconds + (entry:GetSong():MusicLengthSeconds() / rate)
+                seconds = seconds + (entry:GetSong():GetLastSecond() / rate)
                 table.insert(cumulativeSeconds, seconds)
             end
         end
@@ -37,9 +37,9 @@ local CurrentTimeSongOrCourse = function(player)
         
         -- Find out what song in the course and add up all the previous songs
         local courseIndex = GAMESTATE:GetCourseSongIndex()
-        for i = 1, courseIndex do
-            seconds = seconds + cumulativeSeconds[courseIndex]
-        end
+		if courseIndex > 0 then
+			seconds = cumulativeSeconds[courseIndex]
+		end
 
         -- Thenn add on the current song's timer
         local currentSongTimer = playerState:GetSongPosition():GetMusicSecondsVisible()

--- a/Scripts/SL-Helpers.lua
+++ b/Scripts/SL-Helpers.lua
@@ -1043,3 +1043,35 @@ GetPlayerAF = function(pn)
 
 	return playerAF
 end
+
+-- -----------------------------------------------------------------------
+-- cool functions for scatterplotting course mode
+
+-- calculate each chart's actual length by GetLastSecond instead of song length
+TotalCourseLength = function(player)
+    local trail = GAMESTATE:GetCurrentTrail(player)
+    local t = 0
+    for te in ivalues(trail:GetTrailEntries()) do
+        t = t + te:GetSong():GetLastSecond()
+    end
+
+    return t / SL.Global.ActiveModifiers.MusicRate
+end
+
+-- calculate amount of course played for properly scaling the scatterplot of judgments
+TotalCourseLengthPlayed = function(player)
+	local pn = ToEnumShortString(player)
+	local trail = GAMESTATE:GetCurrentTrail(player)
+	local storage = SL[pn].Stages.Stats[SL.Global.Stages.PlayedThisGame + 1]
+	if storage.DeathSecond ~= nil then
+		local deathSecond = storage.DeathSecond
+		local t = 0
+		for te in ivalues(trail:GetTrailEntries()) do
+			t = t + ( te:GetSong():GetLastSecond() / SL.Global.ActiveModifiers.MusicRate )
+			if t > deathSecond then break end
+		end
+		return t
+	else
+		return -1
+	end
+end

--- a/Scripts/SL-Histogram.lua
+++ b/Scripts/SL-Histogram.lua
@@ -1,16 +1,17 @@
-local function gen_vertices(player, width, height, desaturation)
-	local Song, Steps
+local function gen_vertices(player, width, height, Steps, desaturation)
+	local Song
 	local first_step_has_occurred = false
 	local pn = ToEnumShortString(player)
 
-	if GAMESTATE:IsCourseMode() then
-		local TrailEntry = GAMESTATE:GetCurrentTrail(player):GetTrailEntry(GAMESTATE:GetCourseSongIndex())
-		Steps = TrailEntry:GetSteps()
-		Song = TrailEntry:GetSong()
-	else
-		Steps = GAMESTATE:GetCurrentSteps(player)
-		Song = GAMESTATE:GetCurrentSong()
+	if not Steps then 
+		if GAMESTATE:IsCourseMode() then
+			local TrailEntry = GAMESTATE:GetCurrentTrail(player):GetTrailEntry(GAMESTATE:GetCourseSongIndex())
+			Steps = TrailEntry:GetSteps()
+		else
+			Steps = GAMESTATE:GetCurrentSteps(player)
+		end
 	end
+	Song = SONGMAN:GetSongFromSteps(Steps)
 	
 	if not Steps or not Song then return {} end
 
@@ -131,12 +132,50 @@ function NPS_Histogram(player, width, height, desaturation)
 			-- we've reached a new song, so reset the vertices for the density graph
 			-- this will occur at the start of each new song in CourseMode
 			-- and at the start of "normal" gameplay
-			local verts = gen_vertices(player, width, height, desaturation)
+			local verts = gen_vertices(player, width, height, nil, desaturation)
 			self:SetNumVertices(#verts):SetVertices(verts)
 		end
 	}
 
 	return amv
+end
+
+-- set of density graphs for a course
+-- one little issue here is that varying nps per song isn't reflected by the relative height of each chart
+-- honestly too big of a hassle for me to mess with right now
+function NPS_Histogram_Static_Course(player, width, height, desaturation)
+	local pn = ToEnumShortString(player)
+	local af = Def.ActorFrame{}
+	local trail = GAMESTATE:GetCurrentTrail(pn)
+	
+	-- first get the total time
+	local totaltime = TotalCourseLength(player)
+	
+	-- build a table of offsets and widths (doing one loop with everything in InitCommand will just use
+	-- the last value whatever local variable in the loop was once the actors execute)
+	local curx = 0
+	local ptable = {}
+	for te in ivalues(trail:GetTrailEntries()) do
+		local w = (te:GetSong():GetLastSecond() / SL.Global.ActiveModifiers.MusicRate / totaltime) * width
+		table.insert(ptable, {curx, w, te:GetSteps()})
+		curx = curx + w
+	end
+	for i, pos in ipairs(ptable) do
+		-- add density graph amv
+		af[#af+1] = Def.ActorMultiVertex{
+			InitCommand = function(self)
+				self:x(pos[1])
+				self:SetDrawState({Mode="DrawMode_QuadStrip"})
+				self:queuecommand("SetVertices")
+			end,
+			SetVerticesCommand = function(self)
+				local verts = gen_vertices(player, pos[2], height, pos[3], desaturation)
+				self:SetNumVertices(#verts):SetVertices(verts)
+			end
+		}
+	end
+
+	return af
 end
 
 
@@ -156,7 +195,7 @@ function Scrolling_NPS_Histogram(player, width, height, desaturation)
 		end,
 
 		LoadCurrentSong=function(self, scaled_width)
-			verts = gen_vertices(player, scaled_width, height, desaturation)
+			verts = gen_vertices(player, scaled_width, height, nil, desaturation)
 
 			left_idx = 1
 			right_idx = 2


### PR DESCRIPTION
- Fix time tracking in course for getting fail time
- Add timing scatterplot and density graph support for course mode
- Scale lifebar summary across full course duration instead of just until fail point

![Anime_Musi_2025-05-18_223400](https://github.com/user-attachments/assets/7cf69f2e-7030-4278-9639-6cab0f991fa0)
![Anime_Musi_2025-05-18_224403](https://github.com/user-attachments/assets/1753327d-5498-4ce3-aa96-2417943a6be2)
