### PR TITLE
Fix missing OptionNames for 44100 Hz and 48000 Hz in en.ini

### DIFF
--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -661,6 +661,10 @@ Cover=Hide BG
 # NoRolls is a modifier defined in the SM5 engine that transforms Rolls into Holds
 NoRolls=Rolls to Holds
 
+# Audio Sample Rates
+44100 Hz=44100 Hz
+48000 Hz=48000 Hz
+
 [OptionTitles]
 # Top-level Service menu items
 SystemOptions=🤍  System Options


### PR DESCRIPTION
Without these entries, the game throws an error: "String 'OptionNames::44100 Hz' is missing." Added them under the [OptionNames] section to resolve the issue. The options now display correctly in the Options menu.