### PR TITLE
Fix issue where a song can't be favorited if its path is a substring of another favorite

### DIFF
--- a/Scripts/SL-FavoritesHandler.lua
+++ b/Scripts/SL-FavoritesHandler.lua
@@ -30,7 +30,7 @@ addOrRemoveFavorite = function(player)
 
         elseif favoritesString then
             -- If song found in the player's favorites
-            local checksong = string.match(favoritesString, strPlainText(arr[3] .. "/" .. arr[4]))
+            local checksong = string.match(favoritesString, strPlainText(arr[3] .. "/" .. arr[4]) .. "\n")
 
             -- Song found
             if checksong then


### PR DESCRIPTION
Without the newline in the check, if a song path is a substring of another favorited song path, it will attempt to remove a nonexistent favorite instead of adding a new favorite.

For example, if the favorites file contains `Hard-Boiled Eggs/DON'T STOP THE MUSIC`, trying to add a new favorite for `Hard-Boiled Eggs/DON` fails as it treats it as an existing favorite.