### PR TITLE
Fix flasing during ScreenPrompt transitions

### DIFF
--- a/BGAnimations/ScreenPrompt in.redir
+++ b/BGAnimations/ScreenPrompt in.redir
@@ -1,1 +1,1 @@
-_fade in fast
+_blank

--- a/BGAnimations/ScreenPrompt out.redir
+++ b/BGAnimations/ScreenPrompt out.redir
@@ -1,1 +1,1 @@
-_fade out fast
+_blank


### PR DESCRIPTION
The fade transitions don't look good for ScreenPrompt because ScreenPrompt is used on top of other screens but the fades start from or end to a solid color. In addition, the underlay already does a fade in and sets alpha to zero before the out transition.