### PR TITLE
Fix losing input after searching for a song (fixes #388)

### DIFF
--- a/BGAnimations/ScreenSelectMusic overlay/SongSearch/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SongSearch/default.lua
@@ -15,15 +15,20 @@ local af = Def.ActorFrame {
 		self:visible(false)
 	end,
 	DisplaySearchResultsMessageCommand=function(self, params)
+		self:queuecommand("AddInputCallback")
 		self:visible(true)
 		self:playcommand("AssessCandidates", params)
-		-- We have to wait a little bit before adding the input handler.
-		self:sleep(0.25):queuecommand("AddInputCallback")
 	end,
 	AddInputCallbackCommand=function(self)
-		SCREENMAN:GetTopScreen():AddInputCallback(inputHandler)
 		for player in ivalues(PlayerNumber) do
 			SCREENMAN:set_input_redirected(player, true)
+		end
+		-- Queue this command recursively until the ScreenSelectMusic finishes loading
+		if SCREENMAN:GetTopScreen():GetName() ~= "ScreenSelectMusic" then
+			self:sleep(0.01)
+			self:queuecommand("AddInputCallback")
+		else
+			SCREENMAN:GetTopScreen():AddInputCallback(inputHandler)
 		end
 	end,
 	DirectInputToEngineCommand=function(self)


### PR DESCRIPTION
Currently, it's possible to run into the following issues on very slow machines with very large song libraries:
- Mashing inputs before the search result dialog appears can still move the song wheel or start the currently selected song.
- If searching takes more than 250 milliseconds, the game loses input and it's impossible to leave the search result dialog.

This PR restructures this mechanism to redirect the player's input to the results dialog as soon as possible. The redirecting command is queued in a non-blocking manner until the input is redirected successfully.

I tested it on my old machine and queuing every 10 milliseconds does not cause any noticeable slowdowns and I could no longer break the mechanism by mashing random inputs.

I hardcoded the name of `ScreenSelectMusic`, because to according to my research this dialog is not used in any other context. If this can be done in a cleaner way I'd love to hear any suggestions.

Closes #388