### PR TITLE
bugfix: Fix SongSearch with SortOrders that filter the MusicWheel

### DIFF
--- a/BGAnimations/ScreenSelectMusic overlay/SongSearch/InputHandler.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SongSearch/InputHandler.lua
@@ -21,6 +21,18 @@ local input = function(event)
 			if type(songOrExit) ~= "string" then
 				GAMESTATE:SetPreferredSong(songOrExit)
 				local screen = SCREENMAN:GetTopScreen()
+
+				-- some SortOrders reduce the number of songs currently displayed in the MusicWheel.
+				-- GAMESTATE:SetPreferredSong() will correctly set the preferred song, but the MusicWheel
+				-- may not currently have that song to display after screen reload.
+				-- if we're in one of those SortOrders, change the SortOrder to Group as a workaround
+				local current_sort_order = GAMESTATE:GetSortOrder()
+				if (current_sort_order == "SortOrder_Preferred")
+				or (current_sort_order == "SortOrder_Popularity")
+				or (current_sort_order == "SortOrder_Recent") then
+					screen:GetMusicWheel():ChangeSort("SortOrder_Group")
+				end
+
 				screen:SetNextScreenName("ScreenReloadSSM")
 				screen:StartTransitioningScreen("SM_GoToNextScreen")
 			end


### PR DESCRIPTION
Issue #659 points to a broader bug that applies to any active SortOrder that filters the number of songs in the MusicWheel.  This is at least (but perhaps not limited to):
* `SortOrder_Preferred`
* `SortOrder_Recent`
* `SortOrder_Popularity`

These three^ are all possible to get into from Simply-Love-SM5's SortMenu.

I think this behavior should be patched in-engine for the sake of all ITGmania themes, but given SL's [current implementation](<https://github.com/Simply-Love/Simply-Love-SM5/blob/ed98aad9934176c85e8052e238cb04ad09e475d9/BGAnimations/ScreenSelectMusic%20overlay/SongSearch/InputHandler.lua#L22-L25>) of
1. set GAMESTATE's preferred song to the selected search result
2. reload ScreenSelectMusic

it's not immediately clear what an engine-side fix looks like.  We wouldn't want to change the SortOrder every time ScreenSelectMusic reloads.  I can imagine dedicated engine-side methods for song search being worthwhile, but that's a larger effort.

In the meantime, this should address the issue theme-side.