### PR TITLE
track active OptionRow in ScreenOptionsService

### DIFF
--- a/BGAnimations/ScreenOptionsService overlay/ActiveOptionRowState.lua
+++ b/BGAnimations/ScreenOptionsService overlay/ActiveOptionRowState.lua
@@ -1,0 +1,32 @@
+-- after ScreenOptionsService initializes, attempt to set the active OptionRow
+-- based on state that might exist in SL.Global.PrevScreenOptionsServiceRow
+--
+-- this applies to any screens that inherit from ScreenOptionsService, including ScreenOptionsServiceSub
+
+local a = Def.Actor{}
+
+a.InitCommand=function(self)
+	self:queuecommand("SetActiveOptionRow")
+end
+
+-- check if an OptionRow index has been saved for the screen we're currently on.
+-- if so, it tells us we've returned here from a sub-screen, and should set the
+-- active OptionRow
+a.SetActiveOptionRowCommand=function(self)
+	local screen = SCREENMAN:GetTopScreen()
+	local row_index = SL.Global.PrevScreenOptionsServiceRow[screen:GetName()] or 0
+	screen:SetOptionRowIndex(GAMESTATE:GetMasterPlayerNumber(), row_index)
+end
+
+-- when leaving this screen, save the index of the active OptionRow
+a.OffCommand=function(self)
+	local screen = SCREENMAN:GetTopScreen()
+	local row_index = screen:GetCurrentRowIndex(GAMESTATE:GetMasterPlayerNumber())
+  -- if we're on the "Exit" row, save the index for this screen's 1st row
+  if screen:GetNumRows()-1 == row_index then
+    row_index = 0
+  end
+	SL.Global.PrevScreenOptionsServiceRow[screen:GetName()] = row_index
+end
+
+return a

--- a/BGAnimations/ScreenOptionsService overlay/default.lua
+++ b/BGAnimations/ScreenOptionsService overlay/default.lua
@@ -17,10 +17,10 @@ for childscreen_name in THEME:GetMetric("ScreenOptionsService", "LineNames"):gma
 
 	-- We can prepend "Screen" to the beginning of each child screen's Name to transform
 	-- something like "InputOptions" into "ScreenInputOptions".
-	-- From there, we can see metric'c "ScreenInputOptions" has its own LineNames
+	-- From there, we can see metric's "ScreenInputOptions" has its own LineNames
 	-- and split those on commas to get OptionRows that would be available on the next screen.
 	--
-	-- This is is not a safe assumption in other themes (or even everyhere in SL), but I've configured
+	-- This is is not a safe assumption in other themes (or even everywhere in SL), but I've configured
 	-- SL's metrics for ScreenOptionsService and children to Just Work™ for this sort of lookup.
 
 	if THEME:HasMetric("Screen"..childscreen_name, "LineNames") then
@@ -99,6 +99,8 @@ end
 --    some StepMania game types (popn, beat, kickbox, etc.) are not supported in SL
 --    SL only supports official StepMania releases, and a limited range of versions at that
 af[#af+1] = LoadActor("./Support.lua")
+-- -----------------------------------------------------------------------
+af[#af+1] = LoadActor("./ActiveOptionRowState.lua")
 -- -----------------------------------------------------------------------
 
 -- background Quad for side pane

--- a/Scripts/SL_Init.lua
+++ b/Scripts/SL_Init.lua
@@ -152,6 +152,10 @@ local GlobalDefaults = {
 
 			-- TODO(teejusb): We should only initialize this once to save on compute.
 			self.GrooveStatsPlayerOptionKeys = CreateGrooveStatsPlayerOptionKeys()
+
+			-- used to track active OptionRow index when navigating the Operator Menu's many screens and sub-screens
+			-- shaped like: { ScreenOptionsService=3, ScreenVisualOptions=1 }
+			self.PrevScreenOptionsServiceRow = {}
 		end,
 
 		-- These values outside initialize() won't be reset each game cycle,


### PR DESCRIPTION
As noted in https://github.com/itgmania/itgmania/pull/1003, I wanted to improve UX in Simply-Love's Operator Menu by "remembering" what OptionRow you were previously on when going in-and-out of its many screens and sub-screens, like this:

https://github.com/user-attachments/assets/bdc93dcb-6418-48ca-91b6-9efb24df67b4

The current behavior is to always initialize the screen's **first** OptionRow as active.

https://github.com/itgmania/itgmania/pull/1003 needs to be merged for these changes to work correctly.