### PR TITLE
ScreenSelectMusic: Fix cursor when selecting edits

### DIFF
--- a/BGAnimations/ScreenSelectMusic overlay/PerPlayer/Cursor.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/PerPlayer/Cursor.lua
@@ -61,7 +61,10 @@ return Def.Sprite{
 
 	OnCommand=function(self) self:queuecommand("Set") end,
 	CurrentSongChangedMessageCommand=function(self) self:queuecommand("Set") end,
-	["CurrentSteps"..pn.."ChangedMessageCommand"]=function(self) self:queuecommand("Set") end,
+	-- Need to update when either player's selection changes because the other
+	-- player's selection can change which steps are visible.
+	CurrentStepsP1ChangedMessageCommand=function(self) self:queuecommand("Set") end,
+	CurrentStepsP2ChangedMessageCommand=function(self) self:queuecommand("Set") end,
 
 	SetCommand=function(self)
 		local song = GAMESTATE:GetCurrentSong()


### PR DESCRIPTION
The cursor indicating the player's selected steps was not updated when the list of visible steps was changed due to the other player selecting different steps. This caused the cursor to appear at a wrong position.