### PR TITLE
Set preferences when skipping play mode selection

### DIFF
--- a/Scripts/SL-Branches.lua
+++ b/Scripts/SL-Branches.lua
@@ -128,6 +128,8 @@ Branch.AllowScreenSelectPlayMode = function()
 	else
 		-- Set a default game mode if we're skipping the select play mode screen.
 		SL.Global.GameMode = "ITG"
+		SetGameModePreferences()
+		THEME:ReloadMetrics()
 		return Branch.AllowScreenSelectPlayMode2()
 	end
 end


### PR DESCRIPTION
Fixes game preferences not being set to the ITG values when ScreenSelectPlayMode is skipped. The preferences can be different from the ITG values on newly installed setups or if someone had played in Casual mode on the machine before.