### PR TITLE
Fix setting default fail type

### DIFF
--- a/Scripts/SL-OperatorMenuOptions.lua
+++ b/Scripts/SL-OperatorMenuOptions.lua
@@ -133,9 +133,12 @@ OperatorMenuOptionRows.DefaultFailType = function()
 					-- If default_fail is empty, then we need to append the new fail type to the front
 					-- of the DefaultModifiers string.  Otherwise, we need to replace the old fail type
 					-- with the new fail type.
-					if default_fail == "" and (new_fail ~= "failimmediate") then
-						-- if default_mods is empty we cant have the comma
-						if default_mods == "" then
+					if default_fail == "" then
+						if new_fail == "failimmediate" then
+							-- Don't set the fail type if it hadn't been set before and the user
+							-- left the selection at the default option.
+						elseif default_mods == "" then
+							-- if default_mods is empty we cant have the comma
 							PREFSMAN:SetPreference("DefaultModifiers", new_fail)
 						else
 							PREFSMAN:SetPreference("DefaultModifiers", new_fail .. "," .. default_mods)


### PR DESCRIPTION
Fixes default modifiers breaking when doing the following:

1. Start from fresh install with no Preferences.ini.
2. Open the System Options menu.
3. Change the default note skin to something else.
4. Open the Advanced Options menu.
5. Exit by choosing Exit from the bottom.

This results in the DefaultModifiers preference being set to something like

	failimmediateNfailimmediateofailimmediateHfailimmediateifailimmediatedfailimmediateefailimmediateLfailimmediateifailimmediategfailimmediatehfailimmediatetfailimmediatesfailimmediate,failimmediate failimmediateOfailimmediatevfailimmediateefailimmediaterfailimmediatehfailimmediateefailimmediateafailimmediatedfailimmediate,failimmediate failimmediateEfailimmediatenfailimmediatecfailimmediatehfailimmediateafailimmediatenfailimmediatetfailimmediatemfailimmediateefailimmediatenfailimmediatetfailimmediate

The problem was this condition in SL-OperatorMenuOptions:

	if default_fail == "" and (new_fail ~= "failimmediate") then
		...
	else
		string.gsub(default_mods, default_fail, new_fail)

When default_fail is "" and new_fail is "failimmediate", the gsub inserts "failimmediate" between every character in default_mods.