### PR TITLE
Casual Mode should respect the SampleMusicLoop theme preference

### DIFF
--- a/Scripts/SL-SelectMusicHelpers.lua
+++ b/Scripts/SL-SelectMusicHelpers.lua
@@ -14,7 +14,7 @@ play_sample_music = function()
 
 		if songpath and sample_start and sample_len then
 			SOUND:DimMusic(PREFSMAN:GetPreference("SoundVolume"), math.huge)
-			SOUND:PlayMusicPart(songpath, sample_start,sample_len, 0.5, 1.5, true, true)
+			SOUND:PlayMusicPart(songpath, sample_start,sample_len, 0.5, 1.5, ThemePrefs.Get("SampleMusicLoops"), true)
 		else
 			stop_music()
 		end


### PR DESCRIPTION
<img width="1293" height="632" alt="image" src="https://github.com/user-attachments/assets/2f7cf9e6-35b5-455b-8729-554cbdd99193" />


This PR ensures casual mode respects the SampleMusicLoop so the music will only loop if the setting is true.