### PR TITLE
Fix column cues in courses

### DIFF
--- a/BGAnimations/ScreenGameplay in/MeasureCounterAndModsLevel.lua
+++ b/BGAnimations/ScreenGameplay in/MeasureCounterAndModsLevel.lua
@@ -8,10 +8,10 @@ return function(SongNumberInCourse)
 		local pn = ToEnumShortString(player)
 		SL[pn].PlayerOptionsString = GAMESTATE:GetPlayerState(player):GetPlayerOptionsString("ModsLevel_Preferred")
 
-		-- Check if MeasureCounter or ColumnCues are turned on.
+		-- Check if MeasureCounter are turned on.
 		-- We may need to parse the chart
 		local mods = SL[pn].ActiveModifiers
-		if (mods.MeasureCounter and mods.MeasureCounter ~= "None") or mods.ColumnCues then
+		if mods.MeasureCounter and mods.MeasureCounter ~= "None" then
 
 			local steps = nil
 

--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/NoteField/ColumnCues.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/NoteField/ColumnCues.lua
@@ -85,6 +85,19 @@ local af = Def.ActorFrame{
 		self:SetUpdateFunction(Update)
 	end,
 	CurrentSongChangedMessageCommand=function(self)
+		local steps = nil
+		if GAMESTATE:IsCourseMode() then
+			local songIndex = GAMESTATE:GetCourseSongIndex() + 1
+			local trail = GAMESTATE:GetCurrentTrail(player):GetTrailEntries()[songIndex]
+			steps = trail:GetSteps()
+		else
+			steps = GAMESTATE:GetCurrentSteps(player)
+		end
+
+		-- Ensure that SL[pn].Streams.ColumnCues is populated. This will skip
+		-- parsing if SL[pn].Streams is already up to date.
+		ParseChartInfo(steps, pn)
+
 		playerState = GAMESTATE:GetPlayerState(player)
 		columnCues = SL[pn].Streams.ColumnCues
 		curIndex = 1


### PR DESCRIPTION
Fixes column cues appearing at wrong times in courses after the first song.

This was probably intended to work as follows.
1. A CurrentSongChanged message is published when moving to the next song in the course.
2. ScreenGameplay in/default.lua handles the message and calls ParseChartInfo to update SL[pn].Streams for each player.
3. ColumnCues.lua handles the message to read the column cues for the next song from SL[pn].Streams.ColumnCues.

The problem is that there is no guarantee that the message handler in ScreenGameplay in/default.lua runs before the one in ColumnCues.lua, so SL[pn].Streams might contain stale data.

Fixed by changing the message handler in ColumnCues.lua to call ParseChartInfo instead of relying on the data being already there.