### PR TITLE
Fix music wheel spinning after SortMenu is opened

### DIFF
--- a/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
@@ -423,6 +423,8 @@ local t = Def.ActorFrame {
 		for player in ivalues(PlayerNumber) do
 			SCREENMAN:set_input_redirected(player, true)
 		end
+		-- Stop the music wheel in case it's still spinning.
+		screen:GetMusicWheel():Move(0)
 		self:queuecommand("AssessAvailableChoices"):queuecommand("ShowSortMenu")
 		overlay:playcommand("HideTestInput")
 		overlay:playcommand("HideLeaderboard")


### PR DESCRIPTION
Happens when
1. opening the sort menu with Select+Start while holding Left or Right
2. opening the sort menu with Left+Right and releasing one of the keys one on the same frame.

The latter case happens surprisingly often since switching to another song can cause some lag on lower end machines.