### PR TITLE
Fix error in title menu when pre-gameplay screens are disabled

### DIFF
--- a/Scripts/SL-PlayerOptions.lua
+++ b/Scripts/SL-PlayerOptions.lua
@@ -4,8 +4,12 @@
 
 local GetModsAndPlayerOptions = function(player)
 	local mods = SL[ToEnumShortString(player)].ActiveModifiers
-	local topscreen = SCREENMAN:GetTopScreen():GetName()
-	local modslevel = topscreen  == "ScreenEditOptions" and "ModsLevel_Stage" or "ModsLevel_Preferred"
+	-- This can get called already when loading ScreenTitleMenu if all screens
+	-- before and including ScreenSelectPlayMode are disabled. Top screen will
+	-- be nil in that case.
+	local topscreen = SCREENMAN:GetTopScreen()
+	local topscreenname = topscreen and topscreen:GetName()
+	local modslevel = topscreenname == "ScreenEditOptions" and "ModsLevel_Stage" or "ModsLevel_Preferred"
 	local playeroptions = GAMESTATE:GetPlayerState(player):GetPlayerOptions(modslevel)
 
 	return mods, playeroptions


### PR DESCRIPTION
Attempting to use a nil value during evaluation of Choice1 in ScreenTitleMenu broke the Dance Mode option. Fixed by adding a nil check.

The problem occurs when all screens before and including ScreenSelectPlayMode are disabled and the default style is set to 2 players.
1. Branch.AfterScreenSelectColor calls GAMESTATE:JoinPlayer for both players.
2. Branch.AllowScreenSelectPlayMode calls SetGameModePreferences. (Was added in commit de002187.)
3. Because of the JoinPlayer calls, there are two human players, so SetGameModePreferences tries to load their options.
4. GetModsAndPlayerOptions tries to check the name of the top screen, but SCREENMAN:GetTopScreen returns nil because the screen is being initialized and not yet the current screen.