### PR TITLE
Disable the codes for resetting player options

### DIFF
--- a/metrics.ini
+++ b/metrics.ini
@@ -1740,6 +1740,8 @@ NextGroup=""
 PrevGroup=""
 Hidden=""
 RandomVanish=""
+CancelAll=""
+CancelAllPlayerOptions=""
 
 # this has been replaced with Lua-driven screenshot saving
 SaveScreenshot1=""


### PR DESCRIPTION
Disables the CancelAll and CancelAllPlayerOptions codes, which are easy to enter unintentionally and not very useful. The codes reset the player options, including scroll speed, mini and noteskin, without any indication of what happened. This is very confusing when entering the code unknowingly.

Probably fixes #335.