### PR TITLE
SortMenu: Fix input handler removed while menu is open

### DIFF
--- a/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
@@ -355,7 +355,10 @@ local wheel_options = {
 local t = Def.ActorFrame {
 	Name="SortMenu",
 	-- Always ensure player input is directed back to the engine when initializing SelectMusic.
-	InitCommand=function(self) self:visible(false):queuecommand("DirectInputToEngine") end,
+	-- Must to use playcommand here instead of queuecommand. If the player
+	-- enters the code early, queuecommand could run after the menu is opened
+	-- and direct input back to engine while the menu is still open.
+	InitCommand=function(self) self:visible(false):playcommand("DirectInputToEngine") end,
 	-- Always ensure player input is directed back to the engine when leaving SelectMusic.
 	OffCommand=function(self) self:playcommand("DirectInputToEngine") end,
 	-- Figure out which choices to put in the SortWheel based on various current conditions.


### PR DESCRIPTION
Fixes input getting directed back to the engine after opening the sort menu when the player enters the menu code early.

The DirectInputToEngine command queued in the InitCommand can run after the DirectInputToSortMenuCommand if the player enters the code right when ScreenSelectMusic opens. If that happens, the sort menu stays open but receives no input until the player re-enters the menu code. Fixed by changing to playcommand.