### PR TITLE
Make the StepStatistics quad alpha be based on the players' bg filter

### DIFF
--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/StepStatistics/DarkBackground.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/StepStatistics/DarkBackground.lua
@@ -2,10 +2,12 @@ local player, header_height, width = unpack(...)
 
 local style = GAMESTATE:GetCurrentStyle():GetName()
 
+local FilterAlpha = BackgroundFilterValues()
+local alpha = clamp(FilterAlpha[SL[ToEnumShortString(player)].ActiveModifiers.BackgroundFilter]/100 or 0, 0.25, 0.9)
 if style ~= "double" then
 	return Def.Quad{
 		InitCommand=function(self)
-			self:diffuse(0, 0, 0, 0.95):setsize(width, _screen.h):y(-header_height)
+			self:diffuse(0, 0, 0, alpha):setsize(width, _screen.h):y(-header_height)
 		end
 	}
 else
@@ -15,14 +17,14 @@ else
 	-- left side
 	af[#af+1] = Def.Quad{
 		InitCommand=function(self)
-			self:diffuse(0, 0, 0, 0.95):setsize(200, _screen.h):x(-GetNotefieldWidth()/2):y(-header_height):halign(1);
+			self:diffuse(0, 0, 0, alpha):setsize(200, _screen.h):x(-GetNotefieldWidth()/2):y(-header_height):halign(1);
 		end
 	}
 	
 	-- right side
 	af[#af+1] = Def.Quad{
 		InitCommand=function(self)
-			self:diffuse(0, 0, 0, 0.95):setsize(200, _screen.h):x(0 + GetNotefieldWidth()/2):y(-header_height):halign(0);
+			self:diffuse(0, 0, 0, alpha):setsize(200, _screen.h):x(0 + GetNotefieldWidth()/2):y(-header_height):halign(0);
 		end
 	}
 	

--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/StepStatistics/DensityGraph.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/StepStatistics/DensityGraph.lua
@@ -21,7 +21,8 @@ local BothUsingStepStats = (#GAMESTATE:GetHumanPlayers()==2
 and SL.P1.ActiveModifiers.DataVisualizations == "Step Statistics"
 and SL.P2.ActiveModifiers.DataVisualizations == "Step Statistics")
 -- -----------------------------------------------------------------------
-
+local mods = SL[pn].ActiveModifiers
+local FilterAlpha = clamp(BackgroundFilterValues()[mods.BackgroundFilter]/100 or 0, 0.25, 1)
 -- max_seconds is how many seconds of a stepchart we want visualized on-screen at once.
 -- For very long songs (longer than, say, 10 minutes) the density graph becomes too
 -- horizontally compressed (squeezed in, so to speak) and it's dificult to get any useful
@@ -65,6 +66,7 @@ local bg = Def.Quad{
 		self:zoomto(width, height)
 			:align(0,0)
 			:diffuse(color("#1E282F"))
+			:diffusealpha(FilterAlpha)
 	end
 }
 
@@ -77,6 +79,7 @@ local histogram_amv = Scrolling_NPS_Histogram(player, width, height)..{
 	OnCommand=function(self)
 		-- offset the graph's x-position by half the thickness of the LifeLine
 		self:xy( LifeLineThickness/2, height )
+		self:diffusealpha(FilterAlpha)
 	end,
 	PeakNPSUpdatedMessageCommand=function(self) self:queuecommand("Size") end,
 	SizeCommand=function(self)

--- a/BGAnimations/ScreenGameplay underlay/Shared/VersusStepStatistics.lua
+++ b/BGAnimations/ScreenGameplay underlay/Shared/VersusStepStatistics.lua
@@ -26,26 +26,15 @@ local ShouldDisplayStats = function()
     return shouldDisplay
 end
 
+-- Returns a table of the background filter alpha values for each player
+-- used to diffuse the step statistics bg quad accordingly
 local determineFilterAlphas = function()
-    local totalFilterAlpha = 0
-    local numPlayersShowing = 0
-
-    for _, player in ipairs(Players) do
+    local alphas = {}
+    for player in ivalues(Players) do
         local pn = ToEnumShortString(player)
-        if ShouldDisplayStatsForPlayer(player) then
-            totalFilterAlpha = totalFilterAlpha + (FilterAlpha[SL[pn].ActiveModifiers.BackgroundFilter]/100 or 0)
-            numPlayersShowing = numPlayersShowing + 1
-        end
+        alphas[player] = clamp(FilterAlpha[SL[pn].ActiveModifiers.BackgroundFilter]/100 or 0, 0.25, 0.9)
     end
-
-    if numPlayersShowing == 0 then
-        return 0
-    end
-
-    local averageFilterAlpha = totalFilterAlpha / numPlayersShowing
-    averageFilterAlpha = clamp(averageFilterAlpha, 0.25, 0.9)
-
-    return averageFilterAlpha
+    return alphas
 end
 
 if not ShouldDisplayStats() then
@@ -58,20 +47,15 @@ local af = Def.ActorFrame{
     end
 }
 
-local alpha = determineFilterAlphas()
-for player in ivalues(Players) do
-    if ShouldDisplayStatsForPlayer(player) and #Players > 1 then
-	
-		local pn = tonumber(player:sub(-1))
-	
-        af[#af+1] = Def.Quad{
-            InitCommand=function(self)
-                self:diffuse(0, 0, 0, alpha)   
-				self:zoomto(150, SCREEN_HEIGHT)
-            end,
-        }
-        
-    end
+local playerFilters = determineFilterAlphas()
+if ShouldDisplayStats() then
+    af[#af+1] = Def.Quad{
+        InitCommand=function(self)
+            self:diffuseleftedge(0,0,0, playerFilters[PLAYER_1] or 0.25)
+                :diffuserightedge(0,0,0, playerFilters[PLAYER_2] or 0.25)
+            self:zoomto(150, SCREEN_HEIGHT)
+        end,
+    }
 end
 
 for player in ivalues(Players) do

--- a/BGAnimations/ScreenGameplay underlay/Shared/VersusStepStatistics.lua
+++ b/BGAnimations/ScreenGameplay underlay/Shared/VersusStepStatistics.lua
@@ -1,5 +1,6 @@
 local Players = GAMESTATE:GetHumanPlayers()
 local IsUltraWide = (GetScreenAspectRatio() > 21/9)
+local FilterAlpha = BackgroundFilterValues()
 
 local ShouldDisplayStatsForPlayer = function(player)
     local pn = ToEnumShortString(player)
@@ -25,6 +26,28 @@ local ShouldDisplayStats = function()
     return shouldDisplay
 end
 
+local determineFilterAlphas = function()
+    local totalFilterAlpha = 0
+    local numPlayersShowing = 0
+
+    for _, player in ipairs(Players) do
+        local pn = ToEnumShortString(player)
+        if ShouldDisplayStatsForPlayer(player) then
+            totalFilterAlpha = totalFilterAlpha + (FilterAlpha[SL[pn].ActiveModifiers.BackgroundFilter]/100 or 0)
+            numPlayersShowing = numPlayersShowing + 1
+        end
+    end
+
+    if numPlayersShowing == 0 then
+        return 0
+    end
+
+    local averageFilterAlpha = totalFilterAlpha / numPlayersShowing
+    averageFilterAlpha = clamp(averageFilterAlpha, 0.25, 0.9)
+
+    return averageFilterAlpha
+end
+
 if not ShouldDisplayStats() then
     return
 end
@@ -35,6 +58,7 @@ local af = Def.ActorFrame{
     end
 }
 
+local alpha = determineFilterAlphas()
 for player in ivalues(Players) do
     if ShouldDisplayStatsForPlayer(player) and #Players > 1 then
 	
@@ -42,7 +66,7 @@ for player in ivalues(Players) do
 	
         af[#af+1] = Def.Quad{
             InitCommand=function(self)
-                self:diffuse(Color.Black)
+                self:diffuse(0, 0, 0, alpha)   
 				self:zoomto(150, SCREEN_HEIGHT)
             end,
         }


### PR DESCRIPTION
This commit aims to make the StepStatistics background quad link with the players' Background Filters.

I've had a few scenarios happen both in my own testing and also live when just genuinely playing where I _needed_ to see the background but the StepStatistics pane took a chunk off the screen. This is notably an issue when playing with 2 players as one player can "force" hide the middle of the screen by using StepStatistics. I'm one of those players who doesn't use a filter so this was an especially bothersome thing for me.


> Previously the quad was always fully black meaning even if a player wanted to show their background or minimally darken it
the pane would always take a huge chunk of the screen. 
> A Player who uses no or minimal filter and no step statistics, playing with a player with darkest filter + step statistics... in this scenario the screen "real-estate" leans more towards hiding the background with no balance.


In this commit if you are playing alone, the step statistics will align with your filter setting (if no filter, a minimum alpha of 0.25).
If you are playing with someone else the average of your filters will be used to balance the preferences of both players. 
