### PR TITLE
Revert "SortMenu: Fix input handler removed while menu is open"

### DIFF
--- a/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
@@ -355,10 +355,7 @@ local wheel_options = {
 local t = Def.ActorFrame {
 	Name="SortMenu",
 	-- Always ensure player input is directed back to the engine when initializing SelectMusic.
-	-- Must to use playcommand here instead of queuecommand. If the player
-	-- enters the code early, queuecommand could run after the menu is opened
-	-- and direct input back to engine while the menu is still open.
-	InitCommand=function(self) self:visible(false):playcommand("DirectInputToEngine") end,
+	InitCommand=function(self) self:visible(false):queuecommand("DirectInputToEngine") end,
 	-- Always ensure player input is directed back to the engine when leaving SelectMusic.
 	OffCommand=function(self) self:playcommand("DirectInputToEngine") end,
 	-- Figure out which choices to put in the SortWheel based on various current conditions.


### PR DESCRIPTION
This commit reverts: https://github.com/Simply-Love/Simply-Love-SM5/pull/685 as it throws the following error:

<img width="2552" height="153" alt="image" src="https://github.com/user-attachments/assets/36d10a13-8b0b-43ad-a9f7-62276552b008" />

This is because using playcommand calls DirectInputToEngine too early (during Init) and it's unable to GetTopScreen() at this stage. 
