### PR TITLE
Add handling for WheelLocked state

### DIFF
--- a/BGAnimations/ScreenSelectMusic overlay/PreserveMenuTimer.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/PreserveMenuTimer.lua
@@ -1,19 +1,20 @@
 local transitioning_out = false
-
+local menuTimerEnabled = PREFSMAN:GetPreference("MenuTimer")
 local Update = function(self, dt)
 	if not transitioning_out then
-		SL.Global.MenuTimer.ScreenSelectMusic = SCREENMAN:GetTopScreen():GetChild("Timer"):GetSeconds()
+		-- if the MenuTimer is being used, save the current number of seconds remaining
+		-- before transitioning to the next screen. In this manner, we can reinstate this
+		-- value if the player opts to return to ScreenSelectMusic from ScreenPlayerOptions.
+		if menuTimerEnabled then
+			SL.Global.MenuTimer.ScreenSelectMusic = SCREENMAN:GetTopScreen():GetChild("Timer"):GetSeconds()
+		end
+		SL.Global.WheelLocked = SCREENMAN:GetTopScreen():GetMusicWheel():IsLocked()
 	end
 end
 
 return Def.ActorFrame{
 	InitCommand=function(self)
-		-- if the MenuTimer is being used, save the current number of seconds remaining
-		-- before transitioning to the next screen.  In this manner, we can reinstate this
-		-- value if the player opts to return to ScreenSelectMusic from ScreenPlayerOptions.
-		if PREFSMAN:GetPreference("MenuTimer") then
-			self:SetUpdateFunction(Update)
-		end
+		self:SetUpdateFunction(Update)
 	end,
 	ShowPressStartForOptionsCommand=function(self)
 		transitioning_out = true

--- a/BGAnimations/ScreenSelectMusic overlay/SortMenu/SortMenu_InputHandler.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SortMenu/SortMenu_InputHandler.lua
@@ -8,6 +8,10 @@ local input = function(event)
 	local screen   = SCREENMAN:GetTopScreen()
 	local overlay  = screen:GetChild("Overlay")
 	local sortmenu = overlay:GetChild("SortMenu")
+	if SCREENMAN:GetTopScreen():GetMusicWheel():IsLocked() then
+		overlay:queuecommand("DirectInputToEngine")
+	end
+	
 	if event.type ~= "InputEventType_Release" then
 		if event.GameButton == "MenuRight" or event.GameButton == "MenuDown" then
 			sort_wheel:scroll_by_amount(1)

--- a/Scripts/SL-PlayerOptions.lua
+++ b/Scripts/SL-PlayerOptions.lua
@@ -782,14 +782,14 @@ local Overrides = {
 	ScreenAfterPlayerOptions = {
 		Values = function()
 			local choices = { "Gameplay", "Select Music", "Options2", "Options3"  }
-			if SL.Global.MenuTimer.ScreenSelectMusic < 1 then table.remove(choices, 2) end
+			if SL.Global.MenuTimer.ScreenSelectMusic < 1  or SL.Global.MusicWheelLocked == true then table.remove(choices, 2) end
 			return choices
 		end,
 		OneChoiceForAllPlayers = true,
 		SaveSelections = function(self, list, pn)
 			if list[1] then SL.Global.ScreenAfter.PlayerOptions = Branch.GameplayScreen() end
 
-			if SL.Global.MenuTimer.ScreenSelectMusic > 1 then
+			if SL.Global.MenuTimer.ScreenSelectMusic > 1 and SL.Global.MusicWheelLocked == false then
 				if list[2] then SL.Global.ScreenAfter.PlayerOptions = SelectMusicOrCourse() end
 				if list[3] then SL.Global.ScreenAfter.PlayerOptions = "ScreenPlayerOptions2" end
 				if list[4] then SL.Global.ScreenAfter.PlayerOptions = "ScreenPlayerOptions3" end
@@ -803,14 +803,14 @@ local Overrides = {
 	ScreenAfterPlayerOptions2 = {
 		Values = function()
 			local choices = { "Gameplay", "Select Music", "Options1", "Options3"  }
-			if SL.Global.MenuTimer.ScreenSelectMusic < 1 then table.remove(choices, 2) end
+			if SL.Global.MenuTimer.ScreenSelectMusic < 1  or SL.Global.MusicWheelLocked == true	 then table.remove(choices, 2) end
 			return choices
 		end,
 		OneChoiceForAllPlayers = true,
 		SaveSelections = function(self, list, pn)
 			if list[1] then SL.Global.ScreenAfter.PlayerOptions2 = Branch.GameplayScreen() end
 
-			if SL.Global.MenuTimer.ScreenSelectMusic > 1 then
+			if SL.Global.MenuTimer.ScreenSelectMusic > 1 and SL.Global.MusicWheelLocked == false then
 				if list[2] then SL.Global.ScreenAfter.PlayerOptions2 = SelectMusicOrCourse() end
 				if list[3] then SL.Global.ScreenAfter.PlayerOptions2 = "ScreenPlayerOptions" end
 				if list[4] then SL.Global.ScreenAfter.PlayerOptions2 = "ScreenPlayerOptions3" end
@@ -825,14 +825,14 @@ local Overrides = {
 	ScreenAfterPlayerOptions3 = {
 		Values = function()
 			local choices = { "Gameplay", "Select Music", "Options1", "Options2"  }
-			if SL.Global.MenuTimer.ScreenSelectMusic < 1 then table.remove(choices, 2) end
+			if SL.Global.MenuTimer.ScreenSelectMusic < 1  or SL.Global.MusicWheelLocked == true then table.remove(choices, 2) end
 			return choices
 		end,
 		OneChoiceForAllPlayers = true,
 		SaveSelections = function(self, list, pn)
 			if list[1] then SL.Global.ScreenAfter.PlayerOptions3 = Branch.GameplayScreen() end
 
-			if SL.Global.MenuTimer.ScreenSelectMusic > 1 then
+			if SL.Global.MenuTimer.ScreenSelectMusic > 1 and SL.Global.MusicWheelLocked == false then
 				if list[2] then SL.Global.ScreenAfter.PlayerOptions3 = SelectMusicOrCourse() end
 				if list[3] then SL.Global.ScreenAfter.PlayerOptions3 = "ScreenPlayerOptions" end
 				if list[4] then SL.Global.ScreenAfter.PlayerOptions3 = "ScreenPlayerOptions2" end

--- a/Scripts/SL_Init.lua
+++ b/Scripts/SL_Init.lua
@@ -149,6 +149,9 @@ local GlobalDefaults = {
 			self.TimeAtSessionStart = nil
 			self.SampleMusicLoops = ThemePrefs.Get("SampleMusicLoops")
 
+			-- Is the music wheel locked? Useful when loading overlay screens
+			self.MusicWheelLocked = false
+			
 			self.GameplayReloadCheck = false
 			-- How long to wait before displaying a "cue"
 			self.ColumnCueMinTime = 1.5


### PR DESCRIPTION
Theme additions related to: https://github.com/itgmania/itgmania/pull/1123

This is to add theme handling for when the MusicWheel is locked (even before the above PR the MusicWheel could be "locked" through a few means but things like the PlayerOptions menu hadn't accounted for it).

Prevents using the Sort Menu or using the "back out of player options trick" to get around the wheel being locked.