### PR TITLE
Edit "AllowScreenSelectPlayMode" logic to account for DefaultGameMode

### DIFF
--- a/BGAnimations/ScreenSelectPlayMode underlay/default.lua
+++ b/BGAnimations/ScreenSelectPlayMode underlay/default.lua
@@ -31,6 +31,23 @@ local Update = function(af, delta)
 	end
 end
 
+local InputHandler = function(event)
+	if not event.PlayerNumber or not event.button then return false end
+
+	if event.type == "InputEventType_FirstPress" then
+		if event.GameButton == "Start" then
+			if ScreenName=="ScreenSelectPlayMode" or ScreenName=="ScreenSelectPlayModeThonk" then
+				SL.Global.GameMode = choices[cursor.index+1]
+				-- now that a GameMode has been selected, set related preferences
+				SetGameModePreferences()
+				-- and reload the theme's Metrics
+				THEME:ReloadMetrics()
+				SCREENMAN:GetTopScreen():StartTransitioningScreen("SM_GoToNextScreen")
+			end
+		end
+	end
+end
+
 local t = Def.ActorFrame{
 	InitCommand=function(self)
 		self:SetUpdateFunction( Update )
@@ -49,24 +66,9 @@ local t = Def.ActorFrame{
 			choices[#choices+1] = choice
 			choice_actors[#choice_actors+1] = TopScreen:GetChild("IconChoice"..choice)
 		end
+    	SCREENMAN:GetTopScreen():AddInputCallback(InputHandler)
 
 		self:queuecommand("Update")
-	end,
-	MenuStartP1MessageCommand=function(self)
-		if ScreenName=="ScreenSelectPlayMode" or ScreenName=="ScreenSelectPlayModeThonk" then
-			-- set the GameMode now; we'll use it throughout the theme
-			-- to set certain Gameplay settings and determine which screen comes next
-			SL.Global.GameMode = choices[cursor.index+1]
-		end
-		SCREENMAN:GetTopScreen():StartTransitioningScreen("SM_GoToNextScreen")
-	end,
-	MenuStartP2MessageCommand=function(self)
-		if ScreenName=="ScreenSelectPlayMode" or ScreenName=="ScreenSelectPlayModeThonk" then
-			-- set the GameMode now; we'll use it throughout the theme
-			-- to set certain Gameplay settings and determine which screen comes next
-			SL.Global.GameMode = choices[cursor.index+1]
-		end
-		SCREENMAN:GetTopScreen():StartTransitioningScreen("SM_GoToNextScreen")
 	end,
 	-- side mask
 	Def.Quad{

--- a/BGAnimations/ScreenSelectPlayMode underlay/default.lua
+++ b/BGAnimations/ScreenSelectPlayMode underlay/default.lua
@@ -52,18 +52,22 @@ local t = Def.ActorFrame{
 
 		self:queuecommand("Update")
 	end,
-	OffCommand=function(self)
+	MenuStartP1MessageCommand=function(self)
 		if ScreenName=="ScreenSelectPlayMode" or ScreenName=="ScreenSelectPlayModeThonk" then
 			-- set the GameMode now; we'll use it throughout the theme
 			-- to set certain Gameplay settings and determine which screen comes next
 			SL.Global.GameMode = choices[cursor.index+1]
-			-- now that a GameMode has been selected, set related preferences
-			SetGameModePreferences()
-			-- and reload the theme's Metrics
-			THEME:ReloadMetrics()
 		end
+		SCREENMAN:GetTopScreen():StartTransitioningScreen("SM_GoToNextScreen")
 	end,
-
+	MenuStartP2MessageCommand=function(self)
+		if ScreenName=="ScreenSelectPlayMode" or ScreenName=="ScreenSelectPlayModeThonk" then
+			-- set the GameMode now; we'll use it throughout the theme
+			-- to set certain Gameplay settings and determine which screen comes next
+			SL.Global.GameMode = choices[cursor.index+1]
+		end
+		SCREENMAN:GetTopScreen():StartTransitioningScreen("SM_GoToNextScreen")
+	end,
 	-- side mask
 	Def.Quad{
 		InitCommand=function(self) self:zoomto(450, 450):diffuse(1,1,1,1):x(375):MaskSource() end

--- a/Scripts/SL-Branches.lua
+++ b/Scripts/SL-Branches.lua
@@ -126,15 +126,15 @@ Branch.AllowScreenSelectPlayMode = function()
 	if ThemePrefs.Get("AllowScreenSelectPlayMode") then
 		return "ScreenSelectPlayMode"
 	else
-		-- Set a default game mode if we're skipping the select play mode screen.
-		SL.Global.GameMode = "ITG"
-		SetGameModePreferences()
-		THEME:ReloadMetrics()
 		return Branch.AllowScreenSelectPlayMode2()
 	end
 end
 
 Branch.AllowScreenSelectPlayMode2 = function()
+	-- now that a GameMode has been selected (or defaulted), set related preferences
+	SetGameModePreferences()
+	-- and reload the theme's Metrics
+	THEME:ReloadMetrics()
 	if SL.Global.GameMode == "ITG" and ThemePrefs.Get("AllowScreenSelectPlayMode2") then
 		return "ScreenSelectPlayMode2"
 	else

--- a/metrics.ini
+++ b/metrics.ini
@@ -164,13 +164,13 @@ TimerSeconds=20
 Class="ScreenSelectMaster"
 Fallback="ScreenSelectMaster"
 PrevScreen=Branch.TitleMenu()
-
+NextScreen=Branch.AllowScreenSelectPlayMode2()
 ShowFooter=true
 TimerSeconds=20
 
 ChoiceNames="Casual,ITG"
-ChoiceCasual="name,Casual; screen,ScreenProfileLoad"
-ChoiceITG="name,ITG; screen,"..Branch.AllowScreenSelectPlayMode2()
+ChoiceCasual="name,Casual"
+ChoiceITG="name,ITG;"
 
 
 DefaultChoice=SL.Global.GameMode


### PR DESCRIPTION
This addresses https://github.com/Simply-Love/Simply-Love-SM5/issues/686

Modifies the "AllowScreenSelectPlayMode" logic to account for DefaultGameMode theme preference

The previous implementation didn't account for DefaultGameMode which is set on Init
- If Casual Mode is your DefaultGameMode you are able to view the PlayMode2 screen again if you chose ITG
- ITG is no longer forced as the game mode if you decide to disable the SelectPlayMode screens
- Moved Branch.AllowScreenSelectPlayMode2 call to be AFTER a selection has been made
(previously was happening beforehand so your choice didn't actually matter, was based on DefaultGameMode indirectly)