### PR TITLE
Update the Sort Menu so that ChangeableStyles is reevaluated on entry

### DIFF
--- a/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
@@ -233,40 +233,61 @@ local function AddPlaylists()
 	return player_sort_options
 end
 
-local function GetChangeableStyles(style)
+
+local function GetChangeableStyles()
+	local style = GAMESTATE:GetCurrentStyle():GetName():gsub("8", "")
 	local available_styles = {}
 	-- Allow players to switch from single to double and from double to single
 	-- but only present these options if Joint Double or Joint Premium is enabled
 	-- and we're not in "AutoSetStyle" mode (all styles presented simultaneously like PIU does)
 	
-	if THEME:GetMetric("Common", "AutoSetStyle") == false
-	and not (PREFSMAN:GetPreference("Premium") == "Premium_Off" 
-	and GAMESTATE:GetCoinMode() == "CoinMode_Pay") then
-		if style == "single" then
-			table.insert(available_styles, {"ChangeStyle", "Double"})
-			if ThemePrefs.Get("AllowDanceSolo") then
-				table.insert(available_styles, {"ChangeStyle", "Solo"})
-			end
-		elseif style == "double" then
-			table.insert(available_styles, {"ChangeStyle", "Single"})
-			if ThemePrefs.Get("AllowDanceSolo") then
-				table.insert(available_styles, {"ChangeStyle", "Solo"})
-			end
-		elseif style == "solo" then
-			table.insert(available_styles, {"ChangeStyle", "Single"})
-			table.insert(available_styles, {"ChangeStyle", "Double"})
-		-- Couple doesn't have enough content for people to be able to switch into it
-		-- However, if for some reason you end up in couples mode, you should be able to
-		-- escape
-		elseif style == "couple" then
-			table.insert(available_styles, {"ChangeStyle", "Versus"})
-		-- Routine is not ready for use yet, but it might be soon.
-		-- This can be uncommented at that time to allow switching from versus into routine.
-		-- elseif style == "versus" then
-		-- 	table.insert(available_styles, {"ChangeStyle", "Routine"})
+	if THEME:GetMetric("Common", "AutoSetStyle") == true then
+		-- Check number of players
+		if ThemePrefs.Get("AllowDanceSolo") then
+			table.insert(available_styles, {{"ChangeStyle", "Solo"}, GAMESTATE:GetNumPlayersEnabled() == 1  })
 		end
-		return available_styles
+		table.insert(available_styles, {{"ChangeStyle", "Single"}, GAMESTATE:GetNumPlayersEnabled() == 1  })
+
+		table.insert(available_styles, {{"ChangeStyle", "Double"}, GAMESTATE:GetNumPlayersEnabled() == 1  })
+		table.insert(available_styles, {{"ChangeStyle", "Versus"}, not (GAMESTATE:GetNumPlayersEnabled() == 1)  })
+		table.insert(available_styles, {{"ChangeStyle", "Routine"}, not (GAMESTATE:GetNumPlayersEnabled() == 1)  })
+		table.insert(available_styles, {{"ChangeStyle", "Couple"}, not (GAMESTATE:GetNumPlayersEnabled() == 1) })
+	else 
+		if not (PREFSMAN:GetPreference("Premium") == "Premium_Off" and GAMESTATE:GetCoinMode() == "CoinMode_Pay") then
+			if style == "single" then
+				table.insert(available_styles, {{"ChangeStyle", "Double"}})
+				if ThemePrefs.Get("AllowDanceSolo") then
+					table.insert(available_styles, {{"ChangeStyle", "Solo"}})
+				end
+			elseif style == "double" then
+				table.insert(available_styles, {{"ChangeStyle", "Single"}})
+				if ThemePrefs.Get("AllowDanceSolo") then
+					table.insert(available_styles, {{"ChangeStyle", "Solo"}})
+				end
+			elseif style == "solo" then
+				table.insert(available_styles, {{"ChangeStyle", "Single"}})
+				table.insert(available_styles, {{"ChangeStyle", "Double"}})
+			-- Couple doesn't have enough content for people to be able to switch into it
+			-- However, if for some reason you end up in couples mode, you should be able to
+			-- escape
+			elseif style == "couple" then
+				table.insert(available_styles, {{"ChangeStyle", "Versus"}})
+				table.insert(available_styles, {{"ChangeStyle", "Routine"}})
+			elseif style == "routine" then
+				table.insert(available_styles, {{"ChangeStyle", "Versus"}})
+				table.insert(available_styles, {{"ChangeStyle", "Couple"}})
+			-- Routine is not ready for use yet, but it might be soon.
+			-- This can be uncommented at that time to allow switching from versus into routine.
+			-- elseif style == "versus" then
+			--	table.insert(available_styles, {{"ChangeStyle", "Routine"}})
+			--	table.insert(available_styles, {{"ChangeStyle", "Couple"}})
+			end
+			-- table.insert(available_styles, {{"ChangeStyle", "All"}})
+
+		end
 	end
+
+	return available_styles
 end
 local style = GAMESTATE:GetCurrentStyle():GetName():gsub("8", "")
 local wheel_options = {
@@ -327,13 +348,11 @@ local wheel_options = {
 	},
 	{
 		{"", "CategoryStyles"},
-		{
-			GetChangeableStyles(style),
-		}
+		GetChangeableStyles,
 	},
 	{
 		{"", "CategoryPlaylists"},
-		AddPlaylists(),
+		AddPlaylists,
 	},
 	{ {"SortBy", "Group"} },
 	{ {"SortBy", "Title"} },
@@ -365,26 +384,26 @@ local t = Def.ActorFrame {
 	EnterCategoryMessageCommand=function(self, params)
 		local category = params.Category
 		lastCategory = params.Category
-		local style = GAMESTATE:GetCurrentStyle():GetName():gsub("8", "")
 		local filtered_wheel_options = {}
 		for i=1, #wheel_options do
 			local option = wheel_options[i]
-			if option ~= nil then
-				-- Only worry about options with a second element that is a table
-				if type(option[2]) == "table" then
-					-- If the first element of the option is the same as the category we're entering
-					if option[1][2] == category then
-						-- Copy the second element of the option to the wheel_options table
-						local sub_options = {}
-						for j=1, #option[2] do
-							local sub_option = option[2][j]
-							if type(sub_option[2]) == "function" then
-								if sub_option[2]() then
-									table.insert(filtered_wheel_options, sub_option[1])
-								end
-							elseif sub_option[2] == nil or sub_option[2] == true then
+			if option ~= nil and option[1] ~= nil and option[1][2] == category then
+				local source_sub_options = nil
+				-- Allow categories to specify their submenu via a function
+				if type(option[2]) == "function" and option[1][1] == "" then
+					source_sub_options = option[2]() or {}
+				elseif type(option[2]) == "table" then
+					source_sub_options = option[2]
+				end
+				if source_sub_options ~= nil then
+					for j=1, #source_sub_options do
+						local sub_option = source_sub_options[j]
+						if type(sub_option[2]) == "function" then
+							if sub_option[2]() then
 								table.insert(filtered_wheel_options, sub_option[1])
 							end
+						elseif sub_option[2] == nil or sub_option[2] == true then
+							table.insert(filtered_wheel_options, sub_option[1])
 						end
 					end
 				end
@@ -477,15 +496,24 @@ local t = Def.ActorFrame {
 		for i=1, #wheel_options do
 			local option = wheel_options[i]
 			if option ~= nil then
-				if type(option[2]) == "table" then
+				-- If this is a category (empty top text) and uses either
+				-- a table or a function as its submenu source, resolve it
+				local is_category = type(option[1]) == "table" and option[1][1] == "" and option[1][2] ~= nil
+				if is_category and (type(option[2]) == "table" or type(option[2]) == "function") then
+					local source_sub_options
+					if type(option[2]) == "function" then
+						source_sub_options = option[2]() or {}
+					else
+						source_sub_options = option[2]
+					end
 					local sub_options = {}
-					for j=1, #option[2] do
-						local sub_option = option[2][j]
-					if type(sub_option[2]) == "function" then
-						if sub_option[2]() then
-							table.insert(sub_options, sub_option)
-						end
-					elseif sub_option[2] == nil or sub_option[2] == true then
+					for j=1, #source_sub_options do
+						local sub_option = source_sub_options[j]
+						if type(sub_option[2]) == "function" then
+							if sub_option[2]() then
+								table.insert(sub_options, sub_option)
+							end
+						elseif sub_option[2] == nil or sub_option[2] == true then
 							table.insert(sub_options, sub_option)
 						end
 					end


### PR DESCRIPTION
This fixes a bug where the Change Style option in the sort menu did not have it's conditions re-evaluated when entering the sort menu. This would present an issue where for exmaple Change Style would show up even if there were no styles to change to. You can reproduce this by having 1 player in, look at the Sort Menu and you'll see "Doubles". Late join with a second person and notice that "Doubles" is still there.

This commit also updates the logic of ChangeStyle to account for various preferences the user could have set such as AutoSetStyle which previously did not show the menu proper.

