### PR TITLE
SortMenu: Fix input handler removed while menu is open

### DIFF
--- a/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
@@ -354,8 +354,7 @@ local wheel_options = {
 
 local t = Def.ActorFrame {
 	Name="SortMenu",
-	-- Always ensure player input is directed back to the engine when initializing SelectMusic.
-	InitCommand=function(self) self:visible(false):queuecommand("DirectInputToEngine") end,
+	InitCommand=function(self) self:visible(false) end,
 	-- Always ensure player input is directed back to the engine when leaving SelectMusic.
 	OffCommand=function(self) self:playcommand("DirectInputToEngine") end,
 	-- Figure out which choices to put in the SortWheel based on various current conditions.


### PR DESCRIPTION
Second attempt at fixing this. Turns out that input redirections were changed to reset on screen changes, so there's no need to call DirectInputToEngine from the InitCommand anymore.

Fixes input getting directed back to the engine after opening the sort menu when the player enters the menu code early.

The DirectInputToEngine command queued in the InitCommand can run after the DirectInputToSortMenuCommand if the player enters the code right when ScreenSelectMusic opens. If that happens, the sort menu stays open but receives no input until the player re-enters the menu code.

The InitCommand was added in a9cad9bed to fix input remaining redirected after switching between Single and Double styles. Since ITGmania v0.9.0 (specifically commit 17c4e7a2f), input redirections are reset on screen change, so that is no longer needed.