### PR TITLE
Allow practice mode from the song results screen.

### DIFF
--- a/BGAnimations/ScreenEvaluation common/Shared/ExitHandler.lua
+++ b/BGAnimations/ScreenEvaluation common/Shared/ExitHandler.lua
@@ -11,6 +11,11 @@ local RestartHandler = function(event)
 				SM("Replaying Song")
 				SCREENMAN:GetTopScreen():SetNextScreenName("ScreenGameplay"):StartTransitioningScreen("SM_GoToNextScreen")
 			end
+		elseif event.DeviceInput.button == "DeviceButton_p" then
+			if holdingCtrl then
+				SM("Entering Practice Mode")
+				SCREENMAN:GetTopScreen():SetNextScreenName("ScreenPractice"):StartTransitioningScreen("SM_GoToNextScreen")
+			end
 		end
 	elseif event.type == "InputEventType_Release" then
 		if event.DeviceInput.button == "DeviceButton_left ctrl" then

--- a/BGAnimations/ScreenEvaluation common/default.lua
+++ b/BGAnimations/ScreenEvaluation common/default.lua
@@ -48,8 +48,8 @@ end
 -- code for triggering a screenshot and animating a "screenshot" texture
 t[#t+1] = LoadActor("./Shared/ScreenshotHandler.lua")
 
--- code for immediately retrying the song that was just played
-t[#t+1] = LoadActor("./Shared/RestartHandler.lua")
+-- code for non-normal exits, such as restarting the song or entering practice mode
+t[#t+1] = LoadActor("./Shared/ExitHandler.lua")
 
 -- the title of the song and its graphical banner, if there is one
 t[#t+1] = LoadActor("./Shared/TitleAndBanner.lua")


### PR DESCRIPTION
A quick change to allow ctrl + p to enter practice mode after finishing a song. Has the same caveats as restarting, requiring keyboard features.

Quick demo with 2 players (don't mind the background shenanigans in practice mode, that's unrelated)


https://github.com/user-attachments/assets/5c5fb46a-16ea-4757-9c35-6db9614b97e8