### PR TITLE
When entering PracticeMode from the Eval screen, seek to where the player failed.

### DIFF
--- a/BGAnimations/ScreenPractice overlay.lua
+++ b/BGAnimations/ScreenPractice overlay.lua
@@ -24,6 +24,7 @@ local t = Def.ActorFrame{
 }
 
 local players =  GAMESTATE:GetHumanPlayers()
+local timeSeeked = false
 for player in ivalues(players) do
 	local backgroundFilter = LoadActor("ScreenGameplay underlay/PerPlayer/BackgroundFilter.lua", player)
 
@@ -47,6 +48,24 @@ for player in ivalues(players) do
 		ShowCommand=function(self) self:visible(false) end,
 		PlayingCommand=function(self) self:visible(true) end,
 	}
+
+	-- If we're coming from ScreenEvaluationStage, see if anyone failed the song.
+	-- This picks the first player to see a failure, in case both players failed.
+	t[#t+1] = Def.ActorFrame{
+		OnCommand=function(self)
+			if SL.Global.PrevScreenName == "ScreenEvaluationStage" then
+				local pn = ToEnumShortString(player)
+				local storage = SL[pn].Stages.Stats[SL.Global.Stages.PlayedThisGame]
+				if not timeSeeked and storage ~= nil and storage.DeathSecond ~= nil then
+					SCREENMAN:GetTopScreen():SeekSong(storage.DeathSecond)
+					timeSeeked = true
+				end
+			end
+		end
+	}
 end
+
+
+
 
 return t

--- a/BGAnimations/ScreenSystemLayer overlay.lua
+++ b/BGAnimations/ScreenSystemLayer overlay.lua
@@ -594,5 +594,11 @@ t[#t+1] = Def.ActorFrame {
 	}
 }
 -- -----------------------------------------------------------------------
-
+-- For tracking the PrevScreenName.
+t[#t+1] = Def.ActorFrame {
+	ScreenChangedMessageCommand=function(self)
+		local topscreen = SCREENMAN:GetTopScreen():GetName()
+		SL.Global.PrevScreenName = topscreen
+	end
+}
 return t

--- a/Scripts/SL_Init.lua
+++ b/Scripts/SL_Init.lua
@@ -164,6 +164,12 @@ local GlobalDefaults = {
 		-- These values outside initialize() won't be reset each game cycle,
 		-- but are rather manipulated as needed by the theme.
 		ActiveColorIndex = ThemePrefs.Get("SimplyLoveColor") or 1,
+
+		-- PrevScreenName is technically handled by:
+		-- https://quietly-turning.github.io/Lua-For-SM5/LuaAPI?engine=StepMania&version=5.1%20(dev)#Screens-Screen-GetPrevScreenName
+		-- However, it actually just uses the value set in metrics.ini. This allows us to dynamically track
+		-- the real PrevScreenName, in case you have a more complex screen journey.
+		PrevScreenName = "",
 	}
 }
 


### PR DESCRIPTION
Quick demo:

https://github.com/user-attachments/assets/70991aac-203f-498b-983b-c77b6c58403a

This also tracks the `PrevScreenName` in a global, which is updated in the `ScreenSystemLayer overlay.lua` file. Since `PracticeMode` can be entered from more than one `Screen`, we need to accurately track where we came from to make use of the fail time seeking in `PracticeMode`.
