### PR TITLE
SortMenu: Fix bug that causes softlock/crash when switching profiles

### DIFF
--- a/BGAnimations/ScreenSelectMusic overlay/SortMenu/SortMenu_InputHandler.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SortMenu/SortMenu_InputHandler.lua
@@ -108,6 +108,12 @@ local input = function(event)
 					overlay:playcommand("DirectInputToEngine")
 					SCREENMAN:SetNewScreen("ScreenViewDownloads")
 				elseif focus.new_overlay == "SwitchProfile" then
+					-- There's a race condition that occurs when a player mashes the Start button
+					-- fast enough, when the Switch Profiles button is highlighted, that causes
+					-- two SelectProfile screens to be present. This softlocks the game
+					-- due to the first screen not able to receive inputs.
+					if SL.Global.FastProfileSwitchInProgress then return false end
+
 					SL.Global.FastProfileSwitchInProgress = true
 					-- If a memory card is inserted we can't be on that profile's songs when switching profiles
 					-- as the profile is temporarily unloaded when finishing the screen.


### PR DESCRIPTION
### Overview
Addresses [ITGm#169](https://github.com/itgmania/itgmania/issues/169)

After looking at some of the other functionality of the game menus, I think debouncing/serializing menu inputs might mitigate some other latent bugs that might only crop up during race conditions. For instance, anything in the SortMenu isn't protected from a similar issue where 2 of the same screen of present due to a single player (or multiple players) mashing Start rapidly enough.

#### Testing
- Tested for several minutes of attempts without a successful repro
- Commented fix, rebuilt, and was able to repro within a couple of attempts