### PR TITLE
StepStatistics: Fix hold/roll counts

### DIFF
--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/StepStatistics/HoldsMinesRolls.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/StepStatistics/HoldsMinesRolls.lua
@@ -176,10 +176,18 @@ for i, category in ipairs(RadarCategories) do
 			if category=="Mines" and params.TapNoteScore == "TapNoteScore_AvoidMine" then
 				RCJudgments.Mines = RCJudgments.Mines + 1
 
-			elseif category=="Holds" and params.TapNote and params.TapNote:GetTapNoteSubType() == "TapNoteSubType_Hold" then
+			elseif category=="Holds"
+				and params.TapNote
+				and params.TapNote:GetTapNoteSubType() == "TapNoteSubType_Hold"
+				and params.HoldNoteScore == "HoldNoteScore_Held"
+				then
 				RCJudgments.Holds = RCJudgments.Holds + 1
 
-			elseif category=="Rolls" and params.TapNote and params.TapNote:GetTapNoteSubType() == "TapNoteSubType_Roll" then
+			elseif category=="Rolls"
+				and params.TapNote
+				and params.TapNote:GetTapNoteSubType() == "TapNoteSubType_Roll"
+				and params.HoldNoteScore == "HoldNoteScore_Held"
+				then
 				RCJudgments.Rolls = RCJudgments.Rolls + 1
 
 			else


### PR DESCRIPTION
The step statistics display during gameplay didn't check the HoldNoteScore when receiving a judgment so the counters were incremented even on missed holds and rolls.