### PR TITLE
Fix GetPlayerAF in practice mode

### DIFF
--- a/Graphics/HoldJudgment label 1x2.lua
+++ b/Graphics/HoldJudgment label 1x2.lua
@@ -7,19 +7,21 @@
 
 return Def.Sprite{
 	BeginCommand=function(self)
-		local label = "None"
+		local label = nil
 
-		-- force EditMode to use Love HoldJudgment for now
-		if SCREENMAN:GetTopScreen():GetName():match("ScreenEdit") then
-			label = "Love 1x2 (doubleres).png"
-
-		elseif self:GetParent() and self:GetParent():GetParent() then
-			-- self:GetParent():GetParent() will return the main Player ActorFrame
-			-- with a name like "PlayerP1" or "PlayerP2"
-			-- we can use the "P1" or "P2" part of the string to index the SL table
-			local pn = self:GetParent():GetParent():GetName():gsub("Player", "")
-			label = SL[pn].ActiveModifiers.HoldJudgment or "None 1x2.png"
+		-- self:GetParent():GetParent() is the main Player ActorFrame.
+		local playerAf = self:GetParent() and self:GetParent():GetParent()
+		-- We can't just check playerAf:GetName() here because the player actor
+		-- frames don't have their names set on ScreenEdit.
+		for _, player in ipairs(PlayerNumber) do
+			local pn = ToEnumShortString(player)
+			if playerAf and playerAf == GetPlayerAF(pn) then
+				label = SL[pn].ActiveModifiers.HoldJudgment
+				break
+			end
 		end
+
+		label = label or "None 1x2.png"
 
 		self:Load(THEME:GetPathG("", "_HoldJudgments/" .. label))
 	end

--- a/Scripts/SL-Helpers.lua
+++ b/Scripts/SL-Helpers.lua
@@ -971,8 +971,7 @@ end
 -- helper function for returning the player AF
 -- Works as expected in ScreenGameplay + Edit + Practice Mode
 --     arguments:  pn is short string PlayerNumber like "P1" or "P2"
---     returns:    the "PlayerP1" or "PlayerP2" ActorFrame in ScreenGameplay
---                 or, the unnamed equivalent in ScrenEdit
+--     returns:    the "PlayerP1" or "PlayerP2" ActorFrame
 GetPlayerAF = function(pn)
 	local topscreen = SCREENMAN:GetTopScreen()
 	if not topscreen then
@@ -980,44 +979,15 @@ GetPlayerAF = function(pn)
 		return nil
 	end
 
-	local playerAF = nil
-
 	-- Get the player ActorFrame on ScreenGameplay
 	-- It's a direct child of the screen and named "PlayerP1" for P1
 	-- and "PlayerP2" for P2.
 	-- This naming convention is hardcoded in the SM5 engine.
 	--
-	-- ScreenEdit does not name its player ActorFrame, but we can still find it.
-
-	-- find the player ActorFrame in edit mode
-	local notefields = {}
-	if (THEME:GetMetric(topscreen:GetName(), "Class") == "ScreenEdit") then
-		-- loop through all nameless children of topscreen
-		-- and find the one that contains the NoteField
-		-- which is thankfully still named "NoteField"1
-
-		for _,nameless_child in ipairs(topscreen:GetChild("")) do
-			if nameless_child:GetChild("NoteField") then
-				notefields[#notefields+1] = nameless_child
-			end
-		end
-		-- If there is only one side joined always return the first one.
-		if #notefields == 1 then
-			return notefields[1]
-		-- If there are two sides joined, return the one that matches the player number.
-		else
-			return notefields[pn == "P1" and 1 or 2]
-		end
-
-	-- find the player ActorFrame in gameplay
-	else
-		local player_af = topscreen:GetChild("Player"..pn)
-		if player_af then
-			playerAF = player_af
-		end
-	end
-
-	return playerAF
+	-- ScreenEdit does not name its player ActorFrame, but does set its alias to
+	-- "PlayerP1" or "PlayerP2". GetChild will return the child if either the
+	-- name or alias matches.
+	return topscreen:GetChild("Player"..pn)
 end
 
 -- -----------------------------------------------------------------------


### PR DESCRIPTION
Fixes P2's background filter appearing on top of the notefield and early decent and way off flashes appearing on the other player's side in practice mode.

On ScreenEdit, GetPlayerAF relied on the players' actor frames being returned in the order of PlayerP1,PlayerP2 when calling GetChild("") because they are not named on ScreenEdit. The problem is that EditModePlayerManager stores the players in an std::unordered_map before adding them to the screen in AddPlayersToActorFrame, so the order isn't guaranteed.

Since ITGmania commit 448a2be7cd3fe62bc9095f208a41ea6e0058e06b, the player actor frames have their aliases set to "PlayerP1" and "PlayerP2" in ScreenEdit, so we can remove the special case for ScreenEdit.

The swapped actor frames caused two issues: 1) P2's note field was loaded before the background filter when the actors were loaded in `ScreenPractice overlay.lua`, and 2) The EarlyHitMessageCommand in `Player judgment.lua` played the flash on the wrong note field.

With the darkest filter, the practice mode looks like this before the fix:
<img width="1280" height="715" alt="practice-p2-bgfilter" src="https://github.com/user-attachments/assets/0872870f-3039-4e38-bc32-248997f542b3" />

EDIT: Also added a fix for the hold judgment graphics in practice mode. This fixes errors like the following when entering practice mode and the selected hold judgments being not used.
```
/////////////////////////////////////////
WARNING: Error playing command:/Themes/Simply Love/Graphics/HoldJudgment label 1x2.lua:21: attempt to index field '?' (a nil value)
WARNING: /Themes/Simply Love/Graphics/HoldJudgment label 1x2.lua:21: unknown(self = (null),label = None,pn = ,(*temporary) = (null),(*temporary) = Player,(*temporary) = ,(*temporary) = ,(*temporary) = 0,(*temporary) = (null),(*temporary) = attempt to index field '?' (a nil value))
/////////////////////////////////////////
```