### PR TITLE
Initial support for ITG and Pump Couples

### DIFF
--- a/BGAnimations/ScreenEditMenu underlay/LastSeenSong.lua
+++ b/BGAnimations/ScreenEditMenu underlay/LastSeenSong.lua
@@ -70,6 +70,9 @@ if song_str ~= "" then
 						-- set steps
 						local steps = song:GetOneSteps(stepstype_str, diff_str)
 						GAMESTATE:SetCurrentSteps(PLAYER_1, steps)
+						if style == "couple" or style == "routine" then
+							GAMESTATE:SetCurrentSteps(PLAYER_2, steps)
+						end
 						break
 					end
 				end

--- a/BGAnimations/ScreenEvaluation common/InputHandler.lua
+++ b/BGAnimations/ScreenEvaluation common/InputHandler.lua
@@ -23,7 +23,7 @@ local mpn = GAMESTATE:GetMasterPlayerNumber()
 --        so this is more like "validation" than validation
 
 local primary_i   = clamp(SL[ToEnumShortString(mpn)].EvalPanePrimary,   1, num_panes)
-local secondary_i = clamp(SL[ToEnumShortString(mpn)].EvalPaneSecondary, 1, num_panes)
+local secondary_i = clamp(SL[ToEnumShortString(mpn)].EvalPaneSecondary, 1, num_panes)-1
 
 -- -----------------------------------------------------------------------
 -- initialize local tables (panes, active_pane) for the the input handling function to use
@@ -79,10 +79,9 @@ end
 -- EvalPaneSecondary=4
 -- because Pane3 is full-width in double and the other pane is supposed to be hidden when it is visible
 
-if style == "OnePlayerTwoSides" then
+if style == "OnePlayerTwoSides" or (style == "TwoPlayersSharedSides") then
 	local cn  = PlayerNumber:Reverse()[mpn] + 1
 	local ocn = (cn % 2) + 1
-
 	-- if the player wanted their primary pane to be something that is full-width in double
 	if panes[cn][active_pane[cn]]:GetChild(""):GetCommand("ExpandForDouble") then
 		-- hide all panes for the other controller

--- a/BGAnimations/ScreenEvaluation common/Panes/Pane1/JudgmentLabels.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane1/JudgmentLabels.lua
@@ -3,7 +3,7 @@ local player, controller = unpack(...)
 local pn = ToEnumShortString(player)
 local stats = STATSMAN:GetCurStageStats():GetPlayerStageStats(pn)
 local pss = STATSMAN:GetCurStageStats():GetPlayerStageStats(player)
-
+local styletype = ToEnumShortString(GAMESTATE:GetCurrentStyle():GetStyleType())
 local tns_string = "TapNoteScore" .. (SL.Global.GameMode=="ITG" and "" or SL.Global.GameMode)
 
 local firstToUpper = function(str)
@@ -85,17 +85,29 @@ end
 
 -- labels: hands/ex, holds, mines, rolls
 for index, label in ipairs(RadarCategories) do
-    local performance = stats:GetRadarActual():GetValue( "RadarCategory_"..firstToUpper(EnglishRadarCategories[label]) )
-    local possible = stats:GetRadarPossible():GetValue( "RadarCategory_"..firstToUpper(EnglishRadarCategories[label]) )
-
-    t[#t+1] = LoadFont("Common Normal")..{
-        Text=label,
-        InitCommand=function(self) self:zoom(0.833):horizalign(right) end,
-        BeginCommand=function(self)
-            self:x( (controller == PLAYER_1 and -160) or 90 )
-            self:y((index-1)*28 + 41)
-        end
-    }
+	-- Replace hands with the Routine Score if we're in routine mode
+	if index == 1 and (styletype == "TwoPlayersSharedSides") then
+		t[#t+1] = LoadFont("Wendy/_wendy small")..{
+			Text=controller == PLAYER_1 and "P1" or "P2",
+			InitCommand=function(self) self:zoom(0.5):horizalign(right) end,
+			BeginCommand=function(self)
+				self:x( (controller == PLAYER_1 and -160) or 90 )
+				self:y(38)
+				self:diffuse( controller == PLAYER_1 and Color.Blue or Color.Red )
+			end
+		}
+	else
+		local performance = stats:GetRadarActual():GetValue( "RadarCategory_"..firstToUpper(EnglishRadarCategories[label]) )
+		local possible = stats:GetRadarPossible():GetValue( "RadarCategory_"..firstToUpper(EnglishRadarCategories[label]) )
+		t[#t+1] = LoadFont("Common Normal")..{
+			Text=label,
+			InitCommand=function(self) self:zoom(0.833):horizalign(right) end,
+			BeginCommand=function(self)
+				self:x( (controller == PLAYER_1 and -160) or 90 )
+				self:y((index-1)*28 + 41)
+			end
+		}
+	end
 end
 
 return t

--- a/BGAnimations/ScreenEvaluation common/Panes/Pane1/JudgmentLabels.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane1/JudgmentLabels.lua
@@ -85,7 +85,7 @@ end
 
 -- labels: hands/ex, holds, mines, rolls
 for index, label in ipairs(RadarCategories) do
-	-- Replace hands with the Routine Score if we're in routine mode
+	-- Replace hands with the Couples Score if we're in couples mode
 	if index == 1 and (styletype == "TwoPlayersSharedSides") then
 		t[#t+1] = LoadFont("Wendy/_wendy small")..{
 			Text=controller == PLAYER_1 and "P1" or "P2",

--- a/BGAnimations/ScreenEvaluation common/Panes/Pane1/JudgmentNumbers.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane1/JudgmentNumbers.lua
@@ -2,6 +2,7 @@ local player, controller = unpack(...)
 
 local pn = ToEnumShortString(player)
 local pss = STATSMAN:GetCurStageStats():GetPlayerStageStats(player)
+local styletype = ToEnumShortString(GAMESTATE:GetCurrentStyle():GetStyleType())
 
 local TapNoteScores = {
 	Types = { 'W1', 'W2', 'W3', 'W4', 'W5', 'Miss' },
@@ -63,33 +64,51 @@ end
 
 -- then handle hands/ex, holds, mines, rolls
 for index, RCType in ipairs(RadarCategories.Types) do
-    local performance = pss:GetRadarActual():GetValue( "RadarCategory_"..RCType )
-    local possible = pss:GetRadarPossible():GetValue( "RadarCategory_"..RCType )
-    possible = clamp(possible, 0, 999)
+	-- Replace hands with the Routine Score if we're in routine mode
+	if index == 1 and (styletype == "TwoPlayersSharedSides") then
+		local PercentDP = pss:GetPercentDancePoints()
+		percent = FormatPercentScore(PercentDP)
+		-- Format the Percentage string, removing the % symbol
+		percent = percent:gsub("%%", "")
+		t[#t+1] = LoadFont("Wendy/_wendy white")..{
+			Name="Percent",
+			Text=percent,
+			InitCommand=function(self)
+				self:horizalign(right):zoom(0.4)
+				self:x( ((controller == PLAYER_1) and -114) or 286 )
+				self:y(47)
+				self:diffuse( (controller == PLAYER_1) and Color.Blue or Color.Red)
+			end
+		}
+	else
+		local performance = pss:GetRadarActual():GetValue( "RadarCategory_"..RCType )
+		local possible = pss:GetRadarPossible():GetValue( "RadarCategory_"..RCType )
+		possible = clamp(possible, 0, 999)
 
-    -- player performance value
-    -- use a RollingNumber to animate the count tallying up for visual effect
-    t[#t+1] = Def.RollingNumbers{
-        Font="Wendy/_ScreenEvaluation numbers",
-        InitCommand=function(self) self:zoom(0.5):horizalign(right):Load("RollingNumbersEvaluationB") end,
-        BeginCommand=function(self)
-            self:x( RadarCategories.x[ToEnumShortString(controller)] )
-            self:y((index-1)*35 + 53)
-            self:targetnumber(performance)
-        end
-    }
+		-- player performance value
+		-- use a RollingNumber to animate the count tallying up for visual effect
+		t[#t+1] = Def.RollingNumbers{
+			Font="Wendy/_ScreenEvaluation numbers",
+			InitCommand=function(self) self:zoom(0.5):horizalign(right):Load("RollingNumbersEvaluationB") end,
+			BeginCommand=function(self)
+				self:x( RadarCategories.x[ToEnumShortString(controller)] )
+				self:y((index-1)*35 + 53)
+				self:targetnumber(performance)
+			end
+		}
 
-    -- slash and possible value
-    t[#t+1] = LoadFont("Wendy/_ScreenEvaluation numbers")..{
-        InitCommand=function(self) self:zoom(0.5):horizalign(right) end,
-        BeginCommand=function(self)
-            self:x( ((controller == PLAYER_1) and -114) or 286 )
-            self:y((index-1)*35 + 53)
-            self:settext(("/%03d"):format(possible))
-            local leadingZeroAttr = { Length=4-tonumber(tostring(possible):len()), Diffuse=color("#5A6166") }
-            self:AddAttribute(0, leadingZeroAttr )
-        end
-    }
+		-- slash and possible value
+		t[#t+1] = LoadFont("Wendy/_ScreenEvaluation numbers")..{
+			InitCommand=function(self) self:zoom(0.5):horizalign(right) end,
+			BeginCommand=function(self)
+				self:x( ((controller == PLAYER_1) and -114) or 286 )
+				self:y((index-1)*35 + 53)
+				self:settext(("/%03d"):format(possible))
+				local leadingZeroAttr = { Length=4-tonumber(tostring(possible):len()), Diffuse=color("#5A6166") }
+				self:AddAttribute(0, leadingZeroAttr )
+			end
+		}
+	end
 end
 
 return t

--- a/BGAnimations/ScreenEvaluation common/Panes/Pane1/JudgmentNumbers.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane1/JudgmentNumbers.lua
@@ -64,7 +64,7 @@ end
 
 -- then handle hands/ex, holds, mines, rolls
 for index, RCType in ipairs(RadarCategories.Types) do
-	-- Replace hands with the Routine Score if we're in routine mode
+	-- Replace hands with the Couples Score if we're in couples mode
 	if index == 1 and (styletype == "TwoPlayersSharedSides") then
 		local PercentDP = pss:GetPercentDancePoints()
 		percent = FormatPercentScore(PercentDP)

--- a/BGAnimations/ScreenEvaluation common/Panes/Pane1/Percentage.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane1/Percentage.lua
@@ -1,8 +1,15 @@
 local player, controller = unpack(...)
+local styletype = ToEnumShortString(GAMESTATE:GetCurrentStyle():GetStyleType())
 
-local stats = STATSMAN:GetCurStageStats():GetPlayerStageStats(player)
+local stats
+if  styletype == "TwoPlayersSharedSides" then
+	stats = STATSMAN:GetCurStageStats():GetRoutineStageStats()
+else
+	stats = STATSMAN:GetCurStageStats():GetPlayerStageStats(player)
+end
 local PercentDP = stats:GetPercentDancePoints()
 local percent = FormatPercentScore(PercentDP)
+
 -- Format the Percentage string, removing the % symbol
 percent = percent:gsub("%%", "")
 
@@ -15,10 +22,12 @@ return Def.ActorFrame{
 	-- dark background quad behind player percent score
 	Def.Quad{
 		InitCommand=function(self)
-			self:diffuse(color("#101519")):zoomto(158.5, 60)
+			self:diffuse(color("#101519")):zoomto(158.5, (styletype == "TwoPlayersSharedSides") and 88 or 60)
 			self:horizalign(controller==PLAYER_1 and left or right)
 			self:x(150 * (controller == PLAYER_1 and -1 or 1))
-
+			if styletype == "TwoPlayersSharedSides" then
+				self:y(14)
+			end
 			if ThemePrefs.Get("VisualStyle") == "Technique" then
 				self:diffusealpha(0.5)
 			end

--- a/BGAnimations/ScreenEvaluation common/Panes/Pane1/Percentage.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane1/Percentage.lua
@@ -3,7 +3,7 @@ local styletype = ToEnumShortString(GAMESTATE:GetCurrentStyle():GetStyleType())
 
 local stats
 if  styletype == "TwoPlayersSharedSides" then
-	stats = STATSMAN:GetCurStageStats():GetRoutineStageStats()
+	stats = STATSMAN:GetCurStageStats():GetSharedPlayerStageStats()
 else
 	stats = STATSMAN:GetCurStageStats():GetPlayerStageStats(player)
 end

--- a/BGAnimations/ScreenEvaluation common/Panes/Pane2/JudgmentLabels.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane2/JudgmentLabels.lua
@@ -2,7 +2,7 @@ local player, controller = unpack(...)
 
 local pn = ToEnumShortString(player)
 local stats = STATSMAN:GetCurStageStats():GetPlayerStageStats(pn)
-
+local styletype = ToEnumShortString(GAMESTATE:GetCurrentStyle():GetStyleType())
 local firstToUpper = function(str)
     return (str:gsub("^%l", string.upper))
 end
@@ -103,21 +103,32 @@ for index, label in ipairs(RadarCategories) do
 			text = "EX"
 		end
 
-
-		t[#t+1] = LoadFont("Wendy/_wendy small")..{
-			Text=text,
-			InitCommand=function(self) self:zoom(0.5):horizalign(right) end,
-			BeginCommand=function(self)
-				self:x( (controller == PLAYER_1 and -160) or 82 )
-				self:y(38)
-
-				if SL[pn].ActiveModifiers.ShowExScore then
-					self:diffuse(Color.White)
-				else
-					self:diffuse( SL.JudgmentColors[SL.Global.GameMode][1] )
+		if (styletype == "TwoPlayersSharedSides") then
+			t[#t+1] = LoadFont("Wendy/_wendy small")..{
+				Text=controller == PLAYER_1 and "P1" or "P2",
+				InitCommand=function(self) self:zoom(0.5):horizalign(right) end,
+				BeginCommand=function(self)
+					self:x( (controller == PLAYER_1 and -160) or 90 )
+					self:y(38)
+					self:diffuse( controller == PLAYER_1 and Color.Blue or Color.Red )
 				end
-			end
-		}
+			}
+		else
+			t[#t+1] = LoadFont("Wendy/_wendy small")..{
+				Text=text,
+				InitCommand=function(self) self:zoom(0.5):horizalign(right) end,
+				BeginCommand=function(self)
+					self:x( (controller == PLAYER_1 and -160) or 82 )
+					self:y(38)
+
+					if SL[pn].ActiveModifiers.ShowExScore then
+						self:diffuse(Color.White)
+					else
+						self:diffuse( SL.JudgmentColors[SL.Global.GameMode][1] )
+					end
+				end
+			}
+		end
 	end
 
 	local performance = stats:GetRadarActual():GetValue( "RadarCategory_"..firstToUpper(EnglishRadarCategories[label]) )

--- a/BGAnimations/ScreenEvaluation common/Panes/Pane2/JudgmentNumbers.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane2/JudgmentNumbers.lua
@@ -1,7 +1,8 @@
 local player, controller = unpack(...)
-
+local styletype = ToEnumShortString(GAMESTATE:GetCurrentStyle():GetStyleType())
 local pn = ToEnumShortString(player)
 local pss = STATSMAN:GetCurStageStats():GetPlayerStageStats(player)
+
 
 local TapNoteScores = {
 	Types = { 'W0', 'W1', 'W2', 'W3', 'W4', 'W5', 'Miss' },
@@ -83,31 +84,54 @@ end
 for index, RCType in ipairs(RadarCategories.Types) do
 	-- Swap to displaying ITG score if we're showing EX score in gameplay.
 	local percent = nil
-	if SL[pn].ActiveModifiers.ShowExScore then
+	if styletype == "TwoPlayersSharedSides" then
 		local PercentDP = pss:GetPercentDancePoints()
-		percent = FormatPercentScore(PercentDP):gsub("%%", "")
+		percent = FormatPercentScore(PercentDP)
 		-- Format the Percentage string, removing the % symbol
-		percent = tonumber(percent)
+		percent = percent:gsub("%%", "")
 	else
-		percent = CalculateExScore(player)
+		if SL[pn].ActiveModifiers.ShowExScore then
+			local PercentDP = pss:GetPercentDancePoints()
+			percent = FormatPercentScore(PercentDP):gsub("%%", "")
+			-- Format the Percentage string, removing the % symbol
+			percent = tonumber(percent)
+		else
+			percent = CalculateExScore(player)
+		end
 	end
 
 	if index == 1 then
-		t[#t+1] = LoadFont("Wendy/_wendy white")..{
-			Name="Percent",
-			Text=("%.2f"):format(percent),
-			InitCommand=function(self)
-				self:horizalign(right):zoom(0.4)
-				self:x( ((controller == PLAYER_1) and -114) or 286 )
-				self:y(47)
-				
-				if SL[pn].ActiveModifiers.ShowExScore then
-					self:diffuse(Color.White)
-				else
-					self:diffuse( SL.JudgmentColors[SL.Global.GameMode][1] )
+		if (styletype == "TwoPlayersSharedSides") then
+
+			-- Format the Percentage string, removing the % symbol
+			percent = percent:gsub("%%", "")
+			t[#t+1] = LoadFont("Wendy/_wendy white")..{
+				Name="Percent",
+				Text=percent,
+				InitCommand=function(self)
+					self:horizalign(right):zoom(0.4)
+					self:x( ((controller == PLAYER_1) and -114) or 286 )
+					self:y(47)
+					self:diffuse( (controller == PLAYER_1) and Color.Blue or Color.Red)
 				end
-			end
 		}
+		else
+			t[#t+1] = LoadFont("Wendy/_wendy white")..{
+				Name="Percent",
+				Text=("%.2f"):format(percent),
+				InitCommand=function(self)
+					self:horizalign(right):zoom(0.4)
+					self:x( ((controller == PLAYER_1) and -114) or 286 )
+					self:y(47)
+					
+					if SL[pn].ActiveModifiers.ShowExScore then
+						self:diffuse(Color.White)
+					else
+						self:diffuse( SL.JudgmentColors[SL.Global.GameMode][1] )
+					end
+				end
+			}
+		end
 	end
 
 	local possible = counts["total"..RCType]

--- a/BGAnimations/ScreenEvaluation common/Panes/Pane2/Percentage.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane2/Percentage.lua
@@ -2,8 +2,13 @@ local player, controller = unpack(...)
 
 local percent = nil
 local diffuse = nil
-
-if SL[ToEnumShortString(player)].ActiveModifiers.ShowExScore then
+local styletype = ToEnumShortString(GAMESTATE:GetCurrentStyle():GetStyleType())
+if (styletype == "TwoPlayersSharedSides") then
+	stats = STATSMAN:GetCurStageStats():GetRoutineStageStats()
+	-- Format the Percentage string, removing the % symbol
+	percent = CalculateExScore(player)
+	diffuse = SL.JudgmentColors[SL.Global.GameMode][1]
+elseif SL[ToEnumShortString(player)].ActiveModifiers.ShowExScore then
 	percent = CalculateExScore(player)
 	diffuse = SL.JudgmentColors[SL.Global.GameMode][1]
 else

--- a/BGAnimations/ScreenEvaluation common/Panes/Pane2/Percentage.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane2/Percentage.lua
@@ -4,7 +4,7 @@ local percent = nil
 local diffuse = nil
 local styletype = ToEnumShortString(GAMESTATE:GetCurrentStyle():GetStyleType())
 if (styletype == "TwoPlayersSharedSides") then
-	stats = STATSMAN:GetCurStageStats():GetRoutineStageStats()
+	stats = STATSMAN:GetCurStageStats():GetSharedPlayerStageStats()
 	-- Format the Percentage string, removing the % symbol
 	percent = CalculateExScore(player)
 	diffuse = SL.JudgmentColors[SL.Global.GameMode][1]

--- a/BGAnimations/ScreenEvaluation common/Panes/Pane3/Arrows.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane3/Arrows.lua
@@ -7,7 +7,7 @@ local noteskin = GAMESTATE:GetPlayerState(player):GetCurrentPlayerOptions():Note
 -- NOTESKIN:LoadActorForNoteSkin() expects the noteskin name to be all lowercase(?)
 -- so transform the string to be lowercase
 noteskin = noteskin:lower()
-
+local routineStatus = false
 
 -- -----------------------------------------------------------------------
 local game  = GAMESTATE:GetCurrentGame():GetName()
@@ -34,7 +34,8 @@ local box_height = 146
 
 -- more space for double and routine
 local styletype = ToEnumShortString(style:GetStyleType())
-if not (styletype == "OnePlayerOneSide" or styletype == "TwoPlayersTwoSides") then
+
+if (styletype == "OnePlayerTwoSides" or (styletype == "TwoPlayersSharedSides" and routineStatus) ) then
 	box_width = 520
 end
 
@@ -44,18 +45,21 @@ local row_height = box_height/#rows
 -- -----------------------------------------------------------------------
 
 local af = Def.ActorFrame{}
-af.InitCommand=function(self) self:xy(-104, _screen.cy-40) end
+af.InitCommand=function(self) self:xy((styletype == "TwoPlayersSharedSides" and not routineStatus) and -102 or -104, _screen.cy-40) end
 
 
 for i, column in ipairs( cols ) do
 
 	local _x = col_width * i
 
-	-- Calculating column positioning like this in techno game and dance solor results
-	-- in each column being ~10px too far left; this does not happen in other games that
-	-- I've tested.  There's probably a cleaner fix involving scaling column.XOffset to
-	-- fit within the bounds of box_width but this is easer for now.
-	if game == "techno" or (game == "dance" and style_name == "solo") then
+	-- Calculating column positioning like this in techno game, dance solo, and pump routine
+	-- results in each column being ~10px too far left; this does not happen in other games
+	-- that I've tested.  There's probably a cleaner fix involving scaling column.XOffset to
+	-- fit within the bounds of box_width but this is easer for now.  -quietly
+	if game == "techno"
+	or (game == "dance" and style_name == "solo")
+	or (style_name == "routine")
+	then
 		_x = _x + 10
 	end
 
@@ -74,15 +78,17 @@ for i, column in ipairs( cols ) do
 		-- don't add rows for TimingWindows that were turned off, but always add Miss
 		if SL[pn].ActiveModifiers.TimingWindows[j] or j==#rows or (mods.ShowFaPlusWindow and mods.ShowFaPlusPane and SL[pn].ActiveModifiers.TimingWindows[j-1]) then
 			-- add a BitmapText actor to be the number for this column
+			local judgementText = 0
+			judgementText =SL[pn].Stages.Stats[SL.Global.Stages.PlayedThisGame + 1].column_judgments[i][judgment]
+
 			af[#af+1] = LoadFont("Common Normal")..{
-				Text=SL[pn].Stages.Stats[SL.Global.Stages.PlayedThisGame + 1].column_judgments[i][judgment],
+				Text=judgementText,
 				InitCommand=function(self)
 					self:xy(_x, j*row_height + 4)
 						:zoom(0.9)
 					if j == #rows then miss_bmt = self end
 				end
 			}
-
 			if judgment == "W4" or judgment == "W5" then
 				af[#af+1] = LoadFont("Common Normal")..{
 					Text=SL[pn].Stages.Stats[SL.Global.Stages.PlayedThisGame + 1].column_judgments[i]["Early"][judgment],

--- a/BGAnimations/ScreenEvaluation common/Panes/Pane3/Arrows.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane3/Arrows.lua
@@ -7,7 +7,7 @@ local noteskin = GAMESTATE:GetPlayerState(player):GetCurrentPlayerOptions():Note
 -- NOTESKIN:LoadActorForNoteSkin() expects the noteskin name to be all lowercase(?)
 -- so transform the string to be lowercase
 noteskin = noteskin:lower()
-local routineStatus = false
+local coupleStatus = false
 
 -- -----------------------------------------------------------------------
 local game  = GAMESTATE:GetCurrentGame():GetName()
@@ -23,7 +23,7 @@ local cols = {}
 
 -- loop num_columns number of time to fill the cols table with
 -- info about each column for this game
--- each game (dance, pump, techno, etc.) and each style (single, double, routine, etc.)
+-- each game (dance, pump, techno, etc.) and each style (single, double, couples, etc.)
 -- within each game will have its own unique columns
 for i=1,num_columns do
 	table.insert(cols, style:GetColumnInfo(player, i))
@@ -32,10 +32,10 @@ end
 local box_width  = 230
 local box_height = 146
 
--- more space for double and routine
+-- more space for double and couples
 local styletype = ToEnumShortString(style:GetStyleType())
 
-if (styletype == "OnePlayerTwoSides" or (styletype == "TwoPlayersSharedSides" and routineStatus) ) then
+if (styletype == "OnePlayerTwoSides" or (styletype == "TwoPlayersSharedSides" and coupleStatus) ) then
 	box_width = 520
 end
 
@@ -45,20 +45,20 @@ local row_height = box_height/#rows
 -- -----------------------------------------------------------------------
 
 local af = Def.ActorFrame{}
-af.InitCommand=function(self) self:xy((styletype == "TwoPlayersSharedSides" and not routineStatus) and -102 or -104, _screen.cy-40) end
+af.InitCommand=function(self) self:xy((styletype == "TwoPlayersSharedSides" and not coupleStatus) and -102 or -104, _screen.cy-40) end
 
 
 for i, column in ipairs( cols ) do
 
 	local _x = col_width * i
 
-	-- Calculating column positioning like this in techno game, dance solo, and pump routine
+	-- Calculating column positioning like this in techno game, dance solo, and pump couples
 	-- results in each column being ~10px too far left; this does not happen in other games
 	-- that I've tested.  There's probably a cleaner fix involving scaling column.XOffset to
 	-- fit within the bounds of box_width but this is easer for now.  -quietly
 	if game == "techno"
 	or (game == "dance" and style_name == "solo")
-	or (style_name == "routine")
+	or (style_name == "couple")
 	then
 		_x = _x + 10
 	end

--- a/BGAnimations/ScreenEvaluation common/Panes/Pane4/default.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane4/default.lua
@@ -11,6 +11,9 @@ local pane = Def.ActorFrame{
 -- -----------------------------------------------------------------------
 
 local pss = STATSMAN:GetCurStageStats():GetPlayerStageStats(player)
+if (styletype == "TwoPlayersSharedSides") then
+	pss = STATSMAN:GetCurStageStats():GetRoutineStageStats()
+end
 local NumHighScores = math.min(10, PREFSMAN:GetPreference("MaxHighScoresPerListForMachine"))
 
 local HighScoreIndex = {

--- a/BGAnimations/ScreenEvaluation common/Panes/Pane4/default.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane4/default.lua
@@ -12,7 +12,7 @@ local pane = Def.ActorFrame{
 
 local pss = STATSMAN:GetCurStageStats():GetPlayerStageStats(player)
 if (styletype == "TwoPlayersSharedSides") then
-	pss = STATSMAN:GetCurStageStats():GetRoutineStageStats()
+	pss = STATSMAN:GetCurStageStats():GetSharedPlayerStageStats()
 end
 local NumHighScores = math.min(10, PREFSMAN:GetPreference("MaxHighScoresPerListForMachine"))
 

--- a/BGAnimations/ScreenEvaluation common/Panes/Pane6/default.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane6/default.lua
@@ -16,7 +16,7 @@ local style = ToEnumShortString(GAMESTATE:GetCurrentStyle():GetStyleType())
 
 local pane = Def.ActorFrame{
 	InitCommand=function(self)
-		if style == "OnePlayerTwoSides" then
+		if style == "OnePlayerTwoSides" or (style == "TwoPlayersSharedSides" and routineStatus) then
 			if controller == PLAYER_2 then self:x(-260)
 			else self:x(50) end
 		end
@@ -42,8 +42,19 @@ if style == "OnePlayerOneSide" or style == "TwoPlayersTwoSides" then
 		Text=THEME:GetString("ScreenEvaluation",  "TestInputInstructions"),
 		InitCommand=function(self) self:zoom(0.8):xy(-140,255):_wrapwidthpixels(100/0.8):align(0,0):vertspacing(-4) end
 	}
+elseif style == "TwoPlayersSharedSides" then
 
--- for everything else (double, routine, couple), show two pads
+	pane[#pane+1] = LoadFont("Common normal")..{
+		Text=THEME:GetString("ScreenEvaluation",  "TestInput"),
+		InitCommand=function(self) self:zoom(1):xy(-92, 196):vertalign(top):maxwidth(100/self:GetZoom()) end
+	}
+	pane[#pane+1] = LoadActor( THEME:GetPathB("", "_modules/TestInput Pad/default.lua"), {Player=PLAYER_1, ShowMenuButtons=false, ShowPlayerLabel=false})..{
+		InitCommand=function(self) self:xy(-66, 338):zoom(0.65) end
+	}
+	pane[#pane+1] = LoadActor( THEME:GetPathB("", "_modules/TestInput Pad/default.lua"), {Player=PLAYER_2, ShowMenuButtons=false, ShowPlayerLabel=false})..{
+		InitCommand=function(self) self:xy(66, 338):zoom(0.65) end
+	}
+-- for everything else (double, halfdouble, couple, etc.), show two pads
 else
 	pane[#pane+1] = LoadActor( THEME:GetPathB("", "_modules/TestInput Pad/default.lua"), {Player=PLAYER_1, ShowMenuButtons=false, ShowPlayerLabel=false})..{
 		InitCommand=function(self) self:xy(22, 338):zoom(0.8) end

--- a/BGAnimations/ScreenEvaluation common/Panes/Pane6/default.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane6/default.lua
@@ -16,7 +16,7 @@ local style = ToEnumShortString(GAMESTATE:GetCurrentStyle():GetStyleType())
 
 local pane = Def.ActorFrame{
 	InitCommand=function(self)
-		if style == "OnePlayerTwoSides" or (style == "TwoPlayersSharedSides" and routineStatus) then
+		if style == "OnePlayerTwoSides" or (style == "TwoPlayersSharedSides" and coupleStatus) then
 			if controller == PLAYER_2 then self:x(-260)
 			else self:x(50) end
 		end

--- a/BGAnimations/ScreenEvaluation common/Panes/default.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/default.lua
@@ -1,6 +1,6 @@
 local NumPanes = ...
 local players = GAMESTATE:GetHumanPlayers()
-
+local style = ToEnumShortString(GAMESTATE:GetCurrentStyle():GetStyleType())
 local af = Def.ActorFrame{}
 af.Name="Panes"
 
@@ -13,7 +13,7 @@ local offset = {
 -- Note: Some of these Pane actors may be nil. This is not a bug, but
 --       a feature for any panes we want to be conditional.  -teejusb
 
-if #players == 2 or SL.Global.GameMode=="Casual" then
+if #players == 2 or SL.Global.GameMode=="Casual" and not (styletype == "TwoPlayersSharedSides") then
 	for player in ivalues(players) do
 		-- add Panes for this player to the ActorFrame using a simple, numerical for-loop
 		for i=1, NumPanes do
@@ -30,7 +30,7 @@ if #players == 2 or SL.Global.GameMode=="Casual" then
 		end
 	end
 
-elseif #players == 1 then
+elseif #players == 1 or style == "TwoPlayersSharedSides" then
 	-- When only one player is joined (single, double, solo, etc.), we end up loading each
 	-- Pane twice, effectively doing the same work twice.
 	--
@@ -54,6 +54,7 @@ elseif #players == 1 then
 	local mpn = GAMESTATE:GetMasterPlayerNumber()
 
 	for i=1, NumPanes do
+		
 		local left_pane  = LoadActor("./Pane"..i, {mpn, PLAYER_1, ComputedData})
 		local right_pane = LoadActor("./Pane"..i, {mpn, PLAYER_2, ComputedData})
 

--- a/BGAnimations/ScreenEvaluation common/PerPlayer/Lower/Disqualified.lua
+++ b/BGAnimations/ScreenEvaluation common/PerPlayer/Lower/Disqualified.lua
@@ -7,6 +7,10 @@ if SL.Global.GameMode == "Casual" then return end
 local player = ...
 
 local stats = STATSMAN:GetCurStageStats():GetPlayerStageStats(player)
+local style = ToEnumShortString(GAMESTATE:GetCurrentStyle():GetStyleType())
+if (style == "TwoPlayersSharedSides") then
+	stats = STATSMAN:GetCurStageStats():GetRoutineStageStats()
+end
 local disqualified = stats:IsDisqualified()
 
 -- If the player was disqualified, return a BitmapText actor with localized text

--- a/BGAnimations/ScreenEvaluation common/PerPlayer/Lower/Disqualified.lua
+++ b/BGAnimations/ScreenEvaluation common/PerPlayer/Lower/Disqualified.lua
@@ -9,7 +9,7 @@ local player = ...
 local stats = STATSMAN:GetCurStageStats():GetPlayerStageStats(player)
 local style = ToEnumShortString(GAMESTATE:GetCurrentStyle():GetStyleType())
 if (style == "TwoPlayersSharedSides") then
-	stats = STATSMAN:GetCurStageStats():GetRoutineStageStats()
+	stats = STATSMAN:GetCurStageStats():GetSharedPlayerStageStats()
 end
 local disqualified = stats:IsDisqualified()
 

--- a/BGAnimations/ScreenEvaluation common/PerPlayer/Upper/LetterGrade.lua
+++ b/BGAnimations/ScreenEvaluation common/PerPlayer/Upper/LetterGrade.lua
@@ -1,6 +1,12 @@
 local player = ...
 
+local styletype = ToEnumShortString(GAMESTATE:GetCurrentStyle():GetStyleType())
+
 local playerStats = STATSMAN:GetCurStageStats():GetPlayerStageStats(player)
+local routineStatus = SL.Global.RoutineStatus
+if (styletype == "TwoPlayersSharedSides") then
+	playerStats = STATSMAN:GetCurStageStats():GetRoutineStageStats()
+end
 local grade = playerStats:GetGrade()
 
 -- "I passd with a q though."

--- a/BGAnimations/ScreenEvaluation common/PerPlayer/Upper/LetterGrade.lua
+++ b/BGAnimations/ScreenEvaluation common/PerPlayer/Upper/LetterGrade.lua
@@ -3,9 +3,9 @@ local player = ...
 local styletype = ToEnumShortString(GAMESTATE:GetCurrentStyle():GetStyleType())
 
 local playerStats = STATSMAN:GetCurStageStats():GetPlayerStageStats(player)
-local routineStatus = SL.Global.RoutineStatus
+local coupleStatus = SL.Global.CoupleStatus
 if (styletype == "TwoPlayersSharedSides") then
-	playerStats = STATSMAN:GetCurStageStats():GetRoutineStageStats()
+	playerStats = STATSMAN:GetCurStageStats():GetSharedPlayerStageStats()
 end
 local grade = playerStats:GetGrade()
 

--- a/BGAnimations/ScreenEvaluation common/PerPlayer/Upper/RecordTexts.lua
+++ b/BGAnimations/ScreenEvaluation common/PerPlayer/Upper/RecordTexts.lua
@@ -4,6 +4,9 @@ local player = ...
 local pn = ToEnumShortString(player)
 
 local pss = STATSMAN:GetCurStageStats():GetPlayerStageStats(player)
+if styletype == "TwoPlayersSharedSides" then
+	pss = STATSMAN:GetCurStageStats():GetRoutineStageStats()
+end
 
 local HighScoreIndex = {
 	Machine =  pss:GetMachineHighScoreIndex(),

--- a/BGAnimations/ScreenEvaluation common/PerPlayer/Upper/RecordTexts.lua
+++ b/BGAnimations/ScreenEvaluation common/PerPlayer/Upper/RecordTexts.lua
@@ -5,7 +5,7 @@ local pn = ToEnumShortString(player)
 
 local pss = STATSMAN:GetCurStageStats():GetPlayerStageStats(player)
 if styletype == "TwoPlayersSharedSides" then
-	pss = STATSMAN:GetCurStageStats():GetRoutineStageStats()
+	pss = STATSMAN:GetCurStageStats():GetSharedPlayerStageStats()
 end
 
 local HighScoreIndex = {

--- a/BGAnimations/ScreenEvaluation common/Shared/ExitHandler.lua
+++ b/BGAnimations/ScreenEvaluation common/Shared/ExitHandler.lua
@@ -9,7 +9,7 @@ local RestartHandler = function(event)
 		elseif event.DeviceInput.button == "DeviceButton_r" then
 			if holdingCtrl then
 				SM("Replaying Song")
-				SCREENMAN:GetTopScreen():SetNextScreenName("ScreenGameplay"):StartTransitioningScreen("SM_GoToNextScreen")
+				SCREENMAN:GetTopScreen():SetNextScreenName(Branch.GameplayScreen()):StartTransitioningScreen("SM_GoToNextScreen")
 			end
 		elseif event.DeviceInput.button == "DeviceButton_p" then
 			if holdingCtrl then

--- a/BGAnimations/ScreenGameplay out.lua
+++ b/BGAnimations/ScreenGameplay out.lua
@@ -4,6 +4,7 @@ return Def.Quad{
 	OffCommand=function(self)
 		if SL.Global.GameMode == "ITG" then
 			local song = GAMESTATE:GetCurrentSong()
+			local totalWhites = 0
 			for player in ivalues( GAMESTATE:GetHumanPlayers() ) do
 				local pn = ToEnumShortString(player)
 				local pss = STATSMAN:GetCurStageStats():GetPlayerStageStats(player)
@@ -11,6 +12,7 @@ return Def.Quad{
 				local faPlus = SL[pn].Stages.Stats[SL.Global.Stages.PlayedThisGame + 1].ex_counts.W0_total
 				-- Subtract FA+ count from the overall fantastic window count.
 				local whites = number - faPlus
+				totalWhites = totalWhites + whites
 				-- This will save the white count to Stats.xml, so we can later recover
 				-- it when we deprecate FA+ mode and introduce W0.
 				--
@@ -31,6 +33,23 @@ return Def.Quad{
 					end
 				end
 				pss:SetScore(bestWhites)
+			end
+			if IsRoutine() then
+				local routineStats = STATSMAN:GetCurStageStats():GetRoutineStageStats()
+				local bestWhites = totalWhites
+				if PROFILEMAN:IsPersistentProfile(GAMESTATE:GetMasterPlayerNumber()) then
+					local steps = GAMESTATE:GetCurrentSteps(GAMESTATE:GetMasterPlayerNumber())
+					local scores = PROFILEMAN:GetProfile(GAMESTATE:GetMasterPlayerNumber()):GetHighScoreList(song, steps):GetHighScores()
+					for hs in ivalues(scores) do
+						-- If the player previously quadded the song, retain the better white count.
+						-- Technically this is a workaround because the date would be wrong, but
+						-- it's still worth to keep the score around
+						if (routineStats:GetPercentDancePoints() == hs:GetPercentDP() and hs:GetPercentDP() == 1.0) then
+							bestWhites = math.min(bestWhites, hs:GetScore())
+						end
+					end
+				end
+				routineStats:SetScore(bestWhites)
 			end
 		end
 	end

--- a/BGAnimations/ScreenGameplay overlay/TrackFailTime.lua
+++ b/BGAnimations/ScreenGameplay overlay/TrackFailTime.lua
@@ -110,6 +110,7 @@ local af = Def.Actor{
 			local currentMeasure = math.floor(playerState:GetSongPosition():GetSongBeatVisible()/4)
 
 			local streams = SL[pn].Streams
+            if streams == nil then return end
 			local storage = SL[pn].Stages.Stats[SL.Global.Stages.PlayedThisGame + 1]
 
 			storage.TotalSeconds = totalSeconds

--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/BackgroundFilter.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/BackgroundFilter.lua
@@ -4,6 +4,7 @@ local mods = SL[pn].ActiveModifiers
 
 -- if no BackgroundFilter is necessary, it's safe to bail now
 if mods.BackgroundFilter == "Off" then return end
+if IsRoutine() and player ~= GAMESTATE:GetMasterPlayerNumber() then return end
 
 local FilterAlpha = BackgroundFilterValues()
 return Def.Quad{

--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/BackgroundFilter.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/BackgroundFilter.lua
@@ -1,9 +1,9 @@
 local player = ...
 local pn = ToEnumShortString(player)
 local mods = SL[pn].ActiveModifiers
-
 -- if no BackgroundFilter is necessary, it's safe to bail now
 if mods.BackgroundFilter == "Off" then return end
+if IsRoutine() and player ~= GAMESTATE:GetMasterPlayerNumber() then return end
 
 local FilterAlpha = BackgroundFilterValues()
 return Def.Quad{

--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/BackgroundFilter.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/BackgroundFilter.lua
@@ -3,7 +3,7 @@ local pn = ToEnumShortString(player)
 local mods = SL[pn].ActiveModifiers
 -- if no BackgroundFilter is necessary, it's safe to bail now
 if mods.BackgroundFilter == "Off" then return end
-if IsRoutine() and player ~= GAMESTATE:GetMasterPlayerNumber() then return end
+if IsCouples() and player ~= GAMESTATE:GetMasterPlayerNumber() then return end
 
 local FilterAlpha = BackgroundFilterValues()
 return Def.Quad{

--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/NoteField/DisplayMods.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/NoteField/DisplayMods.lua
@@ -6,7 +6,12 @@ local optionslist = GetPlayerOptionsString(player)
 
 local af = Def.ActorFrame{
   InitCommand = function(self)
-    self:diffusealpha(1):xy(GetNotefieldX(player), SCREEN_HEIGHT/4*1.3)
+    if GAMESTATE:GetCurrentStyle():GetStyleType() == "StyleType_TwoPlayersSharedSides" then
+      -- if p1 3/4 of the notefielx, if p2 5/4
+        self:diffusealpha(1):xy(GetNotefieldX(player) / (player == PLAYER_1 and 0.825 or 1.25), SCREEN_HEIGHT/4*1.3)
+		else
+      self:diffusealpha(1):xy(GetNotefieldX(player), SCREEN_HEIGHT/4*1.3)
+    end
   end,
   OnCommand=function(self)
     self:sleep(5):decelerate(0.5):diffusealpha(0)

--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/Score.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/Score.lua
@@ -32,6 +32,10 @@ local pos = {
 
 local pss = STATSMAN:GetCurStageStats():GetPlayerStageStats(player)
 
+if styletype == "TwoPlayersSharedSides" then
+	pss = STATSMAN:GetCurStageStats():GetRoutineStageStats()
+end
+
 local StepsOrTrail = (GAMESTATE:IsCourseMode() and GAMESTATE:GetCurrentTrail(player)) or GAMESTATE:GetCurrentSteps(player)
 local total_tapnotes = StepsOrTrail:GetRadarValues(player):GetValue( "RadarCategory_Notes" )
 
@@ -51,6 +55,32 @@ local ar_scale = {
 local zoom_factor = clamp(scale(GetScreenAspectRatio(), 16/10, 16/9, ar_scale.sixteen_ten, ar_scale.sixteen_nine), 0, 1.125)
 
 -- -----------------------------------------------------------------------
+local function MakePercentScore(actual, possible)
+    if possible == 0 then
+        return 0 -- avoid division by zero
+    end
+
+    if actual == possible then
+        return 1 -- correct for rounding error
+    end
+
+    local percent = actual / possible
+
+    -- Ensure percent is not negative
+    percent = math.max(0.0, percent)
+
+    -- Number of decimal places for percent score
+    local percentTotalDigits = 3 + 2
+    local truncInterval = math.pow(0.1, percentTotalDigits - 1)
+
+    -- Small adjustment to avoid rounding issues
+    percent = percent + 0.000001
+
+    -- Truncate to the desired precision
+    percent = math.floor(percent / truncInterval) * truncInterval
+
+    return percent
+end
 
 return LoadFont("Wendy/_wendy monospace numbers")..{
 	Text="0.00",

--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/Score.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/Score.lua
@@ -33,7 +33,7 @@ local pos = {
 local pss = STATSMAN:GetCurStageStats():GetPlayerStageStats(player)
 
 if styletype == "TwoPlayersSharedSides" then
-	pss = STATSMAN:GetCurStageStats():GetRoutineStageStats()
+	pss = STATSMAN:GetCurStageStats():GetSharedPlayerStageStats()
 end
 
 local StepsOrTrail = (GAMESTATE:IsCourseMode() and GAMESTATE:GetCurrentTrail(player)) or GAMESTATE:GetCurrentSteps(player)

--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/StepStatistics/DensityGraph.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/StepStatistics/DensityGraph.lua
@@ -138,7 +138,7 @@ local text = LoadFont("Common Normal")..{
 		end
 
 		self:y( -self:GetHeight()/2 - 2 )
-		self:settext( ("%s: %g"):format(THEME:GetString("ScreenGameplay", "PeakNPS"), round(my_peak * SL.Global.ActiveModifiers.MusicRate,2)) )
+		self:settext( ("%s: %g"):format(THEME:GetString(Branch.GameplayScreen(), "PeakNPS"), round(my_peak * SL.Global.ActiveModifiers.MusicRate,2)) )
 	end,
 }
 

--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/StepStatistics/Time.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/StepStatistics/Time.lua
@@ -205,7 +205,7 @@ af[#af+1] = LoadFont("Common Normal")..{
 
 -- remaining time label
 af[#af+1] = LoadFont("Common Normal")..{
-	Text=("%s "):format( THEME:GetString("ScreenGameplay", "Remaining") ),
+	Text=("%s "):format( THEME:GetString(Branch.GameplayScreen(), "Remaining") ),
 	InitCommand=function(self)
 		if style ~= "double" then
 			self:halign(PlayerNumber:Reverse()[player]):vertalign(bottom)
@@ -276,7 +276,7 @@ af[#af+1] = LoadFont("Common Normal")..{
 			self:halign( PlayerNumber:Reverse()[OtherPlayer[player]] )
 		end
 
-		local s = GAMESTATE:IsCourseMode() and THEME:GetString("ScreenGameplay", "Course") or THEME:GetString("ScreenGameplay", "Song")
+		local s = GAMESTATE:IsCourseMode() and THEME:GetString(Branch.GameplayScreen(), "Course") or THEME:GetString(Branch.GameplayScreen(), "Song")
 		self:settext( ("%s "):format(s) )
 	end,
 	OnCommand=function(self)

--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/TargetScore/ActionOnTargetMissed.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/TargetScore/ActionOnTargetMissed.lua
@@ -26,7 +26,7 @@ local args = {
 
 			elseif RestartOnMissedTarget then
 				-- EventMode is assumed (i.e. not CoinMode_Pay), so no need to fuss with managing stage counts for SL or SM
-				SCREENMAN:GetTopScreen():SetPrevScreenName("ScreenGameplay"):SetNextScreenName("ScreenGameplay"):begin_backing_out()
+				SCREENMAN:GetTopScreen():SetPrevScreenName(Branch.GameplayScreen()):SetNextScreenName(Branch.GameplayScreen()):begin_backing_out()
 			end
 		end
 	end

--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/UpperNPSGraph.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/UpperNPSGraph.lua
@@ -13,7 +13,7 @@ local horizontal_padding = 30
 local height = 30
 local width  = GetNotefieldWidth()
 
--- support double, double8, and routine by constraining the UpperNPSGraph to have the same width as in single
+-- support double, double8, and couples by constraining the UpperNPSGraph to have the same width as in single
 local styletype = ToEnumShortString(GAMESTATE:GetCurrentStyle():GetStyleType())
 if styletype == "OnePlayerTwoSides" or styletype == "TwoPlayersSharedSides" then
 	width = width/2
@@ -34,7 +34,7 @@ local xpos = {
 }
 
 
--- center the UpperNPSGraph in double, double8, routine, dance solo, when Center1Player is enabled, etc.
+-- center the UpperNPSGraph in double, double8, couples, dance solo, when Center1Player is enabled, etc.
 if GetNotefieldX(player) == _screen.cx then
 	xpos[PLAYER_1] = _screen.cx - width/2
 	xpos[PLAYER_2] = _screen.cx - width/2

--- a/BGAnimations/ScreenGameplay underlay/default.lua
+++ b/BGAnimations/ScreenGameplay underlay/default.lua
@@ -14,7 +14,7 @@ local RestartHandler = function(event)
 			holdingCtrl = true
 		elseif event.DeviceInput.button == "DeviceButton_r" then
 			if holdingCtrl then
-				SCREENMAN:GetTopScreen():SetPrevScreenName("ScreenGameplay"):SetNextScreenName("ScreenGameplay"):begin_backing_out()
+				SCREENMAN:GetTopScreen():SetPrevScreenName(Branch.GameplayScreen()):SetNextScreenName(Branch.GameplayScreen()):begin_backing_out()
 			end
 		end
 	elseif event.type == "InputEventType_Release" then
@@ -22,6 +22,33 @@ local RestartHandler = function(event)
 			holdingCtrl = false
 		end
 	end
+end
+
+local po = {}
+for player in ivalues(GAMESTATE:GetHumanPlayers()) do
+	po[player] = GAMESTATE:GetPlayerState(player):GetPlayerOptions('ModsLevel_Song')
+end
+-- If the style is TwoPlayersSharedSides, we need to set the speed mod for the routine as well
+if GAMESTATE:GetCurrentStyle():GetStyleType() == "StyleType_TwoPlayersSharedSides" then
+	local xmod = po[GAMESTATE:GetMasterPlayerNumber()]:XMod()
+	local mmod = po[GAMESTATE:GetMasterPlayerNumber()]:MMod()
+	local cmod = po[GAMESTATE:GetMasterPlayerNumber()]:CMod()
+
+	local mini = tonumber(SL[ToEnumShortString(GAMESTATE:GetMasterPlayerNumber())].ActiveModifiers.Mini:sub(1, -2)) / 100
+
+	local speedmod = SL[ToEnumShortString(GAMESTATE:GetMasterPlayerNumber())].ActiveModifiers.SpeedMod
+	local speedmod_str = (cmod ~= nil and "CMod") or (mmod ~= nil and "MMod") or (xmod ~= nil and "XMod")
+
+	local fmt = {
+		XMod = "mod,%.2fx",
+		MMod = "mod,m%d",
+		CMod = "mod,c%d",
+	}
+	local gcString = fmt[speedmod_str]:format(speedmod)
+	gcString = gcString ..""
+	GAMESTATE:ApplyGameCommand(gcString.."mod,"..SL[ToEnumShortString(GAMESTATE:GetMasterPlayerNumber())].ActiveModifiers.Mini.." mini", PLAYER_2)
+	GAMESTATE:ApplyGameCommand(gcString.."mod,"..SL[ToEnumShortString(GAMESTATE:GetMasterPlayerNumber())].ActiveModifiers.Mini.." mini", PLAYER_1)
+
 end
 
 local t = Def.ActorFrame{

--- a/BGAnimations/ScreenGameplay underlay/default.lua
+++ b/BGAnimations/ScreenGameplay underlay/default.lua
@@ -28,7 +28,7 @@ local po = {}
 for player in ivalues(GAMESTATE:GetHumanPlayers()) do
 	po[player] = GAMESTATE:GetPlayerState(player):GetPlayerOptions('ModsLevel_Song')
 end
--- If the style is TwoPlayersSharedSides, we need to set the speed mod for the routine as well
+-- If the style is TwoPlayersSharedSides, we need to set the speed mod for the couple as well
 if GAMESTATE:GetCurrentStyle():GetStyleType() == "StyleType_TwoPlayersSharedSides" then
 	local xmod = po[GAMESTATE:GetMasterPlayerNumber()]:XMod()
 	local mmod = po[GAMESTATE:GetMasterPlayerNumber()]:MMod()

--- a/BGAnimations/ScreenPlayerOptions overlay/default.lua
+++ b/BGAnimations/ScreenPlayerOptions overlay/default.lua
@@ -211,6 +211,9 @@ local t = Def.ActorFrame{
 			local VariantRowIndex = FindOptionRowIndex(ScreenOptions,"NoteSkinVariant")
 			if GAMESTATE:GetCurrentStyle():GetStyleType() == "StyleType_TwoPlayersSharedSides" then
 				if player == GAMESTATE:GetMasterPlayerNumber() then
+					local otherPn = pn == "P1" and "P2" or "P1"
+					SL[otherPn].ActiveModifiers.SpeedMod     = SL[pn].ActiveModifiers.SpeedMod
+					SL[otherPn].ActiveModifiers.SpeedModType = SL[pn].ActiveModifiers.SpeedModType
 					SpeedModBMTs[pn] = ScreenOptions:GetOptionRow(SpeedModRowIndex):GetChild(""):GetChild("Item")
 				end
 			else

--- a/BGAnimations/ScreenPlayerOptions overlay/default.lua
+++ b/BGAnimations/ScreenPlayerOptions overlay/default.lua
@@ -15,6 +15,41 @@ local speedmod_def = {
 	M = { upper=2000, increment=5 }
 }
 
+-- In Routine (couples) mode, default players to the red and blue couples skins
+-- if they aren't already on a couples noteskin.
+if IsRoutine() then
+	local couples_noteskin
+	for skin in ivalues(NOTESKIN:GetNoteSkinNames(false)) do
+		if skin:lower() == "couples" then
+			couples_noteskin = skin
+			break
+		end
+	end
+
+	if couples_noteskin then
+		local already_on_couples = true
+		for player in ivalues(GAMESTATE:GetHumanPlayers()) do
+			local current = SL[ToEnumShortString(player)].ActiveModifiers.NoteSkin or ""
+			if current:lower() ~= couples_noteskin:lower() then
+				already_on_couples = false
+				break
+			end
+		end
+
+		if not already_on_couples then
+			local variants = NOTESKIN:GetVariantNamesForNoteSkin(couples_noteskin) or {}
+			local defaults = { P1 = "couples__blue", P2 = "couples__red" }
+			for player in ivalues(GAMESTATE:GetHumanPlayers()) do
+				local pn = ToEnumShortString(player)
+				SL[pn].ActiveModifiers.NoteSkin = couples_noteskin
+				if defaults[pn] then
+					SL[pn].ActiveModifiers.NoteSkinVariant = defaults[pn]
+				end
+			end
+		end
+	end
+end
+
 local variants_def = {}
 for player in ivalues( GAMESTATE:GetHumanPlayers() ) do
 	local pn = ToEnumShortString(player)
@@ -23,7 +58,9 @@ for player in ivalues( GAMESTATE:GetHumanPlayers() ) do
 		if NOTESKIN:HasVariants(noteskin_name) then
 			variants_def[pn] = NOTESKIN:GetVariantNamesForNoteSkin(noteskin_name)
 			-- Put the current NoteSkin at the front of the list of variants so that it's the default selection when we refresh the OptionRow
-			table.insert(variants_def[pn], 1, noteskin_name)
+			if not IsRoutine() then
+				table.insert(variants_def[pn], 1, noteskin_name)
+			end
 		else
 			variants_def[pn] = {noteskin_name}
 		end
@@ -235,7 +272,6 @@ local t = Def.ActorFrame{
 			if variant_bmt then
 				local current_variant = SL[pn].ActiveModifiers.NoteSkinVariant or ""
 				local screen = SCREENMAN:GetTopScreen()
-
 				MESSAGEMAN:Broadcast("RefreshActorProxy", {Player=player, Name="NoteSkinVariant", Value=current_variant})
 				screen:RedrawOptions() 
 			end

--- a/BGAnimations/ScreenPlayerOptions overlay/default.lua
+++ b/BGAnimations/ScreenPlayerOptions overlay/default.lua
@@ -32,6 +32,25 @@ end
 
 local song = GAMESTATE:GetCurrentSong()
 
+-- Use this function to find an OptionRow by name so that you can manipulate its text as needed.
+--     first argument is a screen object provided by SCREENMAN:GetTopScreen()
+--     second argument is a string that might match the name of an OptionRow somewhere on this screen
+--
+--     returns the 0-based index of that OptionRow within this screen
+
+local FindOptionRowIndex = function(ScreenOptions, Name)
+	if not ScreenOptions or not ScreenOptions.GetNumRows then return end
+
+	local num_rows = ScreenOptions:GetNumRows()
+
+	-- OptionRows on ScreenOptions are 0-indexed, so start counting from 0
+	for i=0,num_rows-1 do
+		if ScreenOptions:GetOptionRow(i):GetName() == Name then
+			return i
+		end
+	end
+end
+
 ------------------------------------------------------------
 -- functions local to this file
 
@@ -41,7 +60,18 @@ local song = GAMESTATE:GetCurrentSong()
 local CalculateScrollSpeed = function(player)
 	player   = player or GAMESTATE:GetMasterPlayerNumber()
 	local pn = ToEnumShortString(player)
-
+	local ScreenOptions = SCREENMAN:GetTopScreen()
+	local SpeedModRowIndex = FindOptionRowIndex(ScreenOptions,"Mini")
+	local mini = 0
+	if SpeedModRowIndex then
+		-- The BitmapText actors for P1 and P2 speedmod are both named "Item", so we need to provide a 1 or 2 to index
+		if GAMESTATE:GetCurrentStyle():GetStyleType() == "StyleType_TwoPlayersSharedSides" then
+			miniText = ScreenOptions:GetOptionRow(SpeedModRowIndex):GetChild(""):GetChild("Item"):GetText()
+		else
+			miniText = ScreenOptions:GetOptionRow(SpeedModRowIndex):GetChild(""):GetChild("Item")[ PlayerNumber:Reverse()[player]+1 ]:GetText()
+		end
+		mini = tonumber(miniText:sub(1, -2)) / 100
+	end
 	local StepsOrTrail = (GAMESTATE:IsCourseMode() and GAMESTATE:GetCurrentTrail(player)) or GAMESTATE:GetCurrentSteps(player)
 	local MusicRate    = SL.Global.ActiveModifiers.MusicRate or 1
 
@@ -90,25 +120,10 @@ local ChangeSpeedMod = function(pn, direction)
 	speedmod = increment * math.floor(speedmod/increment + 0.5)
 
 	mods.SpeedMod = speedmod
-end
-
-
--- Use this function to find an OptionRow by name so that you can manipulate its text as needed.
---     first argument is a screen object provided by SCREENMAN:GetTopScreen()
---     second argument is a string that might match the name of an OptionRow somewhere on this screen
---
---     returns the 0-based index of that OptionRow within this screen
-
-local FindOptionRowIndex = function(ScreenOptions, Name)
-	if not ScreenOptions or not ScreenOptions.GetNumRows then return end
-
-	local num_rows = ScreenOptions:GetNumRows()
-
-	-- OptionRows on ScreenOptions are 0-indexed, so start counting from 0
-	for i=0,num_rows-1 do
-		if ScreenOptions:GetOptionRow(i):GetName() == Name then
-			return i
-		end
+	if GAMESTATE:GetCurrentStyle():GetStyleType() == "StyleType_TwoPlayersSharedSides" then
+		local otherPn = pn == "P1" and "P2" or "P1"
+		SL[otherPn].ActiveModifiers.SpeedMod     = SL[pn].ActiveModifiers.SpeedMod
+		SL[otherPn].ActiveModifiers.SpeedModType = SL[pn].ActiveModifiers.SpeedModType
 	end
 end
 
@@ -157,10 +172,16 @@ local t = Def.ActorFrame{
 
 			local SpeedModRowIndex = FindOptionRowIndex(ScreenOptions,"SpeedMod")
 			local VariantRowIndex = FindOptionRowIndex(ScreenOptions,"NoteSkinVariant")
-			if SpeedModRowIndex then
-				-- The BitmapText actors for P1 and P2 speedmod are both named "Item", so we need to provide a 1 or 2 to index
-				SpeedModBMTs[pn] = ScreenOptions:GetOptionRow(SpeedModRowIndex):GetChild(""):GetChild("Item")[ PlayerNumber:Reverse()[player]+1 ]
-				self:playcommand("Set"..pn)
+			if GAMESTATE:GetCurrentStyle():GetStyleType() == "StyleType_TwoPlayersSharedSides" then
+				if player == GAMESTATE:GetMasterPlayerNumber() then
+					SpeedModBMTs[pn] = ScreenOptions:GetOptionRow(SpeedModRowIndex):GetChild(""):GetChild("Item")
+				end
+			else
+				if SpeedModRowIndex then
+					-- The BitmapText actors for P1 and P2 speedmod are both named "Item", so we need to provide a 1 or 2 to index
+					SpeedModBMTs[pn] = ScreenOptions:GetOptionRow(SpeedModRowIndex):GetChild(""):GetChild("Item")[ PlayerNumber:Reverse()[player]+1 ]
+					self:playcommand("Set"..pn)
+				end
 			end
 			if VariantRowIndex then
 				-- The BitmapText actors for P1 and P2 variant are both named "Item", so we need to provide a 1 or 2 to index
@@ -239,13 +260,21 @@ t[#t+1] = LoadActor(THEME:GetPathB("ScreenPlayerOptions", "common"))
 
 for player in ivalues(GAMESTATE:GetHumanPlayers()) do
 	local pn = ToEnumShortString(player)
+	local original_pn = pn
 	local song = GAMESTATE:GetCurrentSong()
 
 	t[#t+1] = Def.Actor{
 
 		-- this is called from ./Scripts/SL-PlayerOptions.lua when the player changes their SpeedModType (X, M, C)
 		["SpeedModType" .. pn .. "SetMessageCommand"]=function(self,params)
-			if params.Player ~= player then return end
+			local pn = pn
+			local player = player
+			if GAMESTATE:GetCurrentStyle():GetStyleType() == "StyleType_TwoPlayersSharedSides" then
+				pn = ToEnumShortString(GAMESTATE:GetMasterPlayerNumber())
+				player = GAMESTATE:GetMasterPlayerNumber()
+			else
+				if params.Player ~= player  then return end
+			end
 
 			local oldtype = SL[pn].ActiveModifiers.SpeedModType
 			local newtype = params.SpeedModType
@@ -274,13 +303,17 @@ for player in ivalues(GAMESTATE:GetHumanPlayers()) do
 
 			SL[pn].ActiveModifiers.SpeedMod     = speedmod
 			SL[pn].ActiveModifiers.SpeedModType = newtype
-
+			if GAMESTATE:GetCurrentStyle():GetStyleType() == "StyleType_TwoPlayersSharedSides" then
+				local otherPn = pn == "P1" and "P2" or "P1"
+				SL[otherPn].ActiveModifiers.SpeedMod     = SL[pn].ActiveModifiers.SpeedMod
+				SL[otherPn].ActiveModifiers.SpeedModType = SL[pn].ActiveModifiers.SpeedModType
+			end
 			self:queuecommand("Set" .. pn)
 		end,
 
 		["Set" .. pn .. "Command"]=function(self)
 			local text = ""
-
+			local pn = pn
 			if  SL[pn].ActiveModifiers.SpeedModType == "X" then
 				text = string.format("%.2f" , SL[pn].ActiveModifiers.SpeedMod ) .. "x"
 
@@ -291,14 +324,19 @@ for player in ivalues(GAMESTATE:GetHumanPlayers()) do
 				text = "M" .. tostring(SL[pn].ActiveModifiers.SpeedMod)
 			end
 
-			SpeedModBMTs[pn]:settext( text )
+			if GAMESTATE:GetCurrentStyle():GetStyleType() == "StyleType_TwoPlayersSharedSides" then
+				local otherPn = pn == "P1" and "P2" or "P1"
+				SpeedModBMTs[ToEnumShortString(GAMESTATE:GetMasterPlayerNumber())]:settext( text )
+			else
+				SpeedModBMTs[pn]:settext( text )
+			end
 			self:GetParent():queuecommand("Refresh")
 		end,
 		["Set" .. pn .. "VariantCommand"]=function(self)
-			local current_variant = SL[pn].ActiveModifiers.NoteSkinVariant or SL[pn].ActiveModifiers.NoteSkin
+			local current_variant = SL[original_pn].ActiveModifiers.NoteSkinVariant or SL[original_pn].ActiveModifiers.NoteSkin
 			-- Get all text after first _ to get the variant name
 			current_variant = current_variant:match("_(.*)") or current_variant
-			VariantBMTs[pn]:settext( current_variant )
+			VariantBMTs[original_pn]:settext( current_variant )
 			self:GetParent():queuecommand("RefreshVariants")
 		end,
 
@@ -306,36 +344,44 @@ for player in ivalues(GAMESTATE:GetHumanPlayers()) do
 		["CurrentTrail" .. pn .. "ChangedMessageCommand"]=function(self) self:queuecommand("Set"..pn) end,
 
 		["MenuLeft" .. pn .. "MessageCommand"]=function(self)
+			local pn = pn
+			if GAMESTATE:GetCurrentStyle():GetStyleType() == "StyleType_TwoPlayersSharedSides" then
+				pn = ToEnumShortString(GAMESTATE:GetMasterPlayerNumber())
+			end
 			local topscreen = SCREENMAN:GetTopScreen()
 			local row_index = topscreen:GetCurrentRowIndex(player)
 
 			if row_index == FindOptionRowIndex(topscreen, "SpeedMod") then
 				ChangeSpeedMod( pn, -1 )
-				self:queuecommand("Set"..pn)
+				self:queuecommand("Set"..original_pn)
 			end
 			if row_index == FindOptionRowIndex(topscreen, "NoteSkinVariant") then
-				ChangeVariant( pn, -1 )
-				self:queuecommand("Set"..pn.."Variant")
+				ChangeVariant( original_pn, -1 )
+				self:queuecommand("Set"..original_pn.."Variant")
 			end
 			if row_index == FindOptionRowIndex(topscreen, "NoteSkin") then
-				ChangeVariant( pn, 0 )
-				self:queuecommand("Set"..pn.."Variant")
+				ChangeVariant( original_pn, 0 )
+				self:queuecommand("Set"..original_pn.."Variant")
 			end
 		end,
 		["MenuRight" .. pn .. "MessageCommand"]=function(self)
+			local pn = pn
+			if GAMESTATE:GetCurrentStyle():GetStyleType() == "StyleType_TwoPlayersSharedSides" then
+				pn = ToEnumShortString(GAMESTATE:GetMasterPlayerNumber())
+			end
 			local topscreen = SCREENMAN:GetTopScreen()
 			local row_index = topscreen:GetCurrentRowIndex(player)
 
 			if row_index == FindOptionRowIndex(topscreen, "SpeedMod") then
 				ChangeSpeedMod( pn, 1 )
-				self:queuecommand("Set"..pn)
+				self:queuecommand("Set"..original_pn)
 			end
 			if row_index == FindOptionRowIndex(topscreen, "NoteSkinVariant") then
-				ChangeVariant( pn, 1 )
-				self:queuecommand("Set"..pn.."Variant")
+				ChangeVariant( original_pn, 1 )
+				self:queuecommand("Set"..original_pn.."Variant")
 			elseif row_index == FindOptionRowIndex(topscreen, "NoteSkin") then
-				ChangeVariant( pn, 0 )
-				self:queuecommand("Set"..pn.."Variant")
+				ChangeVariant( original_pn, 0 )
+				self:queuecommand("Set"..original_pn.."Variant")
 			end
 		end
 	}
@@ -348,6 +394,10 @@ for player in ivalues(GAMESTATE:GetHumanPlayers()) do
 			self:diffuse(PlayerColor(player)):diffusealpha(0)
 			self:zoom(0.5):y(48)
 			self:x(player==PLAYER_1 and WideScale(-77, -100) or WideScale(140,154))
+			-- If we're in TwoPlayersSharedSides, center the text
+			if GAMESTATE:GetCurrentStyle():GetStyleType() == "StyleType_TwoPlayersSharedSides" then
+				self:x(WideScale(-77, -100) + WideScale(140,154)) :halign(0.65)
+			end
 			self:shadowlength(0.55)
 		end,
 		OnCommand=function(self) self:linear(0.4):diffusealpha(1) end,

--- a/BGAnimations/ScreenPlayerOptions overlay/default.lua
+++ b/BGAnimations/ScreenPlayerOptions overlay/default.lua
@@ -397,6 +397,9 @@ for player in ivalues(GAMESTATE:GetHumanPlayers()) do
 			-- If we're in TwoPlayersSharedSides, center the text
 			if GAMESTATE:GetCurrentStyle():GetStyleType() == "StyleType_TwoPlayersSharedSides" then
 				self:x(WideScale(-77, -100) + WideScale(140,154)) :halign(0.65)
+				if pn ~= ToEnumShortString(GAMESTATE:GetMasterPlayerNumber()) then
+					self:visible(false)
+				end
 			end
 			self:shadowlength(0.55)
 		end,

--- a/BGAnimations/ScreenPlayerOptions overlay/default.lua
+++ b/BGAnimations/ScreenPlayerOptions overlay/default.lua
@@ -174,6 +174,9 @@ local t = Def.ActorFrame{
 			local VariantRowIndex = FindOptionRowIndex(ScreenOptions,"NoteSkinVariant")
 			if GAMESTATE:GetCurrentStyle():GetStyleType() == "StyleType_TwoPlayersSharedSides" then
 				if player == GAMESTATE:GetMasterPlayerNumber() then
+					local otherPn = pn == "P1" and "P2" or "P1"
+					SL[otherPn].ActiveModifiers.SpeedMod     = SL[pn].ActiveModifiers.SpeedMod
+					SL[otherPn].ActiveModifiers.SpeedModType = SL[pn].ActiveModifiers.SpeedModType
 					SpeedModBMTs[pn] = ScreenOptions:GetOptionRow(SpeedModRowIndex):GetChild(""):GetChild("Item")
 				end
 			else

--- a/BGAnimations/ScreenSelectMusic overlay/AutoSetStyle.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/AutoSetStyle.lua
@@ -1,0 +1,62 @@
+-- if Metric.ini's [Common] has AutoSetStyle=true
+-- this will allow stepcharts from disparate styles (single, double, routine, halfdouble, etc.)
+-- to appear side-by-side in the same MusicWheel.  It's pretty cool.
+--
+-- But like most things in StepMania, the feature has some UX quirks
+-- (probably oversights in the initial implementation that never saw further work)
+-- that we'll address here in the theme's Lua.
+--
+-- The quirk here is that ScreenSelectMusic seems to only present all playable stepcharts
+-- the first time it loads.  Let's say there are ten songs, and
+--     all 10 of the songs have at least one singles stepchart
+--     7 of the songs have at least one doubles stepchart
+--     2 of the songs have at least one halfdoubles stepchart
+--
+-- When ScreenSelectMusic first loads, I'll see all ten songs.
+-- If I choose and play a doubles stepchart as my first stage, the MusicWheel will
+-- then only show 7 songs when I get back to choose my 2nd song, seemingly because the
+-- SM engine now has "double" set as its current style.
+-- If I then choose and play a halfdouble stepchart, the MusicWheel will
+-- show 2 songs when I return to select my 3rd song. And if I play a singles
+-- stepchart, the MusicWheel will return to show all 10 songs.
+--
+-- My workaround here is to set (or reset) the engine's style to either
+-- "single" (if 1 player is joined) or "versus" (if 2 players are joined) every time
+-- ScreenSelectMusic is about to load, before any of its actors have been processed yet.
+--
+-- I haven't dug into the engine's src, but it seems that having the style set to "single"
+-- is how to get the most playable stepcharts to appear in AutoSetStyle.
+--      -quietly
+
+local actor = Def.Actor{}
+
+if THEME:GetMetric("Common", "AutoSetStyle") == true then
+
+	-- first, store the current steps for each player
+	-- if this is the first time SSM is loading, GetCurrentSteps() will return nil
+	-- otherwise, it will be a steps object
+	local current_steps = {}
+	for player in ivalues(PlayerNumber) do
+		current_steps[player] = GAMESTATE:GetCurrentSteps(player)
+	end
+
+	-- next, force the engine's style to either "single" or "versus"
+	-- this will allow AutoSetStyle to present the most playable stepcharts
+	-- in the MusicWheel.
+	-- This has the side-effect of changing the player's current stepchart
+	-- to the first available singles stepchart, but we can counteract that next...
+	local styles = { "single", "versus" }
+	GAMESTATE:SetCurrentStyle( styles[GAMESTATE:GetNumSidesJoined()] )
+
+	-- finally, set up this Actor's OnCommand to set each player's stepchart
+	-- to whatever it was before we forcibly changed the engine's style.
+	actor.OnCommand=function(self)
+		for player in ivalues(PlayerNumber) do
+			if current_steps[player] then
+				GAMESTATE:SetCurrentSteps(player, current_steps[player])
+			end
+		end
+	end
+end
+
+return actor

--- a/BGAnimations/ScreenSelectMusic overlay/AutoSetStyle.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/AutoSetStyle.lua
@@ -1,5 +1,5 @@
 -- if Metric.ini's [Common] has AutoSetStyle=true
--- this will allow stepcharts from disparate styles (single, double, routine, halfdouble, etc.)
+-- this will allow stepcharts from disparate styles (single, double, couples, halfdouble, etc.)
 -- to appear side-by-side in the same MusicWheel.  It's pretty cool.
 --
 -- But like most things in StepMania, the feature has some UX quirks

--- a/BGAnimations/ScreenSelectMusic overlay/PaneDisplay.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/PaneDisplay.lua
@@ -391,6 +391,13 @@ for player in ivalues(PlayerNumber) do
 		end
 	}
 
+		-- -----------------------------------------------------------------------
+	-- tabs along the top of the PaneDisplay, one per available stepchart
+
+	if ThemePrefs.Get("PreferredStyle")=="auto" then
+		af2[#af2+1] = LoadActor("./StepsDisplayList/TabbedStepchartList/default.lua", {player, _screen.w/2 - 10})
+	end
+
 	-- -----------------------------------------------------------------------
 	-- loop through the six sub-tables in the PaneItems table
 	-- add one BitmapText as the label and one BitmapText as the value for each PaneItem

--- a/BGAnimations/ScreenSelectMusic overlay/PaneDisplay.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/PaneDisplay.lua
@@ -83,7 +83,6 @@ local GetScoresRequestProcessor = function(res, params)
 
 	for i=1,2 do
 		local paneDisplay = master:GetChild("PaneDisplayP"..i)
-
 		local machineScore = paneDisplay:GetChild("MachineHighScore")
 		local machineName = paneDisplay:GetChild("MachineHighScoreName")
 
@@ -408,6 +407,13 @@ for player in ivalues(PlayerNumber) do
 			end
 		end
 	}
+
+		-- -----------------------------------------------------------------------
+	-- tabs along the top of the PaneDisplay, one per available stepchart
+
+	if ThemePrefs.Get("PreferredStyle")=="auto" then
+		af2[#af2+1] = LoadActor("./StepsDisplayList/TabbedStepchartList/default.lua", {player, _screen.w/2 - 10})
+	end
 
 	-- -----------------------------------------------------------------------
 	-- loop through the six sub-tables in the PaneItems table

--- a/BGAnimations/ScreenSelectMusic overlay/PerPlayer/Cursor.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/PerPlayer/Cursor.lua
@@ -17,9 +17,8 @@ return Def.Sprite{
 	Texture=THEME:GetPathB("ScreenSelectMusic", "overlay/PerPlayer/arrow.png"),
 	Name="Cursor"..pn,
 	InitCommand=function(self)
-		self:visible( GAMESTATE:IsHumanPlayer(player) )
+		self:visible( GAMESTATE:IsHumanPlayer(player) and not ThemePrefs.Get("PreferredStyle")=="auto" )
 		self:halign( p ):zoom(0.575)
-
 		-- FIXME: SM5.1-beta's EffectClock enum includes constants for
 		--   CLOCK_BGM_BEAT_PLAYER1 and CLOCK_BGM_BEAT_PLAYER2 but
 		--   but effectclock(), the only method currently available via
@@ -53,7 +52,7 @@ return Def.Sprite{
 	end,
 
 	PlayerJoinedMessageCommand=function(self, params)
-		if params.Player == player then self:visible(true) end
+		if params.Player == player then self:visible(not ThemePrefs.Get("PreferredStyle")=="auto") end
 	end,
 	PlayerUnjoinedMessageCommand=function(self, params)
 		if params.Player == player then self:visible(false) end

--- a/BGAnimations/ScreenSelectMusic overlay/PerPlayer/Cursor.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/PerPlayer/Cursor.lua
@@ -10,14 +10,14 @@ local p = PlayerNumber:Reverse()[player]
 local GetStepsToDisplay = LoadActor("../StepsDisplayList/StepsToDisplay.lua")
 -- I feel like this surely must be the wrong way to do this...
 local GlobalOffsetSeconds = PREFSMAN:GetPreference("GlobalOffsetSeconds")
-
+local auto_style = ThemePrefs.Get("PreferredStyle") == "auto"
 local RowIndex = 1
 
 return Def.Sprite{
 	Texture=THEME:GetPathB("ScreenSelectMusic", "overlay/PerPlayer/arrow.png"),
 	Name="Cursor"..pn,
 	InitCommand=function(self)
-		self:visible( GAMESTATE:IsHumanPlayer(player) and not ThemePrefs.Get("PreferredStyle")=="auto" )
+		self:visible( GAMESTATE:IsHumanPlayer(player) and not auto_style )
 		self:halign( p ):zoom(0.575)
 		-- FIXME: SM5.1-beta's EffectClock enum includes constants for
 		--   CLOCK_BGM_BEAT_PLAYER1 and CLOCK_BGM_BEAT_PLAYER2 but
@@ -52,7 +52,7 @@ return Def.Sprite{
 	end,
 
 	PlayerJoinedMessageCommand=function(self, params)
-		if params.Player == player then self:visible(not ThemePrefs.Get("PreferredStyle")=="auto") end
+		if params.Player == player then self:visible(not auto_style) end
 	end,
 	PlayerUnjoinedMessageCommand=function(self, params)
 		if params.Player == player then self:visible(false) end

--- a/BGAnimations/ScreenSelectMusic overlay/PerPlayer/DensityGraph.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/PerPlayer/DensityGraph.lua
@@ -4,11 +4,14 @@ if GAMESTATE:IsCourseMode() then return end
 
 local player = ...
 local pn = ToEnumShortString(player)
+local autoStyle = ThemePrefs.Get("PreferredStyle")=="auto" 
 
 -- Height and width of the density graph.
 local height = 64
 local width = IsUsingWideScreen() and 286 or 276
-
+if autoStyle then
+	width = 352
+end
 -- In 2-players mode, whether the DensityGraph or PatternInfo is shown
 -- Can be toggled by the code "ToggleChartInfo" in metrics.ini
 local showPatternInfo = false
@@ -17,12 +20,14 @@ local af = Def.ActorFrame{
 	InitCommand=function(self)
 		self:visible( GAMESTATE:IsHumanPlayer(player) )
 		self:xy(_screen.cx-182, _screen.cy+23)
-
+		if autoStyle then
+			self:xy(IsUsingWideScreen() and  _screen.cx-170 or  _screen.cx-176, _screen.cy+20):zoom(0.91)
+		end
 		if player == PLAYER_2 then
-			self:addy(height+24)
+			self:addy(autoStyle and height+11 or height+24)
 		end
 
-		if IsUsingWideScreen() then
+		if IsUsingWideScreen() and not autoStyle then
 			self:addx(-5)
 		end
 	end,
@@ -210,7 +215,7 @@ af2[#af2+1] = Def.ActorFrame{
 		if GAMESTATE:GetNumSidesJoined() == 2 then
 			self:y(0)
 		else
-			self:y(88 * (player == PLAYER_1 and 1 or -1))
+			self:y((autoStyle and 74 or 88) * (player == PLAYER_1 and 1 or -1))
 		end
 		self:visible(GAMESTATE:GetNumSidesJoined() == 1)
 	end,
@@ -219,7 +224,7 @@ af2[#af2+1] = Def.ActorFrame{
 		if GAMESTATE:GetNumSidesJoined() == 2 then
 			self:y(0)
 		else
-			self:y(88 * (player == PLAYER_1 and 1 or -1))
+			self:y((autoStyle and 74 or 88) * (player == PLAYER_1 and 1 or -1))
 		end
 	end,
 	PlayerUnjoinedMessageCommand=function(self, params)
@@ -227,7 +232,7 @@ af2[#af2+1] = Def.ActorFrame{
 		if GAMESTATE:GetNumSidesJoined() == 2 then
 			self:y(0)
 		else
-			self:y(88 * (player == PLAYER_1 and 1 or -1))
+			self:y((autoStyle and 74 or 88) * (player == PLAYER_1 and 1 or -1))
 		end
 	end,
 	TogglePatternInfoCommand=function(self)
@@ -254,7 +259,7 @@ local layout = {
 	{"Brackets", "Total Stream"},
 }
 
-local colSpacing = 150
+local colSpacing = autoStyle and 200 or 150
 local rowSpacing = 20
 local noneText = THEME:GetString("SLPlayerOptions", "None")
 local totalStreamText = THEME:GetString("SLPlayerOptions", "TotalStream")
@@ -272,7 +277,7 @@ for i, row in ipairs(layout) do
 					self:maxwidth(100)
 				end
 				self:xy(-width/2 + 40, -height/2 + 13)
-				self:addx((j-1)*colSpacing)
+				self:addx((j-1)*colSpacing )
 				self:addy((i-1)*rowSpacing)
 			end,
 			HideCommand=function(self)

--- a/BGAnimations/ScreenSelectMusic overlay/PerPlayer/DensityGraph.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/PerPlayer/DensityGraph.lua
@@ -135,7 +135,7 @@ af2[#af2+1] = NPS_Histogram(player, width, height)..{
 af2[#af2]["CurrentSteps"..pn.."ChangedMessageCommand"] = nil
 
 -- The Peak NPS text
-local peakNPSText = THEME:GetString("ScreenGameplay", "PeakNPS")
+local peakNPSText = THEME:GetString(Branch.GameplayScreen(), "PeakNPS")
 af2[#af2+1] = LoadFont("Common Normal")..{
 	Name="NPS",
 	Text=peakNPSText..": ",

--- a/BGAnimations/ScreenSelectMusic overlay/PerPlayer/DensityGraph.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/PerPlayer/DensityGraph.lua
@@ -128,7 +128,7 @@ af2[#af2+1] = NPS_Histogram(player, width, height)..{
 af2[#af2]["CurrentSteps"..pn.."ChangedMessageCommand"] = nil
 
 -- The Peak NPS text
-local peakNPSText = THEME:GetString("ScreenGameplay", "PeakNPS")
+local peakNPSText = THEME:GetString(Branch.GameplayScreen(), "PeakNPS")
 af2[#af2+1] = LoadFont("Common Normal")..{
 	Name="NPS",
 	Text=peakNPSText..": ",

--- a/BGAnimations/ScreenSelectMusic overlay/PerPlayer/DensityGraph.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/PerPlayer/DensityGraph.lua
@@ -4,11 +4,14 @@ if GAMESTATE:IsCourseMode() then return end
 
 local player = ...
 local pn = ToEnumShortString(player)
+local autoStyle = ThemePrefs.Get("PreferredStyle")=="auto" 
 
 -- Height and width of the density graph.
 local height = 64
 local width = IsUsingWideScreen() and 286 or 276
-
+if autoStyle then
+	width = 352
+end
 -- In 2-players mode, whether the DensityGraph or PatternInfo is shown
 -- Can be toggled by the code "ToggleChartInfo" in metrics.ini
 local showPatternInfo = false
@@ -17,12 +20,14 @@ local af = Def.ActorFrame{
 	InitCommand=function(self)
 		self:visible( GAMESTATE:IsHumanPlayer(player) )
 		self:xy(_screen.cx-182, _screen.cy+23)
-
+		if autoStyle then
+			self:xy(IsUsingWideScreen() and  _screen.cx-170 or  _screen.cx-176, _screen.cy+20):zoom(0.91)
+		end
 		if player == PLAYER_2 then
-			self:addy(height+24)
+			self:addy(autoStyle and height+11 or height+24)
 		end
 
-		if IsUsingWideScreen() then
+		if IsUsingWideScreen() and not autoStyle then
 			self:addx(-5)
 		end
 	end,
@@ -203,7 +208,7 @@ af2[#af2+1] = Def.ActorFrame{
 		if GAMESTATE:GetNumSidesJoined() == 2 then
 			self:y(0)
 		else
-			self:y(88 * (player == PLAYER_1 and 1 or -1))
+			self:y((autoStyle and 74 or 88) * (player == PLAYER_1 and 1 or -1))
 		end
 		self:visible(GAMESTATE:GetNumSidesJoined() == 1)
 	end,
@@ -212,7 +217,7 @@ af2[#af2+1] = Def.ActorFrame{
 		if GAMESTATE:GetNumSidesJoined() == 2 then
 			self:y(0)
 		else
-			self:y(88 * (player == PLAYER_1 and 1 or -1))
+			self:y((autoStyle and 74 or 88) * (player == PLAYER_1 and 1 or -1))
 		end
 	end,
 	PlayerUnjoinedMessageCommand=function(self, params)
@@ -220,7 +225,7 @@ af2[#af2+1] = Def.ActorFrame{
 		if GAMESTATE:GetNumSidesJoined() == 2 then
 			self:y(0)
 		else
-			self:y(88 * (player == PLAYER_1 and 1 or -1))
+			self:y((autoStyle and 74 or 88) * (player == PLAYER_1 and 1 or -1))
 		end
 	end,
 	TogglePatternInfoCommand=function(self)
@@ -247,7 +252,7 @@ local layout = {
 	{"Brackets", "Total Stream"},
 }
 
-local colSpacing = 150
+local colSpacing = autoStyle and 200 or 150
 local rowSpacing = 20
 local noneText = THEME:GetString("SLPlayerOptions", "None")
 local totalStreamText = THEME:GetString("SLPlayerOptions", "TotalStream")
@@ -265,7 +270,7 @@ for i, row in ipairs(layout) do
 					self:maxwidth(100)
 				end
 				self:xy(-width/2 + 40, -height/2 + 13)
-				self:addx((j-1)*colSpacing)
+				self:addx((j-1)*colSpacing )
 				self:addy((i-1)*rowSpacing)
 			end,
 			HideCommand=function(self)

--- a/BGAnimations/ScreenSelectMusic overlay/PerPlayer/StepArtist.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/PerPlayer/StepArtist.lua
@@ -41,7 +41,7 @@ return Def.ActorFrame{
 				self:y(_screen.cy + 32)
 			else
 				self:x( _screen.cx - (IsUsingWideScreen() and 356 or 346))
-				self:y(_screen.cy + 12)
+				self:y(_screen.cy + 12)	
 			end
 
 		elseif player == PLAYER_2 then
@@ -49,6 +49,9 @@ return Def.ActorFrame{
 			if GAMESTATE:IsCourseMode() then
 				self:x( _screen.cx - 210)
 				self:y(_screen.cy + 85)
+			elseif ThemePrefs.Get("PreferredStyle")=="auto" then
+				self:x( _screen.cx - 210)
+				self:y(_screen.cy + 28)
 			else
 				self:x( _screen.cx - 244)
 				self:y(_screen.cy + 40)

--- a/BGAnimations/ScreenSelectMusic overlay/SortMenu/SortMenu_InputHandler.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SortMenu/SortMenu_InputHandler.lua
@@ -83,8 +83,18 @@ local input = function(event)
 				if PREFSMAN:GetPreference("MenuTimer") then
 					overlay:playcommand("ShowPressStartForOptions")
 				end
+				-- We have to turn off autosetstyle to switch styles
+				if ThemePrefs.Get("PreferredStyle")=="auto" then
+					ThemePrefs.Set("PreferredStyle", "none")
+					THEME:ReloadMetrics()
+				end
 				-- Get the style we want to change to
 				local new_style = focus.change:lower()
+				if new_style == "all" then
+					ThemePrefs.Set("PreferredStyle", "auto")
+					THEME:ReloadMetrics()
+					new_style = #GAMESTATE:GetHumanPlayers() == 1 and "single" or "versus"
+				end
 				-- accommodate techno game
 				if GAMESTATE:GetCurrentGame():GetName() == "techno" then new_style = new_style .. "8" end
 				-- set it in the engine

--- a/BGAnimations/ScreenSelectMusic overlay/SortMenu/SortMenu_InputHandler.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SortMenu/SortMenu_InputHandler.lua
@@ -67,8 +67,18 @@ local input = function(event)
 				if PREFSMAN:GetPreference("MenuTimer") then
 					overlay:playcommand("ShowPressStartForOptions")
 				end
+				-- We have to turn off autosetstyle to switch styles
+				if ThemePrefs.Get("PreferredStyle")=="auto" then
+					ThemePrefs.Set("PreferredStyle", "none")
+					THEME:ReloadMetrics()
+				end
 				-- Get the style we want to change to
 				local new_style = focus.change:lower()
+				if new_style == "all" then
+					ThemePrefs.Set("PreferredStyle", "auto")
+					THEME:ReloadMetrics()
+					new_style = #GAMESTATE:GetHumanPlayers() == 1 and "single" or "versus"
+				end
 				-- accommodate techno game
 				if GAMESTATE:GetCurrentGame():GetName() == "techno" then new_style = new_style .. "8" end
 				-- set it in the engine

--- a/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
@@ -238,6 +238,7 @@ local function AddProfileEntries()
 	if GAMESTATE:IsCourseMode() then return {} end
 
 	return {
+		{ {"NextPlease", "SwitchProfile"}, ThemePrefs.Get("AllowScreenSelectProfile") },
 		{ {"SortBy", "PopularityP1"}, function() return PROFILEMAN:IsPersistentProfile(PLAYER_1) end },
 		{ {"SortBy", "RecentP1"}, function() return PROFILEMAN:IsPersistentProfile(PLAYER_1) end },
 		{ {"SortBy", "TopP1Grades"}, function() return PROFILEMAN:IsPersistentProfile(PLAYER_1) end },
@@ -405,7 +406,8 @@ local t = Def.ActorFrame {
 			-- It's technically not possible to reach the sort menu in Casual Mode, but juuust in case let's still
 			-- include the check.
 			--
-			{ { "", "GoBack" } },
+			-- Only show GoBack if we're in 3 key navigation mode, as it's redundant in 5 key.
+			{ { "", "GoBack" }, PREFSMAN:GetPreference("ThreeKeyNavigation") },
 			{ {"NextPlease", "SwitchProfile"}, ThemePrefs.Get("AllowScreenSelectProfile") },
 			{ {"GrooveStats", "Leaderboard"}, function() return GAMESTATE:GetCurrentSong() ~= nil end },
 			{ {"WhereforeArtThou", "SongSearch"}, not GAMESTATE:IsCourseMode() and ThemePrefs.Get("KeyboardFeatures") },

--- a/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
@@ -335,7 +335,7 @@ local function GetChangeableStyles()
 				table.insert(available_styles, {{"ChangeStyle", "Couple"}})
 				table.insert(available_styles, {{"ChangeStyle", "All"}})
 			elseif style == "versus" then
-				table.insert(available_styles, {{"ChangeStyle", "Routine"}})
+				-- table.insert(available_styles, {{"ChangeStyle", "Routine"}})
 				-- table.insert(available_styles, {{"ChangeStyle", "Couple"}})
 			end
 			--table.insert(available_styles, {{"ChangeStyle", "All"}})

--- a/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
@@ -328,16 +328,16 @@ local function GetChangeableStyles()
 			elseif style == "couple" then
 				table.insert(available_styles, {{"ChangeStyle", "Versus"}})
 				table.insert(available_styles, {{"ChangeStyle", "Routine"}})
+				table.insert(available_styles, {{"ChangeStyle", "All"}})
 			elseif style == "routine" then
 				table.insert(available_styles, {{"ChangeStyle", "Versus"}})
 				table.insert(available_styles, {{"ChangeStyle", "Couple"}})
-			-- Routine is not ready for use yet, but it might be soon.
-			-- This can be uncommented at that time to allow switching from versus into routine.
-			-- elseif style == "versus" then
-			-- 	table.insert(available_styles, {{"ChangeStyle", "Routine"}})
-			-- 	table.insert(available_styles, {{"ChangeStyle", "Couple"}})
+				table.insert(available_styles, {{"ChangeStyle", "All"}})
+			elseif style == "versus" then
+				table.insert(available_styles, {{"ChangeStyle", "Routine"}})
+				-- table.insert(available_styles, {{"ChangeStyle", "Couple"}})
 			end
-			-- table.insert(available_styles, {{"ChangeStyle", "All"}})
+			--table.insert(available_styles, {{"ChangeStyle", "All"}})
 
 		end
 	end

--- a/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
@@ -36,9 +36,127 @@ local sortmenu_dimensions = { w=210, h=204 }
 -- but its prose was approachable enough for wastes-of-space like me, so I guess I'll
 -- recommend it until I find a more helpful one.
 --                                      -quietly
+local sortmenu_dimensions = { w=210, h=204 }
 local wheel_item_mt = LoadActor("WheelItemMT.lua", {sortmenu_dimensions})
 local lastCategory = ""
 local openCategory = nil
+
+local FilterTable = function(arr, func)
+	local new_index = 1
+	local size_orig = #arr
+	for v in ivalues(arr) do
+		if func(v) then
+			arr[new_index] = v
+			new_index = new_index + 1
+		end
+	end
+	for i = new_index, size_orig do arr[i] = nil end
+end
+
+local GetBpmTier = function(bpm)
+	return math.floor((bpm + 0.5) / 10) * 10
+end
+
+local SongSearchSettings = {
+	Question="'pack/song' format will search for songs in specific packs\n'[###]' format will search for BPMs/Difficulties",
+	InitialAnswer="",
+	MaxInputLength=30,
+	OnOK=function(input)
+		if #input == 0 then return end
+
+		-- Lowercase the input text for comparison
+		local searchText = input:lower()
+
+		-- First extract out the "numbers".
+		-- Anything <= 35 is considered a difficulty, otherwise it's a bpm.
+		local difficulty = nil
+		local bpmTier = nil
+
+		for match in searchText:gmatch("%[(%d+)]") do
+			local value = tonumber(match)
+			if value <= 35 then
+				difficulty = value
+			else
+				-- Determine the "tier".
+				bpmTier = GetBpmTier(value)
+			end
+		end
+
+		-- Remove the parsed atoms, and then strip leading/trailing whitespace.
+		searchText = searchText:gsub("%[%d+]", ""):gsub("^%s*(.-)%s*$", "%1")
+
+		-- The we separate out the pack and song into their own search terms.
+		local packName = nil
+		local songName = nil
+
+		local forwardSlashIdx = searchText:find('/')
+		if not forwardSlashIdx then
+			songName = searchText
+		else
+			packName = searchText:sub(1, forwardSlashIdx - 1)
+			songName = searchText:sub(forwardSlashIdx + 1)
+		end
+
+		-- Normalize empty strings to nil.
+		if packName and #packName == 0 then packName = nil end
+		if songName and #songName == 0 then songName = nil end
+
+		-- If we have no search criteria, then return early.
+		if not (packName or songName or difficulty or bpmTier) then return end
+
+		-- Start with the complete song list.
+		local candidates = SONGMAN:GetAllSongs()
+		local stepsType = GAMESTATE:GetCurrentStyle():GetStepsType()
+
+		-- Only add valid candidates if there are steps in the current mode.
+		FilterTable(candidates, function(song) return song:HasStepsType(stepsType) end)
+
+		if songName then
+			FilterTable(candidates, function(song)
+				return (song:GetDisplayFullTitle():lower():find(songName) ~= nil or
+						song:GetTranslitFullTitle():lower():find(songName) ~= nil)
+			end)
+		end
+
+		if packName then
+			FilterTable(candidates, function(song) return song:GetGroupName():lower():find(packName) end)
+		end
+
+		if difficulty then
+			FilterTable(candidates, function(song)
+				local allSteps = song:GetStepsByStepsType(stepsType)
+				for steps in ivalues(allSteps) do
+					-- Don't consider edits.
+					if steps:GetDifficulty() ~= "Difficulty_Edit" then
+						if steps:GetMeter() == difficulty then
+							return true
+						end
+					end
+				end
+				return false
+			end)
+		end
+
+		if bpmTier then
+			FilterTable(candidates, function(song)
+				-- NOTE(teejusb): Not handling split bpms now, sorry.
+				local bpms = song:GetDisplayBpms()
+				if bpms[2]-bpms[1] == 0 then
+					-- If only one BPM, then check to see if it's in the same tier.
+					return bpmTier == GetBpmTier(bpms[1])
+				else
+					-- Otherwise check and see if the bpm is in the span of the tier.
+					local lowTier = GetBpmTier(bpms[1])
+					local highTier = GetBpmTier(bpms[2])
+					return lowTier <= bpmTier and bpmTier <= highTier
+				end
+			end)
+		end
+
+		-- Even if we don't have any results, we want to show that to the player.
+		MESSAGEMAN:Broadcast("DisplaySearchResults", {searchText=input, candidates=candidates})
+	end,
+}
 
 -- General purpose function to redirect input back to the engine.
 -- "self" here should refer to the SortMenu ActorFrame.
@@ -177,8 +295,8 @@ local function GetChangeableStyles()
 	-- Allow players to switch from single to double and from double to single
 	-- but only present these options if Joint Double or Joint Premium is enabled
 	-- and we're not in "AutoSetStyle" mode (all styles presented simultaneously like PIU does)
-
-	if THEME:GetMetric("Common", "AutoSetStyle") == true then
+	
+	if ThemePrefs.Get("PreferredStyle")=="auto" then
 		-- Check number of players
 		if ThemePrefs.Get("AllowDanceSolo") then
 			table.insert(available_styles, {{"ChangeStyle", "Solo"}, GAMESTATE:GetNumPlayersEnabled() == 1  })
@@ -189,7 +307,7 @@ local function GetChangeableStyles()
 		table.insert(available_styles, {{"ChangeStyle", "Versus"}, not (GAMESTATE:GetNumPlayersEnabled() == 1)  })
 		table.insert(available_styles, {{"ChangeStyle", "Routine"}, not (GAMESTATE:GetNumPlayersEnabled() == 1)  })
 		table.insert(available_styles, {{"ChangeStyle", "Couple"}, not (GAMESTATE:GetNumPlayersEnabled() == 1) })
-	else
+	else 
 		if not (PREFSMAN:GetPreference("Premium") == "Premium_Off" and GAMESTATE:GetCoinMode() == "CoinMode_Pay") then
 			if style == "single" then
 				table.insert(available_styles, {{"ChangeStyle", "Double"}})
@@ -219,7 +337,7 @@ local function GetChangeableStyles()
 				table.insert(available_styles, {{"ChangeStyle", "Routine"}})
 				table.insert(available_styles, {{"ChangeStyle", "Couple"}})
 			end
-			-- table.insert(available_styles, {{"ChangeStyle", "All"}})
+			table.insert(available_styles, {{"ChangeStyle", "All"}})
 
 		end
 	end

--- a/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
@@ -215,9 +215,9 @@ local function GetChangeableStyles()
 				table.insert(available_styles, {{"ChangeStyle", "Couple"}})
 			-- Routine is not ready for use yet, but it might be soon.
 			-- This can be uncommented at that time to allow switching from versus into routine.
-			-- elseif style == "versus" then
-			--	table.insert(available_styles, {{"ChangeStyle", "Routine"}})
-			--	table.insert(available_styles, {{"ChangeStyle", "Couple"}})
+			elseif style == "versus" then
+				table.insert(available_styles, {{"ChangeStyle", "Routine"}})
+				table.insert(available_styles, {{"ChangeStyle", "Couple"}})
 			end
 			-- table.insert(available_styles, {{"ChangeStyle", "All"}})
 

--- a/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
@@ -333,11 +333,11 @@ local function GetChangeableStyles()
 				table.insert(available_styles, {{"ChangeStyle", "Couple"}})
 			-- Routine is not ready for use yet, but it might be soon.
 			-- This can be uncommented at that time to allow switching from versus into routine.
-			elseif style == "versus" then
-				table.insert(available_styles, {{"ChangeStyle", "Routine"}})
-				table.insert(available_styles, {{"ChangeStyle", "Couple"}})
+			-- elseif style == "versus" then
+			-- 	table.insert(available_styles, {{"ChangeStyle", "Routine"}})
+			-- 	table.insert(available_styles, {{"ChangeStyle", "Couple"}})
 			end
-			table.insert(available_styles, {{"ChangeStyle", "All"}})
+			-- table.insert(available_styles, {{"ChangeStyle", "All"}})
 
 		end
 	end

--- a/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
@@ -290,11 +290,11 @@ local function GetChangeableStyles()
 				table.insert(available_styles, {{"ChangeStyle", "Couple"}})
 			-- Routine is not ready for use yet, but it might be soon.
 			-- This can be uncommented at that time to allow switching from versus into routine.
-			elseif style == "versus" then
-				table.insert(available_styles, {{"ChangeStyle", "Routine"}})
-				table.insert(available_styles, {{"ChangeStyle", "Couple"}})
+			-- elseif style == "versus" then
+			-- 	table.insert(available_styles, {{"ChangeStyle", "Routine"}})
+			-- 	table.insert(available_styles, {{"ChangeStyle", "Couple"}})
 			end
-			table.insert(available_styles, {{"ChangeStyle", "All"}})
+			-- table.insert(available_styles, {{"ChangeStyle", "All"}})
 
 		end
 	end

--- a/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
@@ -290,9 +290,9 @@ local function GetChangeableStyles()
 				table.insert(available_styles, {{"ChangeStyle", "Couple"}})
 			-- Routine is not ready for use yet, but it might be soon.
 			-- This can be uncommented at that time to allow switching from versus into routine.
-			-- elseif style == "versus" then
-			--	table.insert(available_styles, {{"ChangeStyle", "Routine"}})
-			--	table.insert(available_styles, {{"ChangeStyle", "Couple"}})
+			elseif style == "versus" then
+				table.insert(available_styles, {{"ChangeStyle", "Routine"}})
+				table.insert(available_styles, {{"ChangeStyle", "Couple"}})
 			end
 			-- table.insert(available_styles, {{"ChangeStyle", "All"}})
 

--- a/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
@@ -288,11 +288,11 @@ local function GetChangeableStyles()
 			elseif style == "routine" then
 				table.insert(available_styles, {{"ChangeStyle", "Versus"}})
 				table.insert(available_styles, {{"ChangeStyle", "Couple"}})
-			-- Routine is not ready for use yet, but it might be soon.
-			-- This can be uncommented at that time to allow switching from versus into routine.
-			-- elseif style == "versus" then
-			-- 	table.insert(available_styles, {{"ChangeStyle", "Routine"}})
-			-- 	table.insert(available_styles, {{"ChangeStyle", "Couple"}})
+			-- Routine/Couples is not ready for use yet, but it might be soon.
+			-- This can be uncommented at that time to allow switching from versus into routine/couples.
+			elseif style == "versus" then
+				table.insert(available_styles, {{"ChangeStyle", "Routine"}})
+				table.insert(available_styles, {{"ChangeStyle", "Couple"}})
 			end
 			-- table.insert(available_styles, {{"ChangeStyle", "All"}})
 

--- a/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
@@ -253,7 +253,7 @@ local function GetChangeableStyles()
 	-- but only present these options if Joint Double or Joint Premium is enabled
 	-- and we're not in "AutoSetStyle" mode (all styles presented simultaneously like PIU does)
 	
-	if THEME:GetMetric("Common", "AutoSetStyle") == true then
+	if ThemePrefs.Get("PreferredStyle")=="auto" then
 		-- Check number of players
 		if ThemePrefs.Get("AllowDanceSolo") then
 			table.insert(available_styles, {{"ChangeStyle", "Solo"}, GAMESTATE:GetNumPlayersEnabled() == 1  })
@@ -294,7 +294,7 @@ local function GetChangeableStyles()
 				table.insert(available_styles, {{"ChangeStyle", "Routine"}})
 				table.insert(available_styles, {{"ChangeStyle", "Couple"}})
 			end
-			-- table.insert(available_styles, {{"ChangeStyle", "All"}})
+			table.insert(available_styles, {{"ChangeStyle", "All"}})
 
 		end
 	end

--- a/BGAnimations/ScreenSelectMusic overlay/StepsDisplayList/Grid.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/StepsDisplayList/Grid.lua
@@ -4,7 +4,7 @@ if GAMESTATE:IsCourseMode() then return end
 -- ----------------------------------------------
 
 local GetStepsToDisplay = LoadActor("./StepsToDisplay.lua")
-
+local autoStyle = ThemePrefs.Get("PreferredStyle")=="auto"
 local t = Def.ActorFrame{
 	Name="StepsDisplayList",
 	InitCommand=function(self) self:xy(_screen.cx-26, _screen.cy + 67) end,
@@ -15,7 +15,10 @@ local t = Def.ActorFrame{
 	CurrentStepsP2ChangedMessageCommand=function(self) self:queuecommand("RedrawStepsDisplay") end,
 
 	RedrawStepsDisplayCommand=function(self)
-
+		if autoStyle then
+			self:visible(false)
+			return
+		end
 		local song = GAMESTATE:GetCurrentSong()
 
 		if song then

--- a/BGAnimations/ScreenSelectMusic overlay/StepsDisplayList/TabbedStepchartList/TabbedStepsToDisplay.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/StepsDisplayList/TabbedStepchartList/TabbedStepsToDisplay.lua
@@ -1,0 +1,44 @@
+local num_tabs = ...
+
+return function(player, AllSteps)
+	local song = GAMESTATE:GetCurrentSong()
+	AllSteps = AllSteps or (song and SongUtil.GetPlayableSteps(song)) or {}
+
+	-- if there are fewer playable stepcharts than the UI accommodates, no problem, return them all
+	if #AllSteps < num_tabs then
+		local t = {}
+		local _i = num_tabs-1
+		for i=1,num_tabs do
+			t[i] = AllSteps[#AllSteps-_i]
+			_i = _i - 1
+		end
+		return t
+	end
+
+	-- otherwise,
+	player = player or GAMESTATE:GetMasterPlayerNumber()
+	if not player then return {} end
+
+	local current_steps = GAMESTATE:GetCurrentSteps(player)
+	local i = FindInTable(current_steps, AllSteps)
+	if not i then return {} end
+
+	local t = {}
+	local _i
+
+
+	if i <= 5 then
+		_i = 1
+	elseif i > 5 and i < #AllSteps-5 then
+		_i = i-5
+	else
+		_i=#AllSteps-(num_tabs-1)
+	end
+
+	for index=1,num_tabs do
+		t[index] = AllSteps[_i]
+		_i = _i + 1
+	end
+
+	return t
+end

--- a/BGAnimations/ScreenSelectMusic overlay/StepsDisplayList/TabbedStepchartList/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/StepsDisplayList/TabbedStepchartList/default.lua
@@ -113,7 +113,7 @@ for i=0,num_tabs-1 do
       InitCommand=function(self)
          self:zoom(0.4):diffuse(0,0,0,1):y(4)
          if not IsUsingWideScreen() then
-            self:x(tab_width - 10) -- 4:3 display
+            self:x(tab_width - 14) -- 4:3 display
          else
             self:x(tab_width - WideScale(5, 0))
          end

--- a/BGAnimations/ScreenSelectMusic overlay/StepsDisplayList/TabbedStepchartList/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/StepsDisplayList/TabbedStepchartList/default.lua
@@ -1,0 +1,163 @@
+local player, pane_width = unpack(...)
+
+local gamename = GAMESTATE:GetCurrentGame():GetName()
+
+
+local num_tabs = IsUsingWideScreen() and 10 or 9
+local tab_width = IsUsingWideScreen() and WideScale(26.66, 37.55) or 30
+local tab_expanded_extra_width = pane_width - (tab_width*num_tabs)
+
+-- SM({num_tabs, pane_width, tab_width, tab_expanded_extra_width})
+
+local GetStepsToDisplay = LoadActor("./TabbedStepsToDisplay.lua", num_tabs)
+
+local af = Def.ActorFrame{}
+af.InitCommand=function(self)
+	self:y(-20)
+end
+
+-- shared background behind all tabs
+af[#af+1] = Def.Quad{
+	InitCommand=function(self)
+      self:x(WideScale(155, 208.5))
+		self:vertalign(top):horizalign(right)
+		self:zoomtowidth(pane_width):zoomtoheight(20)
+		if not DarkUI() then self:diffuse({10/255, 20/255, 27/255, 1})
+		else self:diffusealpha(0.6) end
+	end
+}
+
+for i=0,num_tabs-1 do
+   local tab = Def.ActorFrame{
+      SetCommand=function(self)
+         local StepsToDisplay = GetStepsToDisplay(player)
+         local cur_steps = GAMESTATE:GetCurrentSteps(player)
+
+         local steps_index
+         for k,v in pairs(StepsToDisplay) do
+            if v == cur_steps then steps_index=k; break end
+         end
+
+         self:playcommand("Redraw", StepsToDisplay)
+         self:x( WideScale(-127, -171.5) + (i*tab_width) )
+
+         if steps_index and (i+1 < steps_index) then
+            self:addx(-tab_expanded_extra_width)
+         end
+    end
+   }
+
+   -- colored tab background
+   tab[#tab+1] = Def.Quad{
+      InitCommand=function(self)
+         self:zoomtowidth(tab_width-1):zoomtoheight(20)
+         self:vertalign(top):horizalign(right):x(42)
+         if not DarkUI() then self:diffuse({10/255, 20/255, 27/255, 1}) end
+      end,
+      RedrawCommand=function(self, StepsToDisplay)
+         local stepchart = StepsToDisplay[i+1]
+         if stepchart then
+            if stepchart == GAMESTATE:GetCurrentSteps(player) then
+               self:diffuse( DifficultyColor(stepchart:GetDifficulty(), false) ):zoomtowidth(tab_width+tab_expanded_extra_width)
+            else
+               self:diffuse( BoostColor(DifficultyColor(stepchart:GetDifficulty(), false), DarkUI() and 1 or 0.55) )
+               self:zoomtowidth(tab_width-1)
+               self:diffusealpha(DarkUI() and 0.5 or 1)
+            end
+         else
+            self:diffuse(DarkUI() and Color.White or {10/255, 20/255, 27/255})
+            self:zoomtowidth(tab_width-1)
+
+            if not DarkUI() then
+               self:diffusealpha(1)
+            else
+               local stepchart = StepsToDisplay[i+1]
+               if stepchart then
+                  self:diffusealpha(0.6)
+               else
+                  self:diffusealpha(0.3)
+               end
+            end
+         end
+      end
+   }
+
+   -- difficulty meter
+   tab[#tab+1] = LoadFont("Common Bold")..{
+      InitCommand=function(self)
+         self:zoom(0.4):diffuse(0,0,0,1):y(10)
+
+         if not IsUsingWideScreen() then
+            self:x(tab_width - 3) -- 4:3 display
+         else
+            self:x(tab_width - WideScale(-6,14))
+         end
+      end,
+      RedrawCommand=function(self, StepsToDisplay)
+         local stepchart = StepsToDisplay[i+1]
+         if stepchart then
+            self:settext(stepchart:GetMeter())
+            self:diffusealpha(1)
+            if stepchart == GAMESTATE:GetCurrentSteps(player) then
+               self:diffusealpha(1)
+            else
+               self:diffusealpha( DarkUI() and 0.6 or 1 )
+            end
+         else
+            self:settext("")
+         end
+      end
+   }
+   -- In very small text the first letter of the steps type
+   tab[#tab+1] = LoadFont("Common Normal")..{
+      InitCommand=function(self)
+         self:zoom(0.4):diffuse(0,0,0,1):y(4)
+         if not IsUsingWideScreen() then
+            self:x(tab_width - 10) -- 4:3 display
+         else
+            self:x(tab_width - WideScale(5, 0))
+         end
+      end,
+      RedrawCommand=function(self, StepsToDisplay)
+         local stepchart = StepsToDisplay[i+1]
+         if stepchart then
+            local style = stepchart:GetStepsType():gsub("%w+_%w+_", ""):lower()
+            local styleString = THEME:GetString("StepsType", ("%s-%s"):format(gamename, style))
+            local text = styleString:sub(1,1)
+            self:settext(text)
+            self:diffusealpha(1)
+            if stepchart == GAMESTATE:GetCurrentSteps(player) then
+               self:diffusealpha(1)
+            else
+               self:diffusealpha( DarkUI() and 0.6 or 1 )
+            end
+         else
+            self:settext("")
+         end
+      end
+   }
+
+   -- style string
+   tab[#tab+1] = LoadFont("Common Normal")..{
+      InitCommand=function(self)
+         self:vertspacing(-10):zoom(0.8):diffuse(0,0,0,1)
+         self:x(tab_width-WideScale(35, 50)):y(10.5)
+      end,
+      RedrawCommand=function(self, StepsToDisplay)
+         local stepchart = StepsToDisplay[i+1]
+
+         if stepchart and stepchart == GAMESTATE:GetCurrentSteps(player) then
+            local style = stepchart:GetStepsType():gsub("%w+_%w+_", ""):lower()
+            local styleString = THEME:GetString("StepsType", ("%s-%s"):format(gamename, style))
+            local text = ("%s"):format(styleString)
+            self:settext(text):zoom(text:find("\n") and 0.7 or 0.8)
+         else
+            self:settext("")
+         end
+      end
+   }
+
+   af[#af+1] = tab
+end
+
+return af

--- a/BGAnimations/ScreenSelectMusic overlay/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/default.lua
@@ -52,6 +52,9 @@ local af = Def.ActorFrame{
 	-- Apply player modifiers from profile
 	LoadActor("./PlayerModifiers.lua"),
 
+	-- allow stepcharts from multiple styles (single, double, routine) to coexist
+	-- in the same music wheel
+	LoadActor("./AutoSetStyle.lua"),
 	-- ---------------------------------------------------
 	-- next, load visual elements; the order of these matters
 	-- i.e. content in PerPlayer/Over needs to draw on top of content from PerPlayer/Under

--- a/BGAnimations/ScreenSelectMusic overlay/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/default.lua
@@ -52,7 +52,7 @@ local af = Def.ActorFrame{
 	-- Apply player modifiers from profile
 	LoadActor("./PlayerModifiers.lua"),
 
-	-- allow stepcharts from multiple styles (single, double, routine) to coexist
+	-- allow stepcharts from multiple styles (single, double, couples) to coexist
 	-- in the same music wheel
 	LoadActor("./AutoSetStyle.lua"),
 	-- ---------------------------------------------------

--- a/BGAnimations/ScreenSelectPlayMode underlay/default.lua
+++ b/BGAnimations/ScreenSelectPlayMode underlay/default.lua
@@ -207,7 +207,7 @@ local t = Def.ActorFrame{
 			InitCommand=function(self) self:zoomto(40,14):xy(59,-64):diffuse( GetCurrentColor(true) ) end
 		},
 		-- life meter animated swoosh
-		LoadActor(THEME:GetPathB("ScreenGameplay", "underlay/PerPlayer/LifeMeter/swoosh.png"))..{
+		LoadActor(THEME:GetPathB(Branch.GameplayScreen(), "underlay/PerPlayer/LifeMeter/swoosh.png"))..{
 			InitCommand=function(self) self:zoomto(40,14):diffusealpha(0.45):xy(59,-64) end,
 			OnCommand=function(self)
 				self:customtexturerect(0,0,1,1):texcoordvelocity(-2,0)

--- a/BGAnimations/ScreenSelectProfile underlay/Input.lua
+++ b/BGAnimations/ScreenSelectProfile underlay/Input.lua
@@ -40,7 +40,7 @@ for profile in ivalues(profile_data) do
 	end
 end
 
-local AutoStyle = ThemePrefs.Get("AutoStyle")
+local PreferredStyle = ThemePrefs.Get("PreferredStyle")
 
 local Handle = {}
 
@@ -231,9 +231,9 @@ Handle.Back = function(event)
 		-- unjoin a player from a 2-player setup
 		if SL.Global.FastProfileSwitchInProgress and GAMESTATE:GetNumSidesJoined() == 1 then
 			GAMESTATE:SetCurrentStyle("single")
-			-- If AutoStyle is single then someone had joined during gameplay
+			-- If PreferredStyle is single then someone had joined during gameplay
 			-- We need to explicitly remove this player's join frame
-			if (AutoStyle=="single") then
+			if (PreferredStyle=="single") then
 				SCREENMAN:GetTopScreen():playcommand("Update", {player=event.PlayerNumber})
 			else
 				SCREENMAN:GetTopScreen():playcommand("Update")
@@ -248,7 +248,7 @@ Handle.Select = Handle.Back
 local InputHandler = function(event)
 	if finished then return false end
 	if not event or not event.button then return false end
-	if (((AutoStyle=="single" or AutoStyle=="double") and #GAMESTATE:GetHumanPlayers() == 1) and event.PlayerNumber ~= GAMESTATE:GetMasterPlayerNumber()) then return false	end
+	if (((PreferredStyle=="single" or PreferredStyle=="double") and #GAMESTATE:GetHumanPlayers() == 1) and event.PlayerNumber ~= GAMESTATE:GetMasterPlayerNumber()) then return false	end
 
 	if event.type ~= "InputEventType_Release" then
 		if Handle[event.GameButton] then Handle[event.GameButton](event) end

--- a/BGAnimations/ScreenSelectProfile underlay/default.lua
+++ b/BGAnimations/ScreenSelectProfile underlay/default.lua
@@ -4,6 +4,11 @@
 -- SelectProfileFrames for both PLAYER_1 and PLAYER_2, but only the MasterPlayerNumber
 local PreferredStyle = ThemePrefs.Get("PreferredStyle")
 
+-- retrieve the MasterPlayerNumber now, at initialization, so that if PreferredStyle is set
+-- to "single" or "double" and that singular player unjoins, we still have a handle on
+-- which PlayerNumber they're supposed to be...
+local mpn = GAMESTATE:GetMasterPlayerNumber()
+
 -- a table of profile data (highscore name, most recent song, mods, etc.)
 -- indexed by "ProfileIndex" (provided by engine)
 local profile_data = LoadActor("./PlayerProfileData.lua")
@@ -224,7 +229,7 @@ local t = Def.ActorFrame {
 			return
 		end
 
-		if PreferredStyle=="none" or PreferredStyle=="versus" or #GAMESTATE:GetHumanPlayers() > 1 then
+		if not (PreferredStyle=="single" or PreferredStyle=="double") or #GAMESTATE:GetHumanPlayers() > 1 then
 			HandleStateChange(self, PLAYER_1)
 			HandleStateChange(self, PLAYER_2)
 		else

--- a/BGAnimations/ScreenSelectProfile underlay/default.lua
+++ b/BGAnimations/ScreenSelectProfile underlay/default.lua
@@ -1,8 +1,8 @@
--- AutoStyle is a Simply Love ThemePref that can allow players to always
+-- PreferredStyle is a Simply Love ThemePref that can allow players to always
 -- automatically have one of [single, double, versus] chosen for them.
--- If AutoStyle is either "single" or "double", we don't want to load
+-- If PreferredStyle is either "single" or "double", we don't want to load
 -- SelectProfileFrames for both PLAYER_1 and PLAYER_2, but only the MasterPlayerNumber
-local AutoStyle = ThemePrefs.Get("AutoStyle")
+local PreferredStyle = ThemePrefs.Get("PreferredStyle")
 
 -- a table of profile data (highscore name, most recent song, mods, etc.)
 -- indexed by "ProfileIndex" (provided by engine)
@@ -171,7 +171,7 @@ local t = Def.ActorFrame {
 
 	CodeMessageCommand=function(self, params)
 
-		if (AutoStyle=="single" or AutoStyle=="double" or #GAMESTATE:GetHumanPlayers() > 1 ) and params.PlayerNumber ~= GAMESTATE:GetMasterPlayerNumber()  then return end
+		if (PreferredStyle=="single" or PreferredStyle=="double" or #GAMESTATE:GetHumanPlayers() > 1 ) and params.PlayerNumber ~= GAMESTATE:GetMasterPlayerNumber()  then return end
 
 		-- Don't allow players to unjoin from SelectProfile in CoinMode_Pay.
 		-- 1 credit has already been deducted from ScreenTitleJoin, so allowing players
@@ -224,7 +224,7 @@ local t = Def.ActorFrame {
 			return
 		end
 
-		if AutoStyle=="none" or AutoStyle=="versus" or #GAMESTATE:GetHumanPlayers() > 1 then
+		if PreferredStyle=="none" or PreferredStyle=="versus" or #GAMESTATE:GetHumanPlayers() > 1 then
 			HandleStateChange(self, PLAYER_1)
 			HandleStateChange(self, PLAYER_2)
 		else
@@ -281,7 +281,7 @@ if SL.Global.FastProfileSwitchInProgress then
 end
 
 -- load PlayerFrames for both
-if AutoStyle=="none" or AutoStyle=="versus" or #GAMESTATE:GetHumanPlayers() > 1 then
+if not (PreferredStyle=="single" or PreferredStyle=="double")  or #GAMESTATE:GetHumanPlayers() > 1 then
 	t[#t+1] = LoadActor("PlayerFrame.lua", {Player=PLAYER_1, Scroller=scrollers[PLAYER_1], ProfileData=profile_data, Avatars=avatars})
 	t[#t+1] = LoadActor("PlayerFrame.lua", {Player=PLAYER_2, Scroller=scrollers[PLAYER_2], ProfileData=profile_data, Avatars=avatars})
 -- load only for the MasterPlayerNumber

--- a/BGAnimations/ScreenSelectProfile underlay/default.lua
+++ b/BGAnimations/ScreenSelectProfile underlay/default.lua
@@ -1,8 +1,8 @@
--- AutoStyle is a Simply Love ThemePref that can allow players to always
+-- PreferredStyle is a Simply Love ThemePref that can allow players to always
 -- automatically have one of [single, double, versus] chosen for them.
--- If AutoStyle is either "single" or "double", we don't want to load
+-- If PreferredStyle is either "single" or "double", we don't want to load
 -- SelectProfileFrames for both PLAYER_1 and PLAYER_2, but only the MasterPlayerNumber
-local AutoStyle = ThemePrefs.Get("AutoStyle")
+local PreferredStyle = ThemePrefs.Get("PreferredStyle")
 
 -- a table of profile data (highscore name, most recent song, mods, etc.)
 -- indexed by "ProfileIndex" (provided by engine)
@@ -174,7 +174,7 @@ local t = Def.ActorFrame {
 
 	CodeMessageCommand=function(self, params)
 
-		if (AutoStyle=="single" or AutoStyle=="double" or #GAMESTATE:GetHumanPlayers() > 1 ) and params.PlayerNumber ~= GAMESTATE:GetMasterPlayerNumber()  then return end
+		if (PreferredStyle=="single" or PreferredStyle=="double" or #GAMESTATE:GetHumanPlayers() > 1 ) and params.PlayerNumber ~= GAMESTATE:GetMasterPlayerNumber()  then return end
 
 		-- Don't allow players to unjoin from SelectProfile in CoinMode_Pay.
 		-- 1 credit has already been deducted from ScreenTitleJoin, so allowing players
@@ -227,7 +227,7 @@ local t = Def.ActorFrame {
 			return
 		end
 
-		if AutoStyle=="none" or AutoStyle=="versus" or #GAMESTATE:GetHumanPlayers() > 1 then
+		if PreferredStyle=="none" or PreferredStyle=="versus" or #GAMESTATE:GetHumanPlayers() > 1 then
 			HandleStateChange(self, PLAYER_1)
 			HandleStateChange(self, PLAYER_2)
 		else
@@ -284,7 +284,7 @@ if SL.Global.FastProfileSwitchInProgress then
 end
 
 -- load PlayerFrames for both
-if AutoStyle=="none" or AutoStyle=="versus" or #GAMESTATE:GetHumanPlayers() > 1 then
+if not (PreferredStyle=="single" or PreferredStyle=="double")  or #GAMESTATE:GetHumanPlayers() > 1 then
 	t[#t+1] = LoadActor("PlayerFrame.lua", {Player=PLAYER_1, Scroller=scrollers[PLAYER_1], ProfileData=profile_data, Avatars=avatars})
 	t[#t+1] = LoadActor("PlayerFrame.lua", {Player=PLAYER_2, Scroller=scrollers[PLAYER_2], ProfileData=profile_data, Avatars=avatars})
 -- load only for the MasterPlayerNumber

--- a/BGAnimations/ScreenSelectProfile underlay/default.lua
+++ b/BGAnimations/ScreenSelectProfile underlay/default.lua
@@ -4,6 +4,11 @@
 -- SelectProfileFrames for both PLAYER_1 and PLAYER_2, but only the MasterPlayerNumber
 local PreferredStyle = ThemePrefs.Get("PreferredStyle")
 
+-- retrieve the MasterPlayerNumber now, at initialization, so that if PreferredStyle is set
+-- to "single" or "double" and that singular player unjoins, we still have a handle on
+-- which PlayerNumber they're supposed to be...
+local mpn = GAMESTATE:GetMasterPlayerNumber()
+
 -- a table of profile data (highscore name, most recent song, mods, etc.)
 -- indexed by "ProfileIndex" (provided by engine)
 local profile_data = LoadActor("./PlayerProfileData.lua")
@@ -227,7 +232,7 @@ local t = Def.ActorFrame {
 			return
 		end
 
-		if PreferredStyle=="none" or PreferredStyle=="versus" or #GAMESTATE:GetHumanPlayers() > 1 then
+		if not (PreferredStyle=="single" or PreferredStyle=="double") or #GAMESTATE:GetHumanPlayers() > 1 then
 			HandleStateChange(self, PLAYER_1)
 			HandleStateChange(self, PLAYER_2)
 		else

--- a/BGAnimations/ScreenSystemLayer overlay.lua
+++ b/BGAnimations/ScreenSystemLayer overlay.lua
@@ -53,7 +53,7 @@ local function CreditsText( player )
 						textColor = color(SL.SRPG10.TextColor)
 						shadowLength = 0.4
 					end
-				elseif (screen:GetName() == "ScreenEvaluationStage") or (screen:GetName() == "ScreenEvaluationNonstop") or (screen:GetName() == "ScreenGameplay") then
+				elseif (screen:GetName() == "ScreenEvaluationStage") or (screen:GetName() == "ScreenEvaluationNonstop") or (screen:GetName() == Branch.GameplayScreen()) then
 					-- ignore ShowCreditDisplay metric for ScreenEval
 					-- only show this BitmapText actor on Evaluation if the player is joined
 					bShow = GAMESTATE:IsHumanPlayer(player)

--- a/BGAnimations/ScreenSystemLayer overlay.lua
+++ b/BGAnimations/ScreenSystemLayer overlay.lua
@@ -53,7 +53,7 @@ local function CreditsText( player )
 						textColor = color(SL.SRPG9.TextColor)
 						shadowLength = 0.4
 					end
-				elseif (screen:GetName() == "ScreenEvaluationStage") or (screen:GetName() == "ScreenEvaluationNonstop") or (screen:GetName() == "ScreenGameplay") then
+				elseif (screen:GetName() == "ScreenEvaluationStage") or (screen:GetName() == "ScreenEvaluationNonstop") or (screen:GetName() == Branch.GameplayScreen()) then
 					-- ignore ShowCreditDisplay metric for ScreenEval
 					-- only show this BitmapText actor on Evaluation if the player is joined
 					bShow = GAMESTATE:IsHumanPlayer(player)

--- a/BGAnimations/_modules/TestInput Pad/default.lua
+++ b/BGAnimations/_modules/TestInput Pad/default.lua
@@ -65,7 +65,7 @@ for panel,values in pairs(Highlights) do
 			local style = GAMESTATE:GetCurrentStyle()
 			local styletype = style and style:GetStyleType() or nil
 
-			-- if double or routine
+			-- if double or couples
 			if styletype == "StyleType_OnePlayerTwoSides" or styletype == "StyleType_TwoPlayersSharedSides" then
 
 				-- in double, we can't rely on checking the input event's "PlayerNumber" key (only one human player is joined)

--- a/Graphics/OptionsCursor Left.lua
+++ b/Graphics/OptionsCursor Left.lua
@@ -1,0 +1,29 @@
+local player = ...
+if not player then return Def.Actor end
+
+local StepchartOptRowIndex = nil
+
+-- get all the LinesNames as a single string from Metrics.ini, split on commas,
+local LineNames = split(",", THEME:GetMetric("ScreenPlayerOptions", "LineNames"))
+-- and loop through until we find one that matches "Stepchart" (or, we don't).
+for i, name in ipairs(LineNames) do
+	if name == "Stepchart" then StepchartOptRowIndex = i-1; break end
+end
+
+local PlayerOnStepChartOptRow = function(p)
+	return SCREENMAN:GetTopScreen():GetCurrentRowIndex(p) == StepchartOptRowIndex
+end
+
+-- -----------------------------------------------------------------------
+
+return Def.Quad {
+	Name="CursorLeft",
+	InitCommand=function(self) self:zoomto(2,26) end,
+	OptionRowChangedMessageCommand=function(self, params)
+	if PlayerOnStepChartOptRow(player) then
+			self:y(player==PLAYER_1 and 1 or 3):zoomto(2,30)
+		else
+			self:y(player==PLAYER_1 and -1 or 1):zoomto(2,26)
+		 end
+	end
+}

--- a/Graphics/OptionsCursor Middle.lua
+++ b/Graphics/OptionsCursor Middle.lua
@@ -1,0 +1,37 @@
+local player = ...
+if not player then return Def.Actor end
+
+local StepchartOptRowIndex = nil
+
+-- get all the LinesNames as a single string from Metrics.ini, split on commas,
+local LineNames = split(",", THEME:GetMetric("ScreenPlayerOptions", "LineNames"))
+-- and loop through until we find one that matches "Stepchart" (or, we don't).
+for i, name in ipairs(LineNames) do
+	if name == "Stepchart" then StepchartOptRowIndex = i-1; break end
+end
+
+local PlayerOnStepChartOptRow = function(p)
+	return SCREENMAN:GetTopScreen():GetCurrentRowIndex(p) == StepchartOptRowIndex
+end
+
+-- -----------------------------------------------------------------------
+
+return Def.ActorFrame {
+	Def.Quad {
+		Name="CursorTop",
+		InitCommand=function(self) self:zoomto(1,2):y(-12) end,
+	},
+	Def.Quad {
+		Name="CursorBottom",
+		InitCommand=function(self) self:zoomto(1,2):y(12) end,
+		OptionRowChangedMessageCommand=function(self)
+			if PlayerOnStepChartOptRow(player) then
+				-- self:y(player==PLAYER_1 and 16 or 14)
+				self:y(16)
+			else
+				-- self:y(player==PLAYER_1 and 12 or 10 )
+				self:y(12)
+			end
+		end
+	}
+}

--- a/Graphics/OptionsCursor Right.lua
+++ b/Graphics/OptionsCursor Right.lua
@@ -1,0 +1,29 @@
+local player = ...
+if not player then return Def.Actor end
+
+local StepchartOptRowIndex = nil
+
+-- get all the LinesNames as a single string from Metrics.ini, split on commas,
+local LineNames = split(",", THEME:GetMetric("ScreenPlayerOptions", "LineNames"))
+-- and loop through until we find one that matches "Stepchart" (or, we don't).
+for i, name in ipairs(LineNames) do
+	if name == "Stepchart" then StepchartOptRowIndex = i-1; break end
+end
+
+local PlayerOnStepChartOptRow = function(p)
+	return SCREENMAN:GetTopScreen():GetCurrentRowIndex(p) == StepchartOptRowIndex
+end
+
+-- -----------------------------------------------------------------------
+
+return Def.Quad {
+	Name="CursorRight",
+	InitCommand=function(self) self:zoomto(2,26) end,
+	OptionRowChangedMessageCommand=function(self, params)
+		if PlayerOnStepChartOptRow(player) then
+			self:y(player==PLAYER_1 and 1 or 3):zoomto(2,30)
+		else
+			self:y(player==PLAYER_1 and -1 or 1):zoomto(2,26)
+		end
+	end
+}

--- a/Graphics/OptionsCursorP1 Left.lua
+++ b/Graphics/OptionsCursorP1 Left.lua
@@ -1,4 +1,1 @@
-return Def.Quad {
-	Name="CursorLeft",
-	InitCommand=function(self) self:zoomto(2,26) end
-}
+return LoadActor(THEME:GetPathG("OptionsCursor", "Left"), PLAYER_1)

--- a/Graphics/OptionsCursorP1 Middle.lua
+++ b/Graphics/OptionsCursorP1 Middle.lua
@@ -1,10 +1,1 @@
-return Def.ActorFrame {
-	Def.Quad {
-		Name="CursorTop",
-		InitCommand=function(self) self:zoomto(1,2):y(-12) end
-	},
-	Def.Quad {
-		Name="CursorBottom",
-		InitCommand=function(self) self:zoomto(1,2):y(12) end
-	}
-}
+return LoadActor(THEME:GetPathG("OptionsCursor", "Middle"), PLAYER_1)

--- a/Graphics/OptionsCursorP1 Right.lua
+++ b/Graphics/OptionsCursorP1 Right.lua
@@ -1,4 +1,1 @@
-return Def.Quad {
-	Name="CursorRight",
-	InitCommand=function(self) self:zoomto(2,26) end
-}
+return LoadActor(THEME:GetPathG("OptionsCursor", "Right"), PLAYER_1)

--- a/Graphics/OptionsCursorP2 Left.lua
+++ b/Graphics/OptionsCursorP2 Left.lua
@@ -1,0 +1,1 @@
+return LoadActor(THEME:GetPathG("OptionsCursor", "Left"), PLAYER_2)

--- a/Graphics/OptionsCursorP2 Left.redir
+++ b/Graphics/OptionsCursorP2 Left.redir
@@ -1,1 +1,0 @@
-OptionsCursorP1 Left

--- a/Graphics/OptionsCursorP2 Middle.lua
+++ b/Graphics/OptionsCursorP2 Middle.lua
@@ -1,0 +1,1 @@
+return LoadActor(THEME:GetPathG("OptionsCursor", "Middle"), PLAYER_2)

--- a/Graphics/OptionsCursorP2 Middle.redir
+++ b/Graphics/OptionsCursorP2 Middle.redir
@@ -1,1 +1,0 @@
-OptionsCursorP1 Middle

--- a/Graphics/OptionsCursorP2 Right.lua
+++ b/Graphics/OptionsCursorP2 Right.lua
@@ -1,0 +1,1 @@
+return LoadActor(THEME:GetPathG("OptionsCursor", "Right"), PLAYER_2)

--- a/Graphics/OptionsCursorP2 Right.redir
+++ b/Graphics/OptionsCursorP2 Right.redir
@@ -1,1 +1,0 @@
-OptionsCursorP1 Right

--- a/Graphics/OptionsUnderlineP1 Middle.lua
+++ b/Graphics/OptionsUnderlineP1 Middle.lua
@@ -1,4 +1,44 @@
-return Def.Quad {
+local StepchartOptRowIndex = nil
+
+-- get all the LinesNames as a single string from Metrics.ini, split on commas,
+local LineNames = split(",", THEME:GetMetric("ScreenPlayerOptions", "LineNames"))
+-- and loop through until we find one that matches "Stepchart" (or, we don't).
+for i, name in ipairs(LineNames) do
+	if name == "Stepchart" then StepchartOptRowIndex = i-1; break end
+end
+-- -----------------------------------------------------------------------
+
+return Def.ActorFrame{
 	Name="OptionsUnderlineMiddle",
-	InitCommand=function(self) self:zoomto(1,3) end
+
+	Def.Quad {
+		InitCommand=function(self)
+			self:zoomto(1,3)
+		end,
+		OptionRowChangedMessageCommand=function(self)
+			-- apparently changing one particular OptionRow's underline sprite's y()
+			-- once at Init or On isn't enough to stick because the engine will
+			-- continue to reset the y() of each underline each time the user
+			-- changes focus to a new OptionRow ...
+			--
+			-- So, SL's metrics will broadcast "OptionRowChanged" using MESSAGEMAN.
+			-- Listen for that here, and find the underline actor for the StepChart
+			-- OptionRow amidst myriad unnamed children belonging to the topscreen
+			-- each and every time.
+			local optrow = SCREENMAN:GetTopScreen():GetChild("Container"):GetChild("")[StepchartOptRowIndex+1]
+			if not optrow then return end
+
+			local underline_af = optrow:GetChild("")
+			if not underline_af then return end
+
+			-- there are 18 unnamed children (???)
+			local unnamed_children = underline_af:GetChild("")
+			if not unnamed_children then return end
+
+			for k,v in ipairs(unnamed_children) do
+				-- offset them all by 4px
+				v:y(4)
+			end
+		end
+	}
 }

--- a/Graphics/Player combo.lua
+++ b/Graphics/Player combo.lua
@@ -1,6 +1,8 @@
 local player = Var "Player"
 local pn = ToEnumShortString(player)
 local mods = SL[pn].ActiveModifiers
+local style = GAMESTATE:GetCurrentStyle()
+local styletype = style and style:GetStyleType() or nil
 
 local available_fonts = GetComboFonts()
 local combo_font = (FindInTable(mods.ComboFont, available_fonts) ~= nil and mods.ComboFont) or available_fonts[1] or nil
@@ -45,6 +47,13 @@ local combo_bmt = LoadFont("_Combo Fonts/" .. combo_font .."/" .. combo_font)..{
 	Name="Number",
 	OnCommand=function(self)
 		self:shadowlength(1):vertalign(middle):zoom(0.75)
+		if styletype == "StyleType_TwoPlayersSharedSides" then 
+			if player == PLAYER_1 then
+				self:addx(-120):addy(-20)
+			else
+				self:addx(120):addy(-20)
+			end
+		end
 	end,
 	ComboCommand=function(self, params)
 		self:settext( params.Combo or params.Misses or "" )
@@ -83,7 +92,15 @@ local combo_bmt = LoadFont("_Combo Fonts/" .. combo_font .."/" .. combo_font)..{
 			self:effectcolor1(colors.FullComboW4[1]):effectcolor2(colors.FullComboW4[2])
 
 		elseif params.Combo then
-			self:stopeffect():diffuse( Color.White ) -- not a full combo; no effect, always just #ffffff
+			if styletype == "StyleType_TwoPlayersSharedSides" then 
+				if player == PLAYER_1 then
+					self:stopeffect():diffuse(color("#ADD8E6"))
+				else
+					self:stopeffect():diffuse(color("#FFC0CB"))
+				end
+			else
+				self:stopeffect():diffuse( Color.White ) -- not a full combo; no effect, always just #ffffff
+			end
 
 		elseif params.Misses then
 			self:stopeffect():diffuse( Color.Red ) -- Miss Combo; no effect, always just #ff0000

--- a/Graphics/Player combo.lua
+++ b/Graphics/Player combo.lua
@@ -1,6 +1,8 @@
 local player = Var "Player"
 local pn = ToEnumShortString(player)
 local mods = SL[pn].ActiveModifiers
+local style = GAMESTATE:GetCurrentStyle()
+local styletype = style and style:GetStyleType() or nil
 
 local available_fonts = GetComboFonts()
 local combo_font = (FindInTable(mods.ComboFont, available_fonts) ~= nil and mods.ComboFont) or available_fonts[1] or nil
@@ -45,6 +47,13 @@ local combo_bmt = LoadFont("_Combo Fonts/" .. combo_font .."/" .. combo_font)..{
 	Name="Number",
 	OnCommand=function(self)
 		self:shadowlength(1):vertalign(middle):zoom(0.75)
+		if styletype == "StyleType_TwoPlayersSharedSides" then 
+			if player == PLAYER_1 then
+				self:addx(-120):addy(-20)
+			else
+				self:addx(120):addy(-20)
+			end
+		end
 	end,
 	ComboCommand=function(self, params)
 		self:settext( params.Combo or params.Misses or "" )
@@ -83,11 +92,20 @@ local combo_bmt = LoadFont("_Combo Fonts/" .. combo_font .."/" .. combo_font)..{
 			self:effectcolor1(colors.FullComboW4[1]):effectcolor2(colors.FullComboW4[2])
 
 		elseif params.Combo then
-			self:stopeffect():diffuse( Color.White ) -- not a full combo; no effect, always just #ffffff
+			if styletype == "StyleType_TwoPlayersSharedSides" then 
+				if player == PLAYER_1 then
+					self:stopeffect():diffuse(color("#ADD8E6"))
+				else
+					self:stopeffect():diffuse(color("#FFC0CB"))
+				end
+			else
+				self:stopeffect():diffuse( Color.White ) -- not a full combo; no effect, always just #ffffff
+			end
 
 		elseif params.Misses then
 			self:stopeffect():diffuse( Color.Red ) -- Miss Combo; no effect, always just #ff0000
 		end
+
 	end
 }
 

--- a/Graphics/Player judgment.lua
+++ b/Graphics/Player judgment.lua
@@ -2,6 +2,9 @@ local player = Var "Player"
 local pn = ToEnumShortString(player)
 local mods = SL[pn].ActiveModifiers
 local sprite
+local coupleSprite
+local style = GAMESTATE:GetCurrentStyle()
+local styletype = style and style:GetStyleType() or nil
 
 ------------------------------------------------------------
 -- A profile might ask for a judgment graphic that doesn't exist
@@ -216,6 +219,18 @@ return Def.ActorFrame{
 
 			else
 				self:Load( THEME:GetPathG("", "_judgments/" .. file_to_load) )
+			end
+			-- local mini = mods.Mini:gsub("%%","") / 100
+			-- self:addx((mods.NoteFieldOffsetX * (1 + mini)) * 2)
+			-- self:addy((mods.NoteFieldOffsetY * (1 + mini)) * 2)
+			if styletype == "StyleType_TwoPlayersSharedSides" then 
+				if player == PLAYER_1 then
+					self:addy(10)
+					self:diffuse(Color.Blue)
+				else
+					self:addy(60)
+					self:diffuse(Color.Red)
+				end
 			end
 		end,
 		ResetCommand=function(self) self:finishtweening():stopeffect():visible(false) end

--- a/Languages/de.ini
+++ b/Languages/de.ini
@@ -576,7 +576,7 @@ ThreeKeyNavigation=Drei Tasten Navigation
 
 
 # Simply Love Options
-AutoStyle=Bevorzugter Stil
+PreferredStyle=Bevorzugter Stil
 DefaultGameMode=Standard-\nSpielmodus
 AllowFailingOutOfSet=Allow Players\nTo Fail Set
 NumberOfContinuesAllowed=Number Of\nContinues Allowed
@@ -752,7 +752,7 @@ AxisFix=Workaround fix for some USB adapters that would otherwise map the D-Pad 
 
 
 # Simply Love Options
-AutoStyle=Set this if you ALWAYS play a certain style and want to get to gameplay as fast as possible.\n\nSet this to "None" if you want to choose a style like "1 Player" or "2 Players" for each new game cycle.
+PreferredStyle=Set this if you ALWAYS play a certain style and want to get to gameplay as fast as possible.\n\nSet this to "None" if you want to choose a style like "1 Player" or "2 Players" for each new game cycle.
 DefaultGameMode=Set the starting position of the cursor when selecting a GameMode.\n\nNote that this does not skip the screen, it just changes the starting choice.
 AllowFailingOutOfSet=If 'Yes' players can potentially fail out of a set early.  If 'No' players will always be able to play all their songs.\n\nThis has no impact in EventMode.
 NumberOfContinuesAllowed=Allow players to chain multiple games together by entering extra credits. Set this to 0 if you want to disable it.
@@ -880,7 +880,7 @@ Select Profile=Dieses Profil verwenden oder es ändern.
 [RecommendedOptionExplanations]
 # Simply Love Options
 Recommended=Empfohlen
-AutoStyle='None' is the only appropriate setting for public machines.
+PreferredStyle='None' is the only appropriate setting for public machines.
 DefaultGameMode='Casual' is probably the most appropriate for public machines.
 AllowFailingOutOfSet=This should be 'No' unless you are a mean dude that wants to cycle people through games as quickly as possible.
 MusicWheelStyle='IIDX' allows faster navigation of the MusicWheel.

--- a/Languages/de.ini
+++ b/Languages/de.ini
@@ -572,7 +572,7 @@ ThreeKeyNavigation=Drei Tasten Navigation
 
 
 # Simply Love Options
-AutoStyle=Bevorzugter Stil
+PreferredStyle=Bevorzugter Stil
 DefaultGameMode=Standard-\nSpielmodus
 AllowFailingOutOfSet=Allow Players\nTo Fail Set
 NumberOfContinuesAllowed=Number Of\nContinues Allowed
@@ -748,7 +748,7 @@ AxisFix=Workaround fix for some USB adapters that would otherwise map the D-Pad 
 
 
 # Simply Love Options
-AutoStyle=Set this if you ALWAYS play a certain style and want to get to gameplay as fast as possible.\n\nSet this to "None" if you want to choose a style like "1 Player" or "2 Players" for each new game cycle.
+PreferredStyle=Set this if you ALWAYS play a certain style and want to get to gameplay as fast as possible.\n\nSet this to "None" if you want to choose a style like "1 Player" or "2 Players" for each new game cycle.
 DefaultGameMode=Set the starting position of the cursor when selecting a GameMode.\n\nNote that this does not skip the screen, it just changes the starting choice.
 AllowFailingOutOfSet=If 'Yes' players can potentially fail out of a set early.  If 'No' players will always be able to play all their songs.\n\nThis has no impact in EventMode.
 NumberOfContinuesAllowed=Allow players to chain multiple games together by entering extra credits. Set this to 0 if you want to disable it.\n\nThis feature only applies to Pay Mode, because credits only exist in Pay Mode.
@@ -876,7 +876,7 @@ Select Profile=Dieses Profil verwenden oder es ändern.
 [RecommendedOptionExplanations]
 # Simply Love Options
 Recommended=Empfohlen
-AutoStyle='None' is the only appropriate setting for public machines.
+PreferredStyle='None' is the only appropriate setting for public machines.
 DefaultGameMode='Casual' is probably the most appropriate for public machines.
 AllowFailingOutOfSet=This should be 'No' unless you are a mean dude that wants to cycle people through games as quickly as possible.
 MusicWheelStyle='IIDX' allows faster navigation of the MusicWheel.

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -171,7 +171,10 @@ TopP2Grades=P2 Clear Rank
 Single=Single
 Double=Double
 Versus=Versus
-Routine=Routine
+Routine=Couples
+Couple=Half Couple
+Halfdouble=Half Double
+All=All Styles
 Solo=Solo
 # technomotion's styles include "8" behind the scenes
 # present technomtion style choices to players without the "8"

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -84,8 +84,9 @@ MarathonDescription=Play a predetermined course\nof songs without any\nbreak bet
 
 [ScreenSelectStyle]
 HeaderText=Select Style
-# None is one of the options for "AutoStyle" within Simply Love Options
+# None is one of the options for "PreferredStyle" within Simply Love Options
 None=None
+Auto=All
 Single=1 Player
 Versus=2 Players
 Double=Double
@@ -168,6 +169,7 @@ TopP1Grades=P1 Clear Rank
 TopP2Grades=P2 Clear Rank
 
 # SortMenu "Change Style To" choices
+Auto=All
 Single=Single
 Double=Double
 Versus=Versus
@@ -612,19 +614,19 @@ dance-solo=Solo
 # ...3 panel dance?
 dance-threepanel=3panel
 # 2 players share 8 panels; many people refer to this as "couples" though that is something else D:
-dance-routine=Routine
+dance-routine=Couples
 # 2 players, each stays on their own 4 panel dance pad, but they have unique steps
 # that artisically complement one another; I don't think most people know this exists.
-dance-couple=Couple
+dance-couple=Half\nCouples
 
 # 5 panel pump
 pump-single=Single
 # 10 panel pump
 pump-double=Double
 # 6 panel pump
-pump-halfdouble=Half Double
+pump-halfdouble=Half\nDouble
 # 2 players share 10 panels; this is actually a thing in current PIU games
-pump-routine=Routine
+pump-routine=Co-Op
 # like dance-couple, I guess?  does this appear in any real PIU games?
 pump-couple=Couple
 
@@ -720,7 +722,7 @@ AllowMultipleHighScoreWithSameName=Multiple High Scores\nWith Same Name
 ThreeKeyNavigation=Three Button\nNavigation
 
 # Simply Love Options
-AutoStyle=Preferred Style
+PreferredStyle=Preferred Style
 DefaultGameMode=Default\nGame Mode
 AllowFailingOutOfSet=Allow Players\nTo Fail Set
 NumberOfContinuesAllowed=Number Of\nContinues Allowed
@@ -943,7 +945,7 @@ AxisFix=Set this to "On" if you use a USB adapter to connect your dance pad and 
 #'
 
 # Simply Love Options
-AutoStyle=Set this if you ALWAYS play a certain style and want to get to gameplay as fast as possible.\n\nSet this to "None" if you want to choose a style like "1 Player" or "2 Players" for each new game cycle.
+PreferredStyle=Set to 'All' to skip Style selection and display all available stepcharts for each song side-by-side in the MusicWheel, like PIU does.\n\nSet to '1 Player', '2 Players', or 'Double' to skip Style selection and automatically choose that style.\n\nSet to 'None' if you want to choose a style like "1 Player" or "2 Players" before each new game cycle.
 DefaultGameMode=Set the starting position of the cursor when selecting a GameMode.\n\nNote that this does not skip the screen, it just changes the starting choice.
 AllowFailingOutOfSet=If 'Yes' players can potentially fail out of a set early.  If 'No' players will always be able to play all their songs.\n\nThis has no impact in Event Mode.
 NumberOfContinuesAllowed=Allow players to chain multiple games together by entering extra credits. Set this to 0 if you want to disable it.

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -84,8 +84,9 @@ MarathonDescription=Play a predetermined course\nof songs without any\nbreak bet
 
 [ScreenSelectStyle]
 HeaderText=Select Style
-# None is one of the options for "AutoStyle" within Simply Love Options
+# None is one of the options for "PreferredStyle" within Simply Love Options
 None=None
+Auto=All
 Single=1 Player
 Versus=2 Players
 Double=Double
@@ -167,6 +168,7 @@ TopP1Grades=P1 Clear Rank
 TopP2Grades=P2 Clear Rank
 
 # SortMenu "Change Style To" choices
+Auto=All
 Single=Single
 Double=Double
 Versus=Versus
@@ -606,19 +608,19 @@ dance-solo=Solo
 # ...3 panel dance?
 dance-threepanel=3panel
 # 2 players share 8 panels; many people refer to this as "couples" though that is something else D:
-dance-routine=Routine
+dance-routine=Couples
 # 2 players, each stays on their own 4 panel dance pad, but they have unique steps
 # that artisically complement one another; I don't think most people know this exists.
-dance-couple=Couple
+dance-couple=Half\nCouples
 
 # 5 panel pump
 pump-single=Single
 # 10 panel pump
 pump-double=Double
 # 6 panel pump
-pump-halfdouble=Half Double
+pump-halfdouble=Half\nDouble
 # 2 players share 10 panels; this is actually a thing in current PIU games
-pump-routine=Routine
+pump-routine=Co-Op
 # like dance-couple, I guess?  does this appear in any real PIU games?
 pump-couple=Couple
 
@@ -714,7 +716,7 @@ AllowMultipleHighScoreWithSameName=Multiple High Scores\nWith Same Name
 ThreeKeyNavigation=Three Button\nNavigation
 
 # Simply Love Options
-AutoStyle=Preferred Style
+PreferredStyle=Preferred Style
 DefaultGameMode=Default\nGame Mode
 AllowFailingOutOfSet=Allow Players\nTo Fail Set
 NumberOfContinuesAllowed=Number Of\nContinues Allowed
@@ -935,7 +937,7 @@ AxisFix=Set this to "On" if you use a USB adapter to connect your dance pad and 
 #'
 
 # Simply Love Options
-AutoStyle=Set this if you ALWAYS play a certain style and want to get to gameplay as fast as possible.\n\nSet this to "None" if you want to choose a style like "1 Player" or "2 Players" for each new game cycle.
+PreferredStyle=Set to 'All' to skip Style selection and display all available stepcharts for each song side-by-side in the MusicWheel, like PIU does.\n\nSet to '1 Player', '2 Players', or 'Double' to skip Style selection and automatically choose that style.\n\nSet to 'None' if you want to choose a style like "1 Player" or "2 Players" before each new game cycle.
 DefaultGameMode=Set the starting position of the cursor when selecting a GameMode.\n\nNote that this does not skip the screen, it just changes the starting choice.
 AllowFailingOutOfSet=If 'Yes' players can potentially fail out of a set early.  If 'No' players will always be able to play all their songs.\n\nThis has no impact in Event Mode.
 NumberOfContinuesAllowed=Allow players to chain multiple games together by entering extra credits. Set this to 0 if you want to disable it.\n\nThis feature only applies to Pay Mode, because credits only exist in Pay Mode.
@@ -1079,7 +1081,7 @@ EditorShowBGChangesPlay=Show or hide background images (and scripted FGChanges, 
 [RecommendedOptionExplanations]
 # Simply Love Options
 Recommended=Recommended
-AutoStyle='None' is best for public machines.
+PreferredStyle='None' is best for public machines.
 DefaultGameMode='Casual' is best for public machines.
 AllowFailingOutOfSet=This should be 'No' unless you are a mean dude that wants to cycle people through games as quickly as possible.
 MusicWheelStyle='IIDX' allows faster navigation of the MusicWheel.

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -170,7 +170,10 @@ TopP2Grades=P2 Clear Rank
 Single=Single
 Double=Double
 Versus=Versus
-Routine=Routine
+Routine=Couples
+Couple=Half Couple
+Halfdouble=Half Double
+All=All Styles
 Solo=Solo
 # technomotion's styles include "8" behind the scenes
 # present technomtion style choices to players without the "8"

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -172,8 +172,8 @@ Auto=All
 Single=Single
 Double=Double
 Versus=Versus
-Routine=Couples
-Couple=Half Couple
+Routine=Routine
+Couple=Couples
 Halfdouble=Half Double
 All=All Styles
 Solo=Solo
@@ -607,11 +607,11 @@ dance-double=Double
 dance-solo=Solo
 # ...3 panel dance?
 dance-threepanel=3panel
-# 2 players share 8 panels; many people refer to this as "couples" though that is something else D:
-dance-routine=Couples
 # 2 players, each stays on their own 4 panel dance pad, but they have unique steps
 # that artisically complement one another; I don't think most people know this exists.
-dance-couple=Half\nCouples
+dance-routine=Routine
+# 2 players share 8 panels; many people refer to this as "couples" though that is something else D:
+dance-couple=Couples
 
 # 5 panel pump
 pump-single=Single
@@ -620,9 +620,9 @@ pump-double=Double
 # 6 panel pump
 pump-halfdouble=Half\nDouble
 # 2 players share 10 panels; this is actually a thing in current PIU games
-pump-routine=Co-Op
-# like dance-couple, I guess?  does this appear in any real PIU games?
-pump-couple=Couple
+pump-couple=Co-Op
+# like dance-routine, I guess?  does this appear in any real PIU games?
+pump-routine=Routine
 
 # Arcade TechnoMotion allowed players to choose 4 panel, 5 panel, or 8 panel gameplay.  Neat.
 # While StepMania supports all this, Simply Love only allows 8 panel gameplay.

--- a/Languages/es.ini
+++ b/Languages/es.ini
@@ -682,7 +682,7 @@ AllowMultipleHighScoreWithSameName=Multiples Puntuaciones\nCon Mismo Nombre
 ThreeKeyNavigation=Navegación de\ntres botones
 
 # Simply Love Options
-AutoStyle=Estilo Preferido
+PreferredStyle=Estilo Preferido
 DefaultGameMode=Modo de Juego\nPredeterminado
 AllowFailingOutOfSet=Permitir Fallida\nDe Set
 NumberOfContinuesAllowed=Cantidad de\n"Continuar" Permitidos
@@ -873,7 +873,7 @@ AllowScreenEvalSummary=Coloca esto a 'No' si quieres saltar la pantalla de Resum
 AllowScreenNameEntry=Coloca esto a 'No' si quieres saltar la pantalla de Entrada de Nombre.
 AllowScreenGameOver=Coloca esto a 'No' si quieres saltar la pantalla de Juego Terminado.
 
-AutoStyle=Deja esto en "Ninguno" si quieres escoger algún estilo como "1 Jugador" o "2 Jugadores" para cada nueva partida.
+PreferredStyle=Deja esto en "Ninguno" si quieres escoger algún estilo como "1 Jugador" o "2 Jugadores" para cada nueva partida.
 MusicWheelStyle=Ajusta esto a 'IIDX' si quieres que MusicWheel esconda los otros grupos mientras navegas uno.
 AllowDanceSolo=Deja esto a 'Sí' si quieres habilitar el modo Solo.\nEsto solo impacta al modo 'Dance'.
 MusicWheelSpeed=Cambia la velocidad que MusicWheel se moverá al seleccionar contenido.\n\nUna rueda más rapida es especialmente útil si el temporizador está encendido.
@@ -990,7 +990,7 @@ SeparateUnlocksByPlayer=Desbloqueos separados por jugador
 # Simply Love Options
 Recommended=Recomendado
 
-AutoStyle='Ninguno' es la única opción apropiada para las maquinas públicas.
+PreferredStyle='Ninguno' es la única opción apropiada para las maquinas públicas.
 DefaultGameMode='Casual' es probablemente la opción más apropiada para una maquina pública.
 AllowFailingOutOfSet=Esto debería estar en 'No' al menos que seas un tipo malo que quiere terminar juegos lo más rapido posible.
 MusicWheelStyle='IIDX' permite una navegación más rapida en el Rueda.

--- a/Languages/es.ini
+++ b/Languages/es.ini
@@ -681,7 +681,7 @@ AllowMultipleHighScoreWithSameName=Multiples Puntuaciones\nCon Mismo Nombre
 ThreeKeyNavigation=Navegación de\ntres botones
 
 # Simply Love Options
-AutoStyle=Estilo Preferido
+PreferredStyle=Estilo Preferido
 DefaultGameMode=Modo de Juego\nPredeterminado
 AllowFailingOutOfSet=Permitir Fallida\nDe Set
 NumberOfContinuesAllowed=Cantidad de\n"Continuar" Permitidos
@@ -872,7 +872,7 @@ AllowScreenEvalSummary=Coloca esto a 'No' si quieres saltar la pantalla de Resum
 AllowScreenNameEntry=Coloca esto a 'No' si quieres saltar la pantalla de Entrada de Nombre.
 AllowScreenGameOver=Coloca esto a 'No' si quieres saltar la pantalla de Juego Terminado.
 
-AutoStyle=Deja esto en "Ninguno" si quieres escoger algún estilo como "1 Jugador" o "2 Jugadores" para cada nueva partida.
+PreferredStyle=Deja esto en "Ninguno" si quieres escoger algún estilo como "1 Jugador" o "2 Jugadores" para cada nueva partida.
 MusicWheelStyle=Ajusta esto a 'IIDX' si quieres que MusicWheel esconda los otros grupos mientras navegas uno.
 AllowDanceSolo=Deja esto a 'Sí' si quieres habilitar el modo Solo.\nEsto solo impacta al modo 'Dance'.
 MusicWheelSpeed=Cambia la velocidad que MusicWheel se moverá al seleccionar contenido.\n\nUna rueda más rapida es especialmente útil si el temporizador está encendido.
@@ -989,7 +989,7 @@ SeparateUnlocksByPlayer=Desbloqueos separados por jugador
 # Simply Love Options
 Recommended=Recomendado
 
-AutoStyle='Ninguno' es la única opción apropiada para las maquinas públicas.
+PreferredStyle='Ninguno' es la única opción apropiada para las maquinas públicas.
 DefaultGameMode='Casual' es probablemente la opción más apropiada para una maquina pública.
 AllowFailingOutOfSet=Esto debería estar en 'No' al menos que seas un tipo malo que quiere terminar juegos lo más rapido posible.
 MusicWheelStyle='IIDX' permite una navegación más rapida en el Rueda.

--- a/Languages/fr.ini
+++ b/Languages/fr.ini
@@ -481,7 +481,7 @@ AllowMultipleHighScoreWithSameName=Plusieurs meilleurs scores\navec le même nom
 ThreeKeyNavigation=Navigation à 3 boutons
 
 # Simply Love Options
-AutoStyle=Style préféré
+PreferredStyle=Style préféré
 DefaultGameMode=Mode de jeu\npar défaut
 AllowFailingOutOfSet=Autoriser les joueurs\nà rater l'ensemble
 NumberOfContinuesAllowed=Nombre de\n"Continuer" autorisés
@@ -642,7 +642,7 @@ AxisFix=Solution de contournement pour certains adaptateurs USB qui assignent le
 #'
 
 # Simply Love Options
-AutoStyle=Définissez ceci si vous jouez TOUJOURS d'un certain style et souhaitez arriver en jeu le plus vite possible.\n\nDéfinissez ceci à 'Aucun' si vous souhaitez permettre le choix d'un style comme "1 joueur" ou "2 joueurs" pour chaque partie.
+PreferredStyle=Définissez ceci si vous jouez TOUJOURS d'un certain style et souhaitez arriver en jeu le plus vite possible.\n\nDéfinissez ceci à 'Aucun' si vous souhaitez permettre le choix d'un style comme "1 joueur" ou "2 joueurs" pour chaque partie.
 DefaultGameMode=Définir la position par défaut du curseur en choisissant un mode de jeu.\n\nCeci ne saute pas le choix de mode de jeu, ceci change uniquement le choix de départ.
 AllowFailingOutOfSet=Si activé, les joueurs peuvent rater un ensemble de chansons plus tôt. Si désactivé, les joueurs seront capables de jouer toutes leurs chansons.\n\nCeci n'a aucun impact en mode évènement.
 NumberOfContinuesAllowed=Autoriser les joueurs à enchaîner plusieurs parties en insérant des crédits additionnels (0 désactive cette option).
@@ -751,7 +751,7 @@ Select Profile=Utiliser ce profil ou le modifier.
 [RecommendedOptionExplanations]
 # Simply Love Options
 Recommended=Recommendé
-AutoStyle='Aucun' est le seul mode approprié pour les machines publiques.
+PreferredStyle='Aucun' est le seul mode approprié pour les machines publiques.
 DefaultGameMode='Décontracté' est probablement le plus approprié pour les machines publiques.
 AllowFailingOutOfSet=Ceci devrait être désactivé sauf si vous êtes un grand méchant qui veut voir les parties défiler le plus rapidement possible.
 MusicWheelStyle='IIDX' permet une navigation plus rapide de la roue de musiques.

--- a/Languages/fr.ini
+++ b/Languages/fr.ini
@@ -476,7 +476,7 @@ AllowMultipleHighScoreWithSameName=Plusieurs meilleurs scores\navec le même nom
 ThreeKeyNavigation=Navigation à 3 boutons
 
 # Simply Love Options
-AutoStyle=Style préféré
+PreferredStyle=Style préféré
 DefaultGameMode=Mode de jeu\npar défaut
 AllowFailingOutOfSet=Autoriser les joueurs\nà rater l'ensemble
 NumberOfContinuesAllowed=Nombre de\n"Continuer" autorisés
@@ -637,7 +637,7 @@ AxisFix=Solution de contournement pour certains adaptateurs USB qui assignent le
 #'
 
 # Simply Love Options
-AutoStyle=Définissez ceci si vous jouez TOUJOURS d'un certain style et souhaitez arriver en jeu le plus vite possible.\n\nDéfinissez ceci à 'Aucun' si vous souhaitez permettre le choix d'un style comme "1 joueur" ou "2 joueurs" pour chaque partie.
+PreferredStyle=Définissez ceci si vous jouez TOUJOURS d'un certain style et souhaitez arriver en jeu le plus vite possible.\n\nDéfinissez ceci à 'Aucun' si vous souhaitez permettre le choix d'un style comme "1 joueur" ou "2 joueurs" pour chaque partie.
 DefaultGameMode=Définir la position par défaut du curseur en choisissant un mode de jeu.\n\nCeci ne saute pas le choix de mode de jeu, ceci change uniquement le choix de départ.
 AllowFailingOutOfSet=Si activé, les joueurs peuvent rater un ensemble de chansons plus tôt. Si désactivé, les joueurs seront capables de jouer toutes leurs chansons.\n\nCeci n'a aucun impact en mode évènement.
 NumberOfContinuesAllowed=Autoriser les joueurs à enchaîner plusieurs parties en insérant des crédits additionnels (0 désactive cette option).\n\nCette option s'applique uniquement en mode de jeu payant.
@@ -746,7 +746,7 @@ Select Profile=Utiliser ce profil ou le modifier.
 [RecommendedOptionExplanations]
 # Simply Love Options
 Recommended=Recommendé
-AutoStyle='Aucun' est le seul mode approprié pour les machines publiques.
+PreferredStyle='Aucun' est le seul mode approprié pour les machines publiques.
 DefaultGameMode='Décontracté' est probablement le plus approprié pour les machines publiques.
 AllowFailingOutOfSet=Ceci devrait être désactivé sauf si vous êtes un grand méchant qui veut voir les parties défiler le plus rapidement possible.
 MusicWheelStyle='IIDX' permet une navigation plus rapide de la roue de musiques.

--- a/Languages/it.ini
+++ b/Languages/it.ini
@@ -86,7 +86,7 @@ MarathonDescription=Gioca una sequenza di\ncanzoni predefinite senza\nalcuna int
 
 [ScreenSelectStyle]
 HeaderText=Seleziona Stile
-# None is one of the options for 'AutoStyle' within Simply Love Options
+# None is one of the options for 'PreferredStyle' within Simply Love Options
 None=Nessuno
 Single=1 Giocatore
 Versus=2 Giocatori
@@ -829,7 +829,7 @@ ThreeKeyNavigation=Navigazione a\ntre pulsanti
 AxisFix=Correzione Assi
 
 # Simply Love Options
-AutoStyle=Stile Predefinito
+PreferredStyle=Stile Predefinito
 DefaultGameMode=Modalià di gioco\nPredefinita
 AllowFailingOutOfSet=Permetti il\nfallimento del set
 NumberOfContinuesAllowed=Limite Inserimento\nCrediti
@@ -1118,7 +1118,7 @@ AxisFix=Attiva questa funzione se utilizzi un adattatore USB per collegare la tu
 #'
 
 # Simply Love Options
-AutoStyle=Lascia impostato su 'Nessuno' se preferisci scegliere tra '1 Giocatore', '2 Giocatori' o 'Double' per ogni nuova partita. Altrimenti, scegli una delle altre opzioni.\n\nAttenzione: se imposti uno stile predefinito, la schermata di selezione stile verrà disabilitata!
+PreferredStyle=Lascia impostato su 'Nessuno' se preferisci scegliere tra '1 Giocatore', '2 Giocatori' o 'Double' per ogni nuova partita. Altrimenti, scegli una delle altre opzioni.\n\nAttenzione: se imposti uno stile predefinito, la schermata di selezione stile verrà disabilitata!
 DefaultGameMode=Regola la posizione di default del cursore nella schermata di selezione modalità di gioco.\n\nNota: questo non farà saltare la schermata relativa.
 AllowFailingOutOfSet=Se impostato su 'Sì', i giocatori potrebbero perdere un set prima della fine dello stesso.\n\nSe impostato su 'No', i giocatori saranno in grado di finire il loro set anche se perderanno una o più canzoni.\n\nQuesta impostazione non ha effetto in Event Mode.
 NumberOfContinuesAllowed=Permette ai giocatori di accumulare più partite di fila, inserendo più crediti. Impostalo a 0 se vuoi disattivarlo.
@@ -1246,7 +1246,7 @@ EditorShowBGChangesPlay=Mostra o nascondi le immagini di sfondo (e FGChanges scr
 [RecommendedOptionExplanations]
 # Simply Love Options
 Recommended=Consigliato
-AutoStyle='Nessuno' è l'opzione migliore per un cabinato pubblico.
+PreferredStyle='Nessuno' è l'opzione migliore per un cabinato pubblico.
 DefaultGameMode='Casual' è probabilmente l'opzione migliore per un cabinato pubblico.
 AllowFailingOutOfSet='No', a meno che non ti piaccia perdere un set prima del tempo.
 MusicWheelStyle='IIDX' consente una navigazione più veloce tra le canzoni.

--- a/Languages/it.ini
+++ b/Languages/it.ini
@@ -86,7 +86,7 @@ MarathonDescription=Gioca una sequenza di\ncanzoni predefinite senza\nalcuna int
 
 [ScreenSelectStyle]
 HeaderText=Seleziona Stile
-# None is one of the options for 'AutoStyle' within Simply Love Options
+# None is one of the options for 'PreferredStyle' within Simply Love Options
 None=Nessuno
 Single=1 Giocatore
 Versus=2 Giocatori
@@ -828,7 +828,7 @@ ThreeKeyNavigation=Navigazione a\ntre pulsanti
 AxisFix=Correzione Assi
 
 # Simply Love Options
-AutoStyle=Stile Predefinito
+PreferredStyle=Stile Predefinito
 DefaultGameMode=Modalià di gioco\nPredefinita
 AllowFailingOutOfSet=Permetti il\nfallimento del set
 NumberOfContinuesAllowed=Limite Inserimento\nCrediti
@@ -1117,7 +1117,7 @@ AxisFix=Attiva questa funzione se utilizzi un adattatore USB per collegare la tu
 #'
 
 # Simply Love Options
-AutoStyle=Lascia impostato su 'Nessuno' se preferisci scegliere tra '1 Giocatore', '2 Giocatori' o 'Double' per ogni nuova partita. Altrimenti, scegli una delle altre opzioni.\n\nAttenzione: se imposti uno stile predefinito, la schermata di selezione stile verrà disabilitata!
+PreferredStyle=Lascia impostato su 'Nessuno' se preferisci scegliere tra '1 Giocatore', '2 Giocatori' o 'Double' per ogni nuova partita. Altrimenti, scegli una delle altre opzioni.\n\nAttenzione: se imposti uno stile predefinito, la schermata di selezione stile verrà disabilitata!
 DefaultGameMode=Regola la posizione di default del cursore nella schermata di selezione modalità di gioco.\n\nNota: questo non farà saltare la schermata relativa.
 AllowFailingOutOfSet=Se impostato su 'Sì', i giocatori potrebbero perdere un set prima della fine dello stesso.\n\nSe impostato su 'No', i giocatori saranno in grado di finire il loro set anche se perderanno una o più canzoni.\n\nQuesta impostazione non ha effetto in Event Mode.
 NumberOfContinuesAllowed=Permette ai giocatori di accumulare più partite di fila, inserendo più crediti. Impostalo a 0 se vuoi disattivarlo.\n\nQuesta funzione si applica solo in modalità 'A Pagamento'.
@@ -1245,7 +1245,7 @@ EditorShowBGChangesPlay=Mostra o nascondi le immagini di sfondo (e FGChanges scr
 [RecommendedOptionExplanations]
 # Simply Love Options
 Recommended=Consigliato
-AutoStyle='Nessuno' è l'opzione migliore per un cabinato pubblico.
+PreferredStyle='Nessuno' è l'opzione migliore per un cabinato pubblico.
 DefaultGameMode='Casual' è probabilmente l'opzione migliore per un cabinato pubblico.
 AllowFailingOutOfSet='No', a meno che non ti piaccia perdere un set prima del tempo.
 MusicWheelStyle='IIDX' consente una navigazione più veloce tra le canzoni.

--- a/Languages/ja.ini
+++ b/Languages/ja.ini
@@ -584,7 +584,7 @@ AllowMultipleHighScoreWithSameName=Multiple High Scores\nWith Same Name
 ThreeKeyNavigation=Three Button Navigation
 
 # Simply Love Options
-AutoStyle=Preferred Style
+PreferredStyle=Preferred Style
 DefaultGameMode=Default\nGame Mode
 AllowFailingOutOfSet=Allow Players\nTo Fail Set
 NumberOfContinuesAllowed=Number Of\nContinues Allowed
@@ -752,7 +752,7 @@ AxisFix=D-PadをAxisとして解釈する一部のUSBドライバでは、一部
 
 
 # Simply Love Options
-AutoStyle=このオプションを使うと、スタイル選択画面をスキップすることができます。ゲームプレイをすばやく始めたい場合に有効です。\n\nゲームプレイ毎にスタイルを選択したい場合は、このオプションは'None'にしておきましょう。
+PreferredStyle=このオプションを使うと、スタイル選択画面をスキップすることができます。ゲームプレイをすばやく始めたい場合に有効です。\n\nゲームプレイ毎にスタイルを選択したい場合は、このオプションは'None'にしておきましょう。
 DefaultGameMode=ゲームモード選択画面にて、最初にカーソルが当たるモードを指定します。\n\nこのオプションは'Preferred Style'で指定したように、選択画面をスキップするものではありません。
 AllowFailingOutOfSet='Yes'にすると、プレイヤーがステージをクリアしないと次のステージに進むことができません。\n'No'にすると、ステージをクリアしたかに関係なく、必ず設定ステージ数遊ぶことができます。\n\nこのオプションはEventモードでは無視されます。
 NumberOfContinuesAllowed=もしこの数値が1以上の場合、プレイヤーは追加のクレジットを入れることにより、この数値の回数だけコンティニューできるようになります。
@@ -897,7 +897,7 @@ SeparateUnlocksByPlayer=プレーヤーごとにロック解除を分離しま�
 [RecommendedOptionExplanations]
 # Simply Love Options
 Recommended=おすすめ
-AutoStyle=アーケードで運用するなら、これは'None'にしておくべきでしょう。
+PreferredStyle=アーケードで運用するなら、これは'None'にしておくべきでしょう。
 DefaultGameMode=アーケードで運用するなら、'Casual'にしておくのが無難でしょう。
 AllowFailingOutOfSet=客の回転率をなにがなんでも上げたいケチでもない限り、これは'No'が望ましいです。
 MusicWheelStyle='IIDX'にすると、選曲画面をよりすばやく操作できます。

--- a/Languages/ja.ini
+++ b/Languages/ja.ini
@@ -576,7 +576,7 @@ AllowMultipleHighScoreWithSameName=Multiple High Scores\nWith Same Name
 ThreeKeyNavigation=Three Button Navigation
 
 # Simply Love Options
-AutoStyle=Preferred Style
+PreferredStyle=Preferred Style
 DefaultGameMode=Default\nGame Mode
 AllowFailingOutOfSet=Allow Players\nTo Fail Set
 NumberOfContinuesAllowed=Number Of\nContinues Allowed
@@ -740,7 +740,7 @@ AxisFix=D-PadをAxisとして解釈する一部のUSBドライバでは、一部
 
 
 # Simply Love Options
-AutoStyle=このオプションを使うと、スタイル選択画面をスキップすることができます。ゲームプレイをすばやく始めたい場合に有効です。\n\nゲームプレイ毎にスタイルを選択したい場合は、このオプションは'None'にしておきましょう。
+PreferredStyle=このオプションを使うと、スタイル選択画面をスキップすることができます。ゲームプレイをすばやく始めたい場合に有効です。\n\nゲームプレイ毎にスタイルを選択したい場合は、このオプションは'None'にしておきましょう。
 DefaultGameMode=ゲームモード選択画面にて、最初にカーソルが当たるモードを指定します。\n\nこのオプションは'Preferred Style'で指定したように、選択画面をスキップするものではありません。
 AllowFailingOutOfSet='Yes'にすると、プレイヤーがステージをクリアしないと次のステージに進むことができません。\n'No'にすると、ステージをクリアしたかに関係なく、必ず設定ステージ数遊ぶことができます。\n\nこのオプションはEventモードでは無視されます。
 NumberOfContinuesAllowed=もしこの数値が1以上の場合、プレイヤーは追加のクレジットを入れることにより、この数値の回数だけコンティニューできるようになります。\n\nこのオプションは、Coin Modeが'Pay'のときのみ有効です。
@@ -879,7 +879,7 @@ SeparateUnlocksByPlayer=プレーヤーごとにロック解除を分離しま�
 [RecommendedOptionExplanations]
 # Simply Love Options
 Recommended=推奨
-AutoStyle=アーケードで運用するなら、これは'None'にしておくべきでしょう。
+PreferredStyle=アーケードで運用するなら、これは'None'にしておくべきでしょう。
 DefaultGameMode=アーケードで運用するなら、'Casual'にしておくのが無難でしょう。
 AllowFailingOutOfSet=客の回転率をなにがなんでも上げたいケチでもない限り、これは'No'が望ましいです。
 MusicWheelStyle='IIDX'にすると、選曲画面をよりすばやく操作できます。

--- a/Languages/pl.ini
+++ b/Languages/pl.ini
@@ -83,6 +83,7 @@ MarathonDescription=Graj w ustalone z góry zestawy\nutworów bez żadnych\nprze
 HeaderText=Wybierz Styl
 # None is one of the options for "AutoStyle" within Simply Love Options
 None=Brak
+Auto=Automatyczny
 Single=1 Gracz
 Versus=2 Graczy
 Double=Double
@@ -646,7 +647,7 @@ AllowMultipleHighScoreWithSameName=Wiele Rekordów\nz Tym Samym Imieniem
 ThreeKeyNavigation=Nawigacja\nTrójprzyciskowa
 
 # Opcje Simply Love
-AutoStyle=Preferowany Styl
+PreferredStyle=Preferowany Styl
 DefaultGameMode=Domyślny\nTryb Gry
 AllowFailingOutOfSet=Zezwalaj na\nPorażkę Gry
 NumberOfContinuesAllowed=Ilość Dozwolonych\nKontynuacji
@@ -853,7 +854,7 @@ AxisFix=Włącz tę opcję, gdy podczas używania adaptera USB do podłączenia 
 #'
 
 # Opcje Simply Love
-AutoStyle=Ustaw swój styl, który wybierasz ZAWSZE i chcesz przejść do rozgrywki najszybciej jak to możliwe.\n\nUstaw "Brak" gdy chcesz wybrać styl (np. "1 Gracz" lub "2 Graczy") przed każdą grą.
+PreferredStyle=Ustaw swój styl, który wybierasz ZAWSZE i chcesz przejść do rozgrywki najszybciej jak to możliwe.\n\nUstaw "Brak" gdy chcesz wybrać styl (np. "1 Gracz" lub "2 Graczy") przed każdą grą.
 DefaultGameMode=Wybierz domyślną pozycję kursora podczas wyboru trybu gry.\n\nPamiętaj, że ekran nie zostaje pominięty, tylko zmienia się opcja startowa.
 AllowFailingOutOfSet=Ustawienie 'Tak' sprawia, że gracze potencjalnie mogą przedwcześnie zakończyć grę porażką.  Ustawienie 'Nie' pozwala graczom na zagranie we wszystkie utwory w grze.\n\nTa opcja nie ma wpływu na tryb imprezy.
 NumberOfContinuesAllowed=Pozwala graczom na łączenie wielu rozgrywek ze sobą po wrzuceniu dodatkowych kredytów. Jeżeli chcesz wyłączyć tę możliwość, ustaw ilość kontynuacji na 0.
@@ -988,7 +989,7 @@ EditorShowBGChangesPlay=Pokaż lub ukryj obrazy w tle (i oskryptowane FGChanges,
 [RecommendedOptionExplanations]
 # Opcje Simply Love
 Recommended=Zalecane
-AutoStyle='Brak' jest jedyną słuszną opcją dla automatów.
+PreferredStyle='Brak' jest jedyną słuszną opcją dla automatów.
 DefaultGameMode='Casual' jest najlepszy dla publicznych automatów.
 AllowFailingOutOfSet=Tu powinno być 'Nie', chyba że jesteś tym wrednym gościem, który chce przepchać ludzi przez gry najszybciej jak to możliwe.
 MusicWheelStyle='IIDX' pozwala na szybszą nawigację po kole.

--- a/Languages/pl.ini
+++ b/Languages/pl.ini
@@ -81,8 +81,9 @@ MarathonDescription=Graj w ustalone z góry zestawy\nutworów bez żadnych\nprze
 
 [ScreenSelectStyle]
 HeaderText=Wybierz Styl
-# None is one of the options for "AutoStyle" within Simply Love Options
+# None is one of the options for "PreferredStyle" within Simply Love Options
 None=Brak
+Auto=Automatyczny
 Single=1 Gracz
 Versus=2 Graczy
 Double=Double
@@ -645,7 +646,7 @@ AllowMultipleHighScoreWithSameName=Wiele Rekordów\nz Tym Samym Imieniem
 ThreeKeyNavigation=Nawigacja\nTrójprzyciskowa
 
 # Opcje Simply Love
-AutoStyle=Preferowany Styl
+PreferredStyle=Preferowany Styl
 DefaultGameMode=Domyślny\nTryb Gry
 AllowFailingOutOfSet=Zezwalaj na\nPorażkę Gry
 NumberOfContinuesAllowed=Ilość Dozwolonych\nKontynuacji
@@ -852,7 +853,7 @@ AxisFix=Włącz tę opcję, gdy podczas używania adaptera USB do podłączenia 
 #'
 
 # Opcje Simply Love
-AutoStyle=Ustaw swój styl, który wybierasz ZAWSZE i chcesz przejść do rozgrywki najszybciej jak to możliwe.\n\nUstaw "Brak" gdy chcesz wybrać styl (np. "1 Gracz" lub "2 Graczy") przed każdą grą.
+PreferredStyle=Ustaw swój styl, który wybierasz ZAWSZE i chcesz przejść do rozgrywki najszybciej jak to możliwe.\n\nUstaw "Brak" gdy chcesz wybrać styl (np. "1 Gracz" lub "2 Graczy") przed każdą grą.
 DefaultGameMode=Wybierz domyślną pozycję kursora podczas wyboru trybu gry.\n\nPamiętaj, że ekran nie zostaje pominięty, tylko zmienia się opcja startowa.
 AllowFailingOutOfSet=Ustawienie 'Tak' sprawia, że gracze potencjalnie mogą przedwcześnie zakończyć grę porażką.  Ustawienie 'Nie' pozwala graczom na zagranie we wszystkie utwory w grze.\n\nTa opcja nie ma wpływu na tryb imprezy.
 NumberOfContinuesAllowed=Pozwala graczom na łączenie wielu rozgrywek ze sobą po wrzuceniu dodatkowych kredytów. Jeżeli chcesz wyłączyć tę możliwość, ustaw ilość kontynuacji na 0.\n\nTa opcja ma tylko wpływ na tryb płatny.
@@ -987,7 +988,7 @@ EditorShowBGChangesPlay=Pokaż lub ukryj obrazy w tle (i oskryptowane FGChanges,
 [RecommendedOptionExplanations]
 # Opcje Simply Love
 Recommended=Zalecane
-AutoStyle='Brak' jest jedyną słuszną opcją dla automatów.
+PreferredStyle='Brak' jest jedyną słuszną opcją dla automatów.
 DefaultGameMode='Casual' jest najlepszy dla publicznych automatów.
 AllowFailingOutOfSet=Tu powinno być 'Nie', chyba że jesteś tym wrednym gościem, który chce przepchać ludzi przez gry najszybciej jak to możliwe.
 MusicWheelStyle='IIDX' pozwala na szybszą nawigację po kole.

--- a/Languages/pt-br.ini
+++ b/Languages/pt-br.ini
@@ -96,6 +96,7 @@ MarathonDescription=Jogue uma maratona de\nmúsicas pré determinadas\nsem inter
 [ScreenSelectStyle]
 HeaderText=Selecionar Estilo
 None=Nenhum
+Auto=Automático
 Single=1 Jogador
 Versus=2 Jogadores
 Double=Duplas
@@ -1177,7 +1178,7 @@ AllowMultipleHighScoreWithSameName=Multiplas Pontuações\ncom mesmo Nome
 ThreeKeyNavigation=Naveção de três botões
 
 # Simply Love Options
-AutoStyle=Estilo Preferido
+PreferredStyle=Estilo Preferido
 DefaultGameMode=Modo de Jogo\nPredeterminado
 AllowFailingOutOfSet=Permitir Falha\nDe Set
 NumberOfContinuesAllowed=Quatidade de\n"Continuar" Permitidos
@@ -1495,7 +1496,7 @@ AllowScreenEvalSummary=Defina isto como 'Não' se você quiser pular a tela Resu
 AllowScreenNameEntry=Defina isto como 'Não' se você quiser pular a tela de Entrada de nome.
 AllowScreenGameOver=Defina isto como 'Não' se você quiser pular a tela de Game Over.
 
-AutoStyle=Deixe isso em "Nenhum" se você quiser escolher um estilo como "1 Jogador" ou "2 Jogadores" para cada novo jogo.
+PreferredStyle=Deixe isso em "Nenhum" se você quiser escolher um estilo como "1 Jogador" ou "2 Jogadores" para cada novo jogo.
 MusicWheelStyle=Defina isso como 'IIDX' se quiser que a seleção de música esconda os outros grupos enquanto você navega em um.
 AllowDanceSolo=Deixe isso como 'Sim' se você quiser ativar o modo Solo.\nIsso só afeta o modo 'Dance'.
 MusicWheelSpeed=Altere a velocidade que a seleção de música irá mover ao selecionar o conteúdo.\n\nUma roda mais rápida é especialmente útil se o temporizador estiver ligado.
@@ -1598,7 +1599,7 @@ Select Profile=Use este perfil ou modifique-o.
 # Simply Love Options
 Recommended=Recomendado
 
-AutoStyle='Nenhum' é a única opção apropriada para máquinas públicas.
+PreferredStyle='Nenhum' é a única opção apropriada para máquinas públicas.
 DefaultGameMode='Casual' é provavelmente a opção mais adequada para uma máquina pública.
 AllowFailingOutOfSet=Isso deve ser "Não", a menos que você seja um cara mau e queira terminar os jogos o mais rápido possível.
 MusicWheelStyle='IIDX' permite uma navegação mais rápida na roda.

--- a/Languages/pt-br.ini
+++ b/Languages/pt-br.ini
@@ -96,6 +96,7 @@ MarathonDescription=Jogue uma maratona de\nmúsicas pré determinadas\nsem inter
 [ScreenSelectStyle]
 HeaderText=Selecionar Estilo
 None=Nenhum
+Auto=Automático
 Single=1 Jogador
 Versus=2 Jogadores
 Double=Duplas
@@ -1168,7 +1169,7 @@ AllowMultipleHighScoreWithSameName=Multiplas Pontuações\ncom mesmo Nome
 ThreeKeyNavigation=Naveção de três botões
 
 # Simply Love Options
-AutoStyle=Estilo Preferido
+PreferredStyle=Estilo Preferido
 DefaultGameMode=Modo de Jogo\nPredeterminado
 AllowFailingOutOfSet=Permitir Falha\nDe Set
 NumberOfContinuesAllowed=Quatidade de\n"Continuar" Permitidos
@@ -1486,7 +1487,7 @@ AllowScreenEvalSummary=Defina isto como 'Não' se você quiser pular a tela Resu
 AllowScreenNameEntry=Defina isto como 'Não' se você quiser pular a tela de Entrada de nome.
 AllowScreenGameOver=Defina isto como 'Não' se você quiser pular a tela de Game Over.
 
-AutoStyle=Deixe isso em "Nenhum" se você quiser escolher um estilo como "1 Jogador" ou "2 Jogadores" para cada novo jogo.
+PreferredStyle=Deixe isso em "Nenhum" se você quiser escolher um estilo como "1 Jogador" ou "2 Jogadores" para cada novo jogo.
 MusicWheelStyle=Defina isso como 'IIDX' se quiser que a seleção de música esconda os outros grupos enquanto você navega em um.
 AllowDanceSolo=Deixe isso como 'Sim' se você quiser ativar o modo Solo.\nIsso só afeta o modo 'Dance'.
 MusicWheelSpeed=Altere a velocidade que a seleção de música irá mover ao selecionar o conteúdo.\n\nUma roda mais rápida é especialmente útil se o temporizador estiver ligado.
@@ -1589,7 +1590,7 @@ Select Profile=Use este perfil ou modifique-o.
 # Simply Love Options
 Recommended=Recomendado
 
-AutoStyle='Nenhum' é a única opção apropriada para máquinas públicas.
+PreferredStyle='Nenhum' é a única opção apropriada para máquinas públicas.
 DefaultGameMode='Casual' é provavelmente a opção mais adequada para uma máquina pública.
 AllowFailingOutOfSet=Isso deve ser "Não", a menos que você seja um cara mau e queira terminar os jogos o mais rápido possível.
 MusicWheelStyle='IIDX' permite uma navegação mais rápida na roda.

--- a/Languages/ru.ini
+++ b/Languages/ru.ini
@@ -84,7 +84,7 @@ MarathonDescription=Играйте определённый плейлист\nп
 
 [ScreenSelectStyle]
 HeaderText=Выберите Режим Игры
-# None is one of the options for "AutoStyle" within Simply Love Options
+# None is one of the options for "PreferredStyle" within Simply Love Options
 None=None
 Single=1 Игрок
 Versus=2 Игрока
@@ -638,7 +638,7 @@ AllowMultipleHighScoreWithSameName=Несколько Рекордов\n от О
 ThreeKeyNavigation=Управление в 3 кнопки
 
 # Simply Love Options
-AutoStyle=Кол-во Человек по Умолчанию
+PreferredStyle=Кол-во Человек по Умолчанию
 DefaultGameMode=Приоритетный\nРежим Игры
 AllowFailingOutOfSet=Возможность\nПроиграть Кредит
 NumberOfContinuesAllowed=Количество разрешённых продолжений
@@ -845,7 +845,7 @@ AxisFix=Включите, если ваш контроллер или платф
 #'
 
 # Simply Love Options
-AutoStyle=Настраивайте, если играете ТОЛЬКО в один и тот же режим и хотите убрать это меню.\n\nПоставьте "None", чтобы каждую новую игру можно было выбрать количество игроков.
+PreferredStyle=Настраивайте, если играете ТОЛЬКО в один и тот же режим и хотите убрать это меню.\n\nПоставьте "None", чтобы каждую новую игру можно было выбрать количество игроков.
 DefaultGameMode=Выберите исходную позицию в меню выбора режима игры.\n\nЭто не убирает это меню.
 AllowFailingOutOfSet=Если "Да", игроки могут проиграть на первой песне и игра закончится быстрее. Если "Нет", игроки всегда смогут отыграть свои песни.\n\nНе влияет на режим ивента.
 NumberOfContinuesAllowed=Даст игрокам продолжить ту же игру, заплатив ещё кредиты. Поставьте 0, чтобы это выключить.
@@ -979,7 +979,7 @@ EditorShowBGChangesPlay=Show or hide background images (and scripted FGChanges, 
 [RecommendedOptionExplanations]
 # Simply Love Options
 Recommended=Рекомендуем
-AutoStyle='None' лучше всего подходит пля публичных автоматов.
+PreferredStyle='None' лучше всего подходит пля публичных автоматов.
 DefaultGameMode=Рекомендуем 'Простой', чтобы не отпугивать новых игроков.
 AllowFailingOutOfSet=Оставьте 'Нет', если хотите, чтобы люди могли проиграть сет. Грубо, но так быстрее.
 MusicWheelStyle='IIDX' быстрее, 'ITG' понятнее.

--- a/Languages/ru.ini
+++ b/Languages/ru.ini
@@ -84,7 +84,7 @@ MarathonDescription=Играйте определённый плейлист\nп
 
 [ScreenSelectStyle]
 HeaderText=Выберите Режим Игры
-# None is one of the options for "AutoStyle" within Simply Love Options
+# None is one of the options for "PreferredStyle" within Simply Love Options
 None=None
 Single=1 Игрок
 Versus=2 Игрока
@@ -637,7 +637,7 @@ AllowMultipleHighScoreWithSameName=Несколько Рекордов\n от О
 ThreeKeyNavigation=Управление в 3 кнопки
 
 # Simply Love Options
-AutoStyle=Кол-во Человек по Умолчанию
+PreferredStyle=Кол-во Человек по Умолчанию
 DefaultGameMode=Приоритетный\nРежим Игры
 AllowFailingOutOfSet=Возможность\nПроиграть Кредит
 NumberOfContinuesAllowed=Количество разрешённых продолжений
@@ -844,7 +844,7 @@ AxisFix=Включите, если ваш контроллер или платф
 #'
 
 # Simply Love Options
-AutoStyle=Настраивайте, если играете ТОЛЬКО в один и тот же режим и хотите убрать это меню.\n\nПоставьте "None", чтобы каждую новую игру можно было выбрать количество игроков.
+PreferredStyle=Настраивайте, если играете ТОЛЬКО в один и тот же режим и хотите убрать это меню.\n\nПоставьте "None", чтобы каждую новую игру можно было выбрать количество игроков.
 DefaultGameMode=Выберите исходную позицию в меню выбора режима игры.\n\nЭто не убирает это меню.
 AllowFailingOutOfSet=Если "Да", игроки могут проиграть на первой песне и игра закончится быстрее. Если "Нет", игроки всегда смогут отыграть свои песни.\n\nНе влияет на режим ивента.
 NumberOfContinuesAllowed=Даст игрокам продолжить ту же игру, заплатив ещё кредиты. Поставьте 0, чтобы это выключить.\n\nТолько для платного режима.
@@ -978,7 +978,7 @@ EditorShowBGChangesPlay=Show or hide background images (and scripted FGChanges, 
 [RecommendedOptionExplanations]
 # Simply Love Options
 Recommended=Рекомендуем
-AutoStyle='None' лучше всего подходит пля публичных автоматов.
+PreferredStyle='None' лучше всего подходит пля публичных автоматов.
 DefaultGameMode=Рекомендуем 'Простой', чтобы не отпугивать новых игроков.
 AllowFailingOutOfSet=Оставьте 'Нет', если хотите, чтобы люди могли проиграть сет. Грубо, но так быстрее.
 MusicWheelStyle='IIDX' быстрее, 'ITG' понятнее.

--- a/Modules/README.md
+++ b/Modules/README.md
@@ -17,7 +17,7 @@ t["ScreenSelectMusic"] = Def.ActorFrame {
     end
 }
 
-t["ScreenGameplay"] = Def.ActorFrame {
+t[Branch.GameplayScreen()] = Def.ActorFrame {
     ModuleCommand=function(self)
         SCREENMAN:SystemMessage("hello from ScreenGameplay")
     end

--- a/Scripts/99 SL-ThemePrefs.lua
+++ b/Scripts/99 SL-ThemePrefs.lua
@@ -76,17 +76,17 @@ SL_CustomPrefs.Get = function()
 			},
 			Values = { "Casual", "ITG" }
 		},
-
-		AutoStyle =
+		PreferredStyle =
 		{
 			Default = "none",
 			Choices = {
 				THEME:GetString("ScreenSelectStyle", "None"),
+				THEME:GetString("ScreenSelectStyle", "Auto"),
 				THEME:GetString("ScreenSelectStyle", "Single"),
 				THEME:GetString("ScreenSelectStyle", "Versus"),
 				THEME:GetString("ScreenSelectStyle", "Double")
 			},
-			Values = { "none", "single", "versus", "double" }
+			Values = { "none", "auto", "single", "versus", "double" }
 		},
 		VisualStyle =
 		{

--- a/Scripts/SL-Branches.lua
+++ b/Scripts/SL-Branches.lua
@@ -217,7 +217,7 @@ Branch.AfterSelectMusic = function()
 		end
 
 		-- while everything else (single, versus, double, etc.) uses ScreenGameplay
-		return "ScreenGameplay"
+		return Branch.GameplayScreen()
 	end
 end
 

--- a/Scripts/SL-Branches.lua
+++ b/Scripts/SL-Branches.lua
@@ -96,10 +96,18 @@ Branch.AllowScreenSelectColor = function()
 end
 
 Branch.AfterScreenSelectColor = function()
-	local preferred_style = ThemePrefs.Get("AutoStyle")
+	
+	if THEME:GetMetric("Common", "AutoSetStyle") == true then
+		local styles = { "single", "versus" }
+		GAMESTATE:SetCurrentStyle( styles[GAMESTATE:GetNumSidesJoined()] )
+		return "ScreenSelectPlayMode"
+	end
+
+	-- ------------------------------------------------------------
+	local preferred_style = ThemePrefs.Get("PreferredStyle")
 
 	if preferred_style ~= "none"
-	-- AutoStyle should not be possible in pay mode
+	-- PreferredStyle should not be possible in pay mode
 	-- it's too confusing for machine operators, novice players, and developers alike
 	and GAMESTATE:GetCoinMode() ~= "CoinMode_Pay" then
 
@@ -108,7 +116,7 @@ Branch.AfterScreenSelectColor = function()
 			GAMESTATE:JoinPlayer(PLAYER_1)
 			GAMESTATE:JoinPlayer(PLAYER_2)
 
-		-- if AutoStyle was "single" but both players are already joined
+		-- if PreferredStyle was "single" but both players are already joined
 		-- (for whatever reason), we're in a bit of a pickle, as there is
 		-- no way to read the player's mind and know which side they really
 		-- want to play on. Unjoin PLAYER_2 for lack of a better solution.

--- a/Scripts/SL-Branches.lua
+++ b/Scripts/SL-Branches.lua
@@ -99,8 +99,11 @@ Branch.AfterScreenSelectColor = function()
 	
 	if THEME:GetMetric("Common", "AutoSetStyle") == true then
 		local styles = { "single", "versus" }
-		GAMESTATE:SetCurrentStyle( styles[GAMESTATE:GetNumSidesJoined()] )
-		return "ScreenSelectPlayMode"
+		-- If for any reason all the screens prior are skipped we may
+		-- end up here without any players joined yet, so default to 
+		-- to single as PLAYER_2 can always join later
+		GAMESTATE:SetCurrentStyle( styles[math.max(GAMESTATE:GetNumSidesJoined(), 1)] )
+		return Branch.AllowScreenSelectPlayMode()
 	end
 
 	-- ------------------------------------------------------------

--- a/Scripts/SL-Branches.lua
+++ b/Scripts/SL-Branches.lua
@@ -95,8 +95,11 @@ Branch.AfterScreenSelectColor = function()
 	
 	if THEME:GetMetric("Common", "AutoSetStyle") == true then
 		local styles = { "single", "versus" }
-		GAMESTATE:SetCurrentStyle( styles[GAMESTATE:GetNumSidesJoined()] )
-		return "ScreenSelectPlayMode"
+		-- If for any reason all the screens prior are skipped we may
+		-- end up here without any players joined yet, so default to 
+		-- to single as PLAYER_2 can always join later
+		GAMESTATE:SetCurrentStyle( styles[math.max(GAMESTATE:GetNumSidesJoined(), 1)] )
+		return Branch.AllowScreenSelectPlayMode()
 	end
 
 	-- ------------------------------------------------------------

--- a/Scripts/SL-Branches.lua
+++ b/Scripts/SL-Branches.lua
@@ -92,10 +92,18 @@ Branch.AllowScreenSelectColor = function()
 end
 
 Branch.AfterScreenSelectColor = function()
-	local preferred_style = ThemePrefs.Get("AutoStyle")
+	
+	if THEME:GetMetric("Common", "AutoSetStyle") == true then
+		local styles = { "single", "versus" }
+		GAMESTATE:SetCurrentStyle( styles[GAMESTATE:GetNumSidesJoined()] )
+		return "ScreenSelectPlayMode"
+	end
+
+	-- ------------------------------------------------------------
+	local preferred_style = ThemePrefs.Get("PreferredStyle")
 
 	if preferred_style ~= "none"
-	-- AutoStyle should not be possible in pay mode
+	-- PreferredStyle should not be possible in pay mode
 	-- it's too confusing for machine operators, novice players, and developers alike
 	and GAMESTATE:GetCoinMode() ~= "CoinMode_Pay" then
 
@@ -104,7 +112,7 @@ Branch.AfterScreenSelectColor = function()
 			GAMESTATE:JoinPlayer(PLAYER_1)
 			GAMESTATE:JoinPlayer(PLAYER_2)
 
-		-- if AutoStyle was "single" but both players are already joined
+		-- if PreferredStyle was "single" but both players are already joined
 		-- (for whatever reason), we're in a bit of a pickle, as there is
 		-- no way to read the player's mind and know which side they really
 		-- want to play on. Unjoin PLAYER_2 for lack of a better solution.

--- a/Scripts/SL-Branches.lua
+++ b/Scripts/SL-Branches.lua
@@ -213,7 +213,7 @@ Branch.AfterSelectMusic = function()
 		end
 
 		-- while everything else (single, versus, double, etc.) uses ScreenGameplay
-		return "ScreenGameplay"
+		return Branch.GameplayScreen()
 	end
 end
 

--- a/Scripts/SL-Helpers.lua
+++ b/Scripts/SL-Helpers.lua
@@ -971,7 +971,8 @@ end
 -- helper function for returning the player AF
 -- Works as expected in ScreenGameplay + Edit + Practice Mode
 --     arguments:  pn is short string PlayerNumber like "P1" or "P2"
---     returns:    the "PlayerP1" or "PlayerP2" ActorFrame
+--     returns:    the "PlayerP1" or "PlayerP2" ActorFrame in ScreenGameplay
+--                 or, the unnamed equivalent in ScrenEdit
 GetPlayerAF = function(pn)
 	local topscreen = SCREENMAN:GetTopScreen()
 	if not topscreen then
@@ -979,11 +980,42 @@ GetPlayerAF = function(pn)
 		return nil
 	end
 
+	local playerAF = nil
+
 	-- Get the player ActorFrame on ScreenGameplay
 	-- It's a direct child of the screen and named "PlayerP1" for P1
 	-- and "PlayerP2" for P2.
 	-- This naming convention is hardcoded in the SM5 engine.
 	--
+	-- ScreenEdit does not name its player ActorFrame, but we can still find it.
+
+	-- find the player ActorFrame in edit mode
+	local notefields = {}
+	if (THEME:GetMetric(topscreen:GetName(), "Class") == "ScreenEdit") then
+		-- loop through all nameless children of topscreen
+		-- and find the one that contains the NoteField
+		-- which is thankfully still named "NoteField"1
+
+		for _,nameless_child in ipairs(topscreen:GetChild("")) do
+			if nameless_child:GetChild("NoteField") then
+				notefields[#notefields+1] = nameless_child
+			end
+		end
+		-- If there is only one side joined always return the first one.
+		if #notefields == 1 then
+			return notefields[1]
+		-- If there are two sides joined, return the one that matches the player number.
+		else
+			return notefields[pn == "P1" and 1 or 2]
+		end
+
+	-- find the player ActorFrame in gameplay
+	else
+		local player_af = topscreen:GetChild("Player"..pn)
+		if player_af then
+			playerAF = player_af
+		end
+	end
 	-- ScreenEdit does not name its player ActorFrame, but does set its alias to
 	-- "PlayerP1" or "PlayerP2". GetChild will return the child if either the
 	-- name or alias matches.

--- a/Scripts/SL-Helpers.lua
+++ b/Scripts/SL-Helpers.lua
@@ -134,7 +134,7 @@ GetNotefieldX = function( player )
 	local PlayerOffset = SL[p].ActiveModifiers.NoteFieldOffsetX * (player == PLAYER_1 and -1 or 1)
 
 	local NumPlayersAndSides = ToEnumShortString( style:GetStyleType() )
-	return THEME:GetMetric("ScreenGameplay","Player".. p .. NumPlayersAndSides .."X") + PlayerOffset
+	return THEME:GetMetric(Branch.GameplayScreen(),"Player".. p .. NumPlayersAndSides .."X") + PlayerOffset
 end
 
 -- -----------------------------------------------------------------------

--- a/Scripts/SL-Helpers.lua
+++ b/Scripts/SL-Helpers.lua
@@ -149,9 +149,8 @@ local NoteFieldWidth = {
 		double  = 512,
 		solo    = 384,
 		routine = 512,
-		-- couple and threepanel not supported in Simply Love at this time D:
-		-- couple = 256,
-		-- threepanel = 192
+		couple = 256,
+		threepanel = 192
 	},
 	-- pump's values are very similar to those used in dance, but curiously smaller
 	pump = {
@@ -159,6 +158,7 @@ local NoteFieldWidth = {
 		versus  = 250,
 		double  = 500,
 		routine = 500,
+		halfdouble = 300
 	},
 	-- These values for techno, para, and kb7 are the result of empirical observation
 	-- of the SM5 engine and should not be regarded as any kind of Truth.

--- a/Scripts/SL-Helpers.lua
+++ b/Scripts/SL-Helpers.lua
@@ -148,8 +148,8 @@ local NoteFieldWidth = {
 		versus  = 256,
 		double  = 512,
 		solo    = 384,
-		routine = 512,
-		couple = 256,
+		couple = 512,
+		routine = 256,
 		threepanel = 192
 	},
 	-- pump's values are very similar to those used in dance, but curiously smaller
@@ -157,7 +157,7 @@ local NoteFieldWidth = {
 		single  = 250,
 		versus  = 250,
 		double  = 500,
-		routine = 500,
+		couple = 500,
 		halfdouble = 300
 	},
 	-- These values for techno, para, and kb7 are the result of empirical observation

--- a/Scripts/SL-OnlineHelpers.lua
+++ b/Scripts/SL-OnlineHelpers.lua
@@ -14,11 +14,12 @@ local startHoldTime = {
 }
 local lastDisconnectCountdown = nil
 -- These screens are the ones we want to display the player's scores for.
-local scoreScreens = {"ScreenGameplay", "ScreenEvaluationStage"}
+local scoreScreens = {"ScreenGameplay", "ScreenGameplayShared", "ScreenEvaluationStage"}
 
 local syncLockScreens = {
 	["ScreenSelectMusic"] = true,
 	["ScreenGameplay"] = true,
+	["ScreenGameplayShared"] = true,
 	["ScreenEvaluationStage"] = true,
 }
 
@@ -48,7 +49,7 @@ local InputHandler = function(event)
 		if event.type == "InputEventType_FirstPress" and event.GameButton == "Start" then
 			startHoldTime[pn] = GetTimeSinceStart()
 			lastDisconnectCountdown = nil
-			if SCREENMAN:GetTopScreen():GetName() == "ScreenGameplay" then
+			if SCREENMAN:GetTopScreen():GetName() == Branch.GameplayScreen() then
 				readyState[pn] = true
 				MESSAGEMAN:Broadcast("UpdateMachineState")
 			end
@@ -66,7 +67,7 @@ local InputHandler = function(event)
 					startHoldTime[pn] = 0
 					lastDisconnectCountdown = nil
 					isWaiting = false
-					if SCREENMAN:GetTopScreen():GetName() == "ScreenGameplay" then
+					if SCREENMAN:GetTopScreen():GetName() == Branch.GameplayScreen() then
 						SCREENMAN:GetTopScreen():PauseGame(false)
 					end
 					MESSAGEMAN:Broadcast("DisconnectOnline")
@@ -138,7 +139,7 @@ local GetMachineState = function()
 			local judgments = nil
 			local score = nil
 			local exScore = nil
-			if screenName == "ScreenGameplay" or screenName == "ScreenEvaluationStage" then
+			if screenName == Branch.GameplayScreen() or screenName == "ScreenEvaluationStage" then
 				judgments = GetJudgmentCounts(player)
 				local dance_points = STATSMAN:GetCurStageStats():GetPlayerStageStats(player):GetPercentDancePoints()
 				local percent = FormatPercentScore( dance_points ):gsub("%%", "")
@@ -202,7 +203,7 @@ local OrderPlayers = function(data, localScreenName)
 			updatedData.aux.allInSameScreen = false
 		end
 
-		if player.screenName == "ScreenGameplay" then
+		if player.screenName == Branch.GameplayScreen() then
 			updatedData.aux.anyInGameplay = true
 		end
 
@@ -241,7 +242,7 @@ local OrderPlayers = function(data, localScreenName)
 			updatedData.aux.allInSameScreen = false
 		end
 
-		if player.screenName == "ScreenGameplay" then
+		if player.screenName == Branch.GameplayScreen() then
 			updatedData.aux.anyInGameplay = true
 		end
 
@@ -277,7 +278,7 @@ local DisplayLobbyState = function(data, actor)
 
 	if isWaiting then
 		local readyToUnlock = false
-		if screenName == "ScreenGameplay" then
+		if screenName == Branch.GameplayScreen() then
 			-- Gameplay requires everyone to be in gameplay and manually ready-up.
 			readyToUnlock = updatedData.aux.allInSameScreen and updatedData.aux.allPlayersReady
 		elseif screenName == "ScreenEvaluationStage" then
@@ -318,12 +319,12 @@ local DisplayLobbyState = function(data, actor)
 				SCREENMAN:set_input_redirected(player, false)
 			end
 
-			if screenName == "ScreenGameplay" then
+			if screenName == Branch.GameplayScreen() then
 				SCREENMAN:GetTopScreen():PauseGame(false)
 			end
 		else
 			lines[#lines+1] = "Waiting for players to sync screens...\n"
-			if screenName == "ScreenGameplay" then
+			if screenName == Branch.GameplayScreen() then
 				lines[#lines+1] = "Press &START; to ready up!\n"
 			end
 		end
@@ -331,7 +332,7 @@ local DisplayLobbyState = function(data, actor)
 	for i, player in ipairs(updatedData.players) do
 		local displayedScreen = player.screenName ~= "NoScreen" and player.screenName:gsub("Screen", "") or "Transitioning"
 		local readyText = ""
-		if screenName == "ScreenGameplay" and not updatedData.aux.allPlayersReady then
+		if screenName == Branch.GameplayScreen() and not updatedData.aux.allPlayersReady then
 			readyText =" ["..(player.ready and "✔" or "❌").."]"
 		end
 
@@ -537,7 +538,7 @@ CreateOnlineHandler = function()
 			end
 		end
 
-          if screenName == "ScreenGameplay" then
+          if screenName == Branch.GameplayScreen() then
 			for player in ivalues(GAMESTATE:GetEnabledPlayers()) do
 				local pn = ToEnumShortString(player)
 				readyState[pn] = false
@@ -670,7 +671,7 @@ CreateOnlineHandler = function()
           if screenName == "ScreenSelectMusic" then
             self:xy(LEFT, _screen.cy)
             bg:zoomto(width, height)
-          elseif screenName == "ScreenEvaluationStage" or screenName == "ScreenGameplay" then
+          elseif screenName == "ScreenEvaluationStage" or screenName == Branch.GameplayScreen() then
             local p1Joined = GAMESTATE:IsSideJoined("PlayerNumber_P1")
             local p2Joined = GAMESTATE:IsSideJoined("PlayerNumber_P2")
 

--- a/Scripts/SL-OnlineHelpers.lua
+++ b/Scripts/SL-OnlineHelpers.lua
@@ -14,11 +14,12 @@ local startHoldTime = {
 }
 local lastDisconnectCountdown = nil
 -- These screens are the ones we want to display the player's scores for.
-local scoreScreens = {"ScreenGameplay", "ScreenEvaluationStage"}
+local scoreScreens = {"ScreenGameplay", "ScreenGameplayShared", "ScreenEvaluationStage"}
 
 local syncLockScreens = {
   ["ScreenSelectMusic"] = true,
   ["ScreenGameplay"] = true,
+  ["ScreenGameplayShared"] = true,
   ["ScreenEvaluationStage"] = true,
 }
 
@@ -62,7 +63,7 @@ local InputHandler = function(event)
     if event.type == "InputEventType_FirstPress" and event.GameButton == "Start" then
       startHoldTime[pn] = GetTimeSinceStart()
       lastDisconnectCountdown = nil
-      if SCREENMAN:GetTopScreen():GetName() == "ScreenGameplay" then
+      if SCREENMAN:GetTopScreen():GetName() == Branch.GameplayScreen() then
         readyState[pn] = true
         MESSAGEMAN:Broadcast("UpdateMachineState")
       end
@@ -80,7 +81,7 @@ local InputHandler = function(event)
           startHoldTime[pn] = 0
           lastDisconnectCountdown = nil
           isWaiting = false
-          if SCREENMAN:GetTopScreen():GetName() == "ScreenGameplay" then
+          if SCREENMAN:GetTopScreen():GetName() == Branch.GameplayScreen() then
             SCREENMAN:GetTopScreen():PauseGame(false)
           end
           MESSAGEMAN:Broadcast("DisconnectOnline")
@@ -152,7 +153,7 @@ local GetMachineState = function()
       local judgments = nil
       local score = nil
       local exScore = nil
-      if screenName == "ScreenGameplay" or screenName == "ScreenEvaluationStage" then
+      if screenName == Branch.GameplayScreen() or screenName == "ScreenEvaluationStage" then
         judgments = GetJudgmentCounts(player)
         local dance_points = STATSMAN:GetCurStageStats():GetPlayerStageStats(player):GetPercentDancePoints()
         local percent = FormatPercentScore( dance_points ):gsub("%%", "")
@@ -216,7 +217,7 @@ local OrderPlayers = function(data, localScreenName)
       updatedData.aux.allInSameScreen = false
     end
 
-    if player.screenName == "ScreenGameplay" then
+    if player.screenName == Branch.GameplayScreen() then
       updatedData.aux.anyInGameplay = true
     end
 
@@ -255,7 +256,7 @@ local OrderPlayers = function(data, localScreenName)
       updatedData.aux.allInSameScreen = false
     end
 
-    if player.screenName == "ScreenGameplay" then
+    if player.screenName == Branch.GameplayScreen() then
       updatedData.aux.anyInGameplay = true
     end
 
@@ -291,7 +292,7 @@ local DisplayLobbyState = function(data, actor)
 
   if isWaiting then
     local readyToUnlock = false
-    if screenName == "ScreenGameplay" then
+    if screenName == Branch.GameplayScreen() then
       -- Gameplay requires everyone to be in gameplay and manually ready-up.
       readyToUnlock = updatedData.aux.allInSameScreen and updatedData.aux.allPlayersReady
     elseif screenName == "ScreenEvaluationStage" then
@@ -332,12 +333,12 @@ local DisplayLobbyState = function(data, actor)
         SCREENMAN:set_input_redirected(player, false)
       end
 
-      if screenName == "ScreenGameplay" then
+      if screenName == Branch.GameplayScreen() then
         SCREENMAN:GetTopScreen():PauseGame(false)
       end
     else
       lines[#lines+1] = "Waiting for players to sync screens...\n"
-      if screenName == "ScreenGameplay" then
+      if screenName == Branch.GameplayScreen() then
         lines[#lines+1] = "Press &START; to ready up!\n"
       end
     end
@@ -345,7 +346,7 @@ local DisplayLobbyState = function(data, actor)
   for i, player in ipairs(updatedData.players) do
     local displayedScreen = player.screenName ~= "NoScreen" and player.screenName:gsub("Screen", "") or "Transitioning"
     local readyText = ""
-    if screenName == "ScreenGameplay" and not updatedData.aux.allPlayersReady then
+    if screenName == Branch.GameplayScreen() and not updatedData.aux.allPlayersReady then
       readyText =" ["..(player.ready and "✔" or "❌").."]"
     end
 
@@ -572,7 +573,7 @@ CreateOnlineHandler = function()
             end
           end
 
-          if screenName == "ScreenGameplay" then
+          if screenName == Branch.GameplayScreen() then
             for player in ivalues(GAMESTATE:GetEnabledPlayers()) do
               local pn = ToEnumShortString(player)
               readyState[pn] = false
@@ -704,7 +705,7 @@ CreateOnlineHandler = function()
           if screenName == "ScreenSelectMusic" then
             self:xy(LEFT, _screen.cy)
             bg:zoomto(width, height)
-          elseif screenName == "ScreenEvaluationStage" or screenName == "ScreenGameplay" then
+          elseif screenName == "ScreenEvaluationStage" or screenName == Branch.GameplayScreen() then
             local p1Joined = GAMESTATE:IsSideJoined("PlayerNumber_P1")
             local p2Joined = GAMESTATE:IsSideJoined("PlayerNumber_P2")
 

--- a/Scripts/SL-PlayerOptions.lua
+++ b/Scripts/SL-PlayerOptions.lua
@@ -360,11 +360,13 @@ local Overrides = {
 				local song = GAMESTATE:GetCurrentSong()
 				if song then
 					for steps in ivalues( SongUtil.GetPlayableSteps(song) ) do
+						local choice
 						if steps:IsAnEdit() then
-							choices[#choices+1] = ("%s %i"):format(steps:GetDescription(), steps:GetMeter())
+							choice = ("%s\n%s %i"):format(steps:GetStepsType():gsub("%w+_%w+_", ""):lower(), steps:GetDescription(), steps:GetMeter())
 						else
-							choices[#choices+1] = ("%s %i"):format(THEME:GetString("Difficulty", ToEnumShortString(steps:GetDifficulty())), steps:GetMeter())
+							choice = ("%s\n%s %i"):format(steps:GetStepsType():gsub("%w+_%w+_", ""):lower(), THEME:GetString("Difficulty", ToEnumShortString(steps:GetDifficulty())), steps:GetMeter())
 						end
+						table.insert(choices, choice)
 					end
 				end
 			else
@@ -894,6 +896,18 @@ local OptionRowDefault = {
 			self.LayoutType = Overrides[name].LayoutType or "ShowAllInRow"
 			self.SelectType = Overrides[name].SelectType or "SelectOne"
 			self.OneChoiceForAllPlayers = Overrides[name].OneChoiceForAllPlayers or false
+			if GAMESTATE:GetCurrentStyle() ~= nil and GAMESTATE:GetCurrentStyle():GetStyleType() == "StyleType_TwoPlayersSharedSides" then
+				local list = {
+					"NoteSkin",
+					"NoteSkinVariant",
+					"JudgmentGraphic",
+					"ComboFont",
+					"HoldJudgment",
+				}
+				if not FindInTable(name, list) then
+					self.OneChoiceForAllPlayers = true
+				end
+			end
 			self.ExportOnChange = Overrides[name].ExportOnChange or false
 			self.EnabledForPlayers = Overrides[name].EnabledForPlayers or function() return {PLAYER_1, PLAYER_2} end
 			self.ReloadRowMessages = Overrides[name].ReloadRowMessages or {}

--- a/Scripts/SL-PlayerOptions.lua
+++ b/Scripts/SL-PlayerOptions.lua
@@ -896,7 +896,7 @@ local OptionRowDefault = {
 			self.LayoutType = Overrides[name].LayoutType or "ShowAllInRow"
 			self.SelectType = Overrides[name].SelectType or "SelectOne"
 			self.OneChoiceForAllPlayers = Overrides[name].OneChoiceForAllPlayers or false
-			if GAMESTATE:GetCurrentStyle() ~= nil and GAMESTATE:GetCurrentStyle():GetStyleType() == "StyleType_TwoPlayersSharedSides" then
+			if IsRoutine() then
 				local list = {
 					"NoteSkin",
 					"NoteSkinVariant",

--- a/Scripts/SL-PlayerOptions.lua
+++ b/Scripts/SL-PlayerOptions.lua
@@ -359,11 +359,13 @@ local Overrides = {
 				local song = GAMESTATE:GetCurrentSong()
 				if song then
 					for steps in ivalues( SongUtil.GetPlayableSteps(song) ) do
+						local choice
 						if steps:IsAnEdit() then
-							choices[#choices+1] = ("%s %i"):format(steps:GetDescription(), steps:GetMeter())
+							choice = ("%s\n%s %i"):format(steps:GetStepsType():gsub("%w+_%w+_", ""):lower(), steps:GetDescription(), steps:GetMeter())
 						else
-							choices[#choices+1] = ("%s %i"):format(THEME:GetString("Difficulty", ToEnumShortString(steps:GetDifficulty())), steps:GetMeter())
+							choice = ("%s\n%s %i"):format(steps:GetStepsType():gsub("%w+_%w+_", ""):lower(), THEME:GetString("Difficulty", ToEnumShortString(steps:GetDifficulty())), steps:GetMeter())
 						end
+						table.insert(choices, choice)
 					end
 				end
 			else
@@ -902,6 +904,18 @@ local OptionRowDefault = {
 			self.LayoutType = Overrides[name].LayoutType or "ShowAllInRow"
 			self.SelectType = Overrides[name].SelectType or "SelectOne"
 			self.OneChoiceForAllPlayers = Overrides[name].OneChoiceForAllPlayers or false
+			if GAMESTATE:GetCurrentStyle() ~= nil and GAMESTATE:GetCurrentStyle():GetStyleType() == "StyleType_TwoPlayersSharedSides" then
+				local list = {
+					"NoteSkin",
+					"NoteSkinVariant",
+					"JudgmentGraphic",
+					"ComboFont",
+					"HoldJudgment",
+				}
+				if not FindInTable(name, list) then
+					self.OneChoiceForAllPlayers = true
+				end
+			end
 			self.ExportOnChange = Overrides[name].ExportOnChange or false
 			self.EnabledForPlayers = Overrides[name].EnabledForPlayers or function() return {PLAYER_1, PLAYER_2} end
 			self.ReloadRowMessages = Overrides[name].ReloadRowMessages or {}

--- a/Scripts/SL-PlayerOptions.lua
+++ b/Scripts/SL-PlayerOptions.lua
@@ -904,7 +904,7 @@ local OptionRowDefault = {
 			self.LayoutType = Overrides[name].LayoutType or "ShowAllInRow"
 			self.SelectType = Overrides[name].SelectType or "SelectOne"
 			self.OneChoiceForAllPlayers = Overrides[name].OneChoiceForAllPlayers or false
-			if IsRoutine() then
+			if IsCouples() then
 				local list = {
 					"NoteSkin",
 					"NoteSkinVariant",

--- a/Scripts/SL-PlayerOptions.lua
+++ b/Scripts/SL-PlayerOptions.lua
@@ -904,7 +904,7 @@ local OptionRowDefault = {
 			self.LayoutType = Overrides[name].LayoutType or "ShowAllInRow"
 			self.SelectType = Overrides[name].SelectType or "SelectOne"
 			self.OneChoiceForAllPlayers = Overrides[name].OneChoiceForAllPlayers or false
-			if GAMESTATE:GetCurrentStyle() ~= nil and GAMESTATE:GetCurrentStyle():GetStyleType() == "StyleType_TwoPlayersSharedSides" then
+			if IsRoutine() then
 				local list = {
 					"NoteSkin",
 					"NoteSkinVariant",

--- a/Scripts/SL_Init.lua
+++ b/Scripts/SL_Init.lua
@@ -137,9 +137,9 @@ local GlobalDefaults = {
 			}
 			self.ScreenAfter = {
 				PlayAgain = "ScreenEvaluationSummary",
-				PlayerOptions  = "ScreenGameplay",
-				PlayerOptions2 = "ScreenGameplay",
-				PlayerOptions3 = "ScreenGameplay",
+				PlayerOptions  = Branch.GameplayScreen(),
+				PlayerOptions2 = Branch.GameplayScreen(),
+				PlayerOptions3 = Branch.GameplayScreen(),
 			}
 			self.ContinuesRemaining = ThemePrefs.Get("NumberOfContinuesAllowed") or 0
 			self.GameMode = ThemePrefs.Get("DefaultGameMode") or "ITG"

--- a/Scripts/SL_Init.lua
+++ b/Scripts/SL_Init.lua
@@ -131,9 +131,9 @@ local GlobalDefaults = {
 			}
 			self.ScreenAfter = {
 				PlayAgain = "ScreenEvaluationSummary",
-				PlayerOptions  = "ScreenGameplay",
-				PlayerOptions2 = "ScreenGameplay",
-				PlayerOptions3 = "ScreenGameplay",
+				PlayerOptions  = Branch.GameplayScreen(),
+				PlayerOptions2 = Branch.GameplayScreen(),
+				PlayerOptions3 = Branch.GameplayScreen(),
 			}
 			self.ContinuesRemaining = ThemePrefs.Get("NumberOfContinuesAllowed") or 0
 			self.GameMode = ThemePrefs.Get("DefaultGameMode") or "ITG"

--- a/metrics.ini
+++ b/metrics.ini
@@ -1610,7 +1610,7 @@ BannerFadeFromCachedCommand=stoptweening;accelerate,0.1;diffusealpha,0
 
 [ScreenSelectMusicCasual]
 Fallback="ScreenWithMenuElements"
-NextScreen="ScreenGameplay"
+NextScreen=Branch.GameplayScreen()
 
 HeaderOnCommand=visible,false
 ShowCreditDisplay=false

--- a/metrics.ini
+++ b/metrics.ini
@@ -433,7 +433,7 @@ ItemsLongRowP2X=WideScale(_screen.cx+100,_screen.cx+100)
 # pixels between each item when the OptionRow's layout is ShowAllInOneRow
 ItemsGapX=14
 
-ItemOnCommand=zoom,0.75; diffusealpha,1
+ItemOnCommand=zoom,0.75;diffusealpha,1;vertspacing,-10
 ItemGainFocusCommand=
 ItemLoseFocusCommand=
 
@@ -1166,13 +1166,13 @@ LineNames=(function() \
 	local lines = "VisualStyle" \
 	if ThemePrefs.Get("VisualStyle") == "SRPG10" then lines = lines .. ",AllowThemeVideos" end \
 	if ThemePrefs.Get("VisualStyle") ~= "SRPG10" then lines = lines .. ",RainbowMode" end \
-	lines = lines.. ",,MusicWheelSpeed,,MusicWheelStyle,AutoStyle,DefaultGameMode,AllowFailingOutOfSet,NumberOfContinuesAllowed,CasualMaxMeter,SelectProfile,SelectColor,SelectPlayMode,SelectPlayMode2,EvalSummary,NameEntry,GameOver,HideStockNoteSksins,DanceSolo,Nice,WriteCustomScores,KeyboardFeatures,SampleMusicLoops,SampleMusicStartsImmediately,RescoreEarlyHits,AnimateBanners" \
+	lines = lines.. ",,MusicWheelSpeed,,MusicWheelStyle,PreferredStyle,DefaultGameMode,AllowFailingOutOfSet,NumberOfContinuesAllowed,CasualMaxMeter,SelectProfile,SelectColor,SelectPlayMode,SelectPlayMode2,EvalSummary,NameEntry,GameOver,HideStockNoteSksins,DanceSolo,Nice,WriteCustomScores,KeyboardFeatures,SampleMusicLoops,SampleMusicStartsImmediately,RescoreEarlyHits,AnimateBanners" \
 	if Sprite.LoadFromCached ~= nil then lines = lines .. ",UseImageCache" end \
 	return lines \
 end)()
 LineCasualMaxMeter="lua,ThemePrefsRows.GetRow('CasualMaxMeter')"
 
-LineAutoStyle="lua,ThemePrefsRows.GetRow('AutoStyle')"
+LinePreferredStyle="lua,ThemePrefsRows.GetRow('PreferredStyle')"
 LineDefaultGameMode="lua,ThemePrefsRows.GetRow('DefaultGameMode')"
 
 LineAllowFailingOutOfSet="lua,ThemePrefsRows.GetRow('AllowFailingOutOfSet')"

--- a/metrics.ini
+++ b/metrics.ini
@@ -2,6 +2,7 @@
 InitialScreen="ScreenInit"
 ImageCache=ThemePrefs.Get("UseImageCache") and "Banner,Background,Jacket" or "Banner"
 DefaultNoteSkinName="cel"
+AutoSetStyle=ThemePrefs.Get("PreferredStyle")=="auto"
 
 [ScreenInit]
 AllowStartToSkip=false

--- a/metrics.ini
+++ b/metrics.ini
@@ -433,7 +433,7 @@ ItemsLongRowP2X=WideScale(_screen.cx+100,_screen.cx+100)
 # pixels between each item when the OptionRow's layout is ShowAllInOneRow
 ItemsGapX=14
 
-ItemOnCommand=zoom,0.75; diffusealpha,1
+ItemOnCommand=zoom,0.75;diffusealpha,1;vertspacing,-10
 ItemGainFocusCommand=
 ItemLoseFocusCommand=
 
@@ -1164,13 +1164,13 @@ LineNames=(function() \
 	local lines = "VisualStyle" \
 	if ThemePrefs.Get("VisualStyle") == "SRPG9" then lines = lines .. ",AllowThemeVideos" end \
 	if ThemePrefs.Get("VisualStyle") ~= "SRPG9" then lines = lines .. ",RainbowMode" end \
-	lines = lines.. ",,MusicWheelSpeed,,MusicWheelStyle,AutoStyle,DefaultGameMode,AllowFailingOutOfSet,NumberOfContinuesAllowed,CasualMaxMeter,SelectProfile,SelectColor,SelectPlayMode,SelectPlayMode2,EvalSummary,NameEntry,GameOver,HideStockNoteSksins,DanceSolo,Nice,WriteCustomScores,KeyboardFeatures,SampleMusicLoops,RescoreEarlyHits,AnimateBanners" \
+	lines = lines.. ",,MusicWheelSpeed,,MusicWheelStyle,PreferredStyle,DefaultGameMode,AllowFailingOutOfSet,NumberOfContinuesAllowed,CasualMaxMeter,SelectProfile,SelectColor,SelectPlayMode,SelectPlayMode2,EvalSummary,NameEntry,GameOver,HideStockNoteSksins,DanceSolo,Nice,WriteCustomScores,KeyboardFeatures,SampleMusicLoops,RescoreEarlyHits,AnimateBanners" \
 	if Sprite.LoadFromCached ~= nil then lines = lines .. ",UseImageCache" end \
 	return lines \
 end)()
 LineCasualMaxMeter="lua,ThemePrefsRows.GetRow('CasualMaxMeter')"
 
-LineAutoStyle="lua,ThemePrefsRows.GetRow('AutoStyle')"
+LinePreferredStyle="lua,ThemePrefsRows.GetRow('PreferredStyle')"
 LineDefaultGameMode="lua,ThemePrefsRows.GetRow('DefaultGameMode')"
 
 LineAllowFailingOutOfSet="lua,ThemePrefsRows.GetRow('AllowFailingOutOfSet')"

--- a/metrics.ini
+++ b/metrics.ini
@@ -1979,7 +1979,7 @@ SelectionBeatUnfinishedFormat=" ...\n"
 SelectionBeatEndFormat="-%.3f\n"
 DifficultyFormat="%s:  %s\n\n"
 
-RoutinePlayerFormat="%s: %d\n"
+CouplesPlayerFormat="%s: %d\n"
 DescriptionFormat="%s:  %s\n"
 ChartNameFormat="%s:\n  %s\n"
 StepAuthorFormat="%s:\n  %s\n"

--- a/metrics.ini
+++ b/metrics.ini
@@ -1606,7 +1606,7 @@ BannerFadeFromCachedCommand=stoptweening;accelerate,0.1;diffusealpha,0
 
 [ScreenSelectMusicCasual]
 Fallback="ScreenWithMenuElements"
-NextScreen="ScreenGameplay"
+NextScreen=Branch.GameplayScreen()
 
 HeaderOnCommand=visible,false
 ShowCreditDisplay=false


### PR DESCRIPTION
This PR adds initial support and handling for Routine mode in both dance and pump modes. It also includes several fixes for AutoSetStyle and pump that are related. These changes only affect when you're in couples mode or if you have AutoSetStyle enabled.

### Evaluation
ScreenEvaluation will now show the "Team" score and the per player score when you're playing a couples chart. You get the full breakdown for each player. The Arrows Pane will show your stats per player across the whole pad. 

<img width="1923" height="1093" alt="image" src="https://github.com/user-attachments/assets/b26cbf32-030d-4775-a897-56adbd462314" />

<img width="1929" height="1086" alt="image" src="https://github.com/user-attachments/assets/0beabdc0-6355-4f50-b3ac-50c744270ae4" />

### Judging

Each player will receive judgements color coded (P1 is Blue, and P2 is Red). This also applies to their combos.

<img width="1920" height="1108" alt="image" src="https://github.com/user-attachments/assets/5ca6643a-cc55-4d12-aee2-f9a569876b4e" />

Enabling AutoSetStyle (or setting your PreferredStyle to auto) would break the difficulty selector if you had a chart with > 5 total charts from multiple playable modes. For example a chart with 5 singles charts and 5 doubles charts would not visibly scroll reliably and would jump through. 

^ This is a major issue for pump as many pump charts come with a ton of difficulties making it extremely difficult to scroll through. (Viewable by just trying out any of the pump official charts) Playing with AutoSetStyle is "standard" behavior in pump environments, especially given the existence of couples. I included the tabbed layout when this is enabled specifically so that these are visible as it was not a nice user experience when you're playing charts that have > 5 charts across all styles. Most of these AutoSetStyle changes including the tabbed layout come from quietly. Noting the PRs since they have relevant details in them:

https://github.com/CrashCringle12/Simply-Love-SM5/pull/13
https://github.com/CrashCringle12/Simply-Love-SM5/pull/11
https://github.com/CrashCringle12/Simply-Love-SM5/pull/10
https://github.com/CrashCringle12/Simply-Love-SM5/pull/12
https://github.com/CrashCringle12/Simply-Love-SM5/pull/15

When AutoSetStyle is enabled there was no way of knowing what style a chart was as it only displayed the number. This was a notable issue in PlayerOptions so there's helper text to display what the style is both in the wheel and in player options.

Adjusted PlayerOptions so that most options that aren't in the below highlighted box are OneChoiceForAllPlayers:

<img width="1914" height="1087" alt="image" src="https://github.com/user-attachments/assets/a4e95fbe-5d7a-41ae-8a15-57553768d85f" />

### Enabling
Uncommenting these lines will make couples and such visible. Currently is not selectable: https://github.com/CrashCringle12/Simply-Love-SM5/commit/da269770ae3166024d65576de42012dd7d81513f, There's improvements to be made, but this makes the mode usable and fixes existing issues w/ autosetstyle.


Requires: 
https://github.com/itgmania/itgmania/pull/1216

