### PR TITLE
Gray out boxes when choosing a lobby

### DIFF
--- a/BGAnimations/ScreenOnlineLobbies overlay/default.lua
+++ b/BGAnimations/ScreenOnlineLobbies overlay/default.lua
@@ -828,7 +828,6 @@ local af = Def.ActorFrame{
 				self:x(180)
 				self.idx = idx - 1
 			end,
-
 			Def.Quad{
 				InitCommand=function(self)
 					self:zoomto(200, 40):diffuse(Color.White)
@@ -855,7 +854,23 @@ local af = Def.ActorFrame{
 				HoverCommand=function(self)
 					self:diffuse(active_index == self:GetParent().idx and GetHexColor(SL.Global.ActiveColorIndex) or Color.White)
 				end
-			}
+			},
+			Def.Quad{
+				InitCommand=function(self)
+					self:zoomto(200, 40):diffuse(color("#424242")):diffusealpha(0)
+				end,
+				SelectedCommand=function(self)
+					if active_index ~= self:GetParent().idx then
+						-- Gray out the button if it's not selected, since it won't do anything.
+						self:diffusealpha(0.70)
+					else
+						self:diffusealpha(0)
+					end
+				end,
+				LoseFocusCommand=function(self)
+					self:diffusealpha(0)
+				end
+			},
 		},
 
 		Def.ActorFrame{
@@ -896,7 +911,23 @@ local af = Def.ActorFrame{
 				HoverCommand=function(self)
 					self:diffuse(active_index == self:GetParent().idx and GetHexColor(SL.Global.ActiveColorIndex) or Color.White)
 				end
-			}
+			},
+			Def.Quad{
+				InitCommand=function(self)
+					self:zoomto(200, 40):diffuse(color("#424242")):diffusealpha(0)
+				end,
+				SelectedCommand=function(self)
+					if active_index ~= self:GetParent().idx then
+						-- Gray out the button if it's not selected, since it won't do anything.
+						self:diffusealpha(0.70)
+					else
+						self:diffusealpha(0)
+					end
+				end,
+				LoseFocusCommand=function(self)
+					self:diffusealpha(0)
+				end
+			},
 		},
 
 		Def.ActorFrame{
@@ -937,7 +968,23 @@ local af = Def.ActorFrame{
 				HoverCommand=function(self)
 					self:diffuse(active_index == self:GetParent().idx and GetHexColor(SL.Global.ActiveColorIndex) or Color.White)
 				end
-			}
+			},
+			Def.Quad{
+				InitCommand=function(self)
+					self:zoomto(200, 40):diffuse(color("#424242")):diffusealpha(0)
+				end,
+				SelectedCommand=function(self)
+					if active_index ~= self:GetParent().idx then
+						-- Gray out the button if it's not selected, since it won't do anything.
+						self:diffusealpha(0.70)
+					else
+						self:diffusealpha(0)
+					end
+				end,
+				LoseFocusCommand=function(self)
+					self:diffusealpha(0)
+				end
+			},
 		},
 	},
 


### PR DESCRIPTION
It's not suuuper clear input is locked to the lobby selection submenu so this grays out the other buttons when they're not in use:

<img width="1267" height="750" alt="image" src="https://github.com/user-attachments/assets/45dcbfc1-1863-46c5-aee7-05ad8e2bb505" />
