### PR TITLE
Handle the now mismatch in size of Choice vs Values for TimingWindows

### DIFF
--- a/Scripts/SL-PlayerOptions.lua
+++ b/Scripts/SL-PlayerOptions.lua
@@ -699,19 +699,20 @@ local Overrides = {
 			for w in ivalues(disabledWindows) do
 				windows[tonumber(ToEnumShortString(w):sub(-1))] = false
 			end
-
 			-- Compare them to any of our available selections
 			local matched = false
 			for i=1,#list do
 				local all_match = true
-				for w,window in ipairs(windows) do
-					if window ~= self.Values[i][w] then all_match = false; break end
-				end
-				if all_match then
-					matched = true
-					list[i] = true
-					mods.TimingWindows = windows
-					break
+				if self.Values[i] then
+					for w,window in ipairs(windows) do
+						if window ~= self.Values[i][w] then all_match = false; break end
+					end		
+					if all_match then
+						matched = true
+						list[i] = true
+						mods.TimingWindows = windows
+						break
+					end
 				end
 			end
 


### PR DESCRIPTION
Handle the now mismatch in size of Choice vs Values for TimingWindows option

Since there's functionally now only 2 possibilities the OptRow expects choices to also only have 2 options.
Choices (The component on the TimingWindows OptRow) is currently still building all 4 options some of which are now deprecated so probs worth removing that logic entirely at some point (or i can snag that on this)


Folks who had disabled timing windows that weren't the combo that Casual Mode uses would be greeted w/ an error since that wasn't a valid choice. All this does is just ensure invalid choices default to all timing windows being enabled by adding a null check.