### PR TITLE
OnlineLobbies: A few OnlineLobbies Fixes

### DIFF
--- a/Scripts/SL-OnlineHelpers.lua
+++ b/Scripts/SL-OnlineHelpers.lua
@@ -147,6 +147,8 @@ local OrderPlayers = function(data, localScreenName)
 		aux = {
 			-- Used to give input back to the players if we're waiting.
 			allInSameScreen = true,
+			-- Evaluation should stay locked only while any player is still in gameplay.
+			anyInGameplay = false,
 			-- Used to determine when to display the Ready/Not Ready state for players.
 			allPlayersReady = true,
 		}
@@ -166,6 +168,10 @@ local OrderPlayers = function(data, localScreenName)
 
 		if player.screenName ~= firstScreen then
 			updatedData.aux.allInSameScreen = false
+		end
+
+		if player.screenName == "ScreenGameplay" then
+			updatedData.aux.anyInGameplay = true
 		end
 
 		if not player.ready then
@@ -203,6 +209,10 @@ local OrderPlayers = function(data, localScreenName)
 			updatedData.aux.allInSameScreen = false
 		end
 
+		if player.screenName == "ScreenGameplay" then
+			updatedData.aux.anyInGameplay = true
+		end
+
 		if not player.ready then
 			updatedData.aux.allPlayersReady = false
 		end
@@ -238,8 +248,11 @@ local DisplayLobbyState = function(data, actor)
 		if screenName == "ScreenGameplay" then
 			-- Gameplay requires everyone to be in gameplay and manually ready-up.
 			readyToUnlock = updatedData.aux.allInSameScreen and updatedData.aux.allPlayersReady
+		elseif screenName == "ScreenEvaluationStage" then
+			-- Evaluation should only be blocked while someone is still playing.
+			readyToUnlock = not updatedData.aux.anyInGameplay
 		elseif autoReadyScreens[screenName] then
-			-- Select Music and Evaluation only require everyone to arrive at the same screen.
+			-- Other auto-ready screens require everyone to arrive at the same screen.
 			readyToUnlock = updatedData.aux.allInSameScreen
 		else
 			readyToUnlock = updatedData.aux.allPlayersReady

--- a/Scripts/SL-OnlineHelpers.lua
+++ b/Scripts/SL-OnlineHelpers.lua
@@ -139,7 +139,7 @@ local GetMachineState = function()
 	}
 end
 
-local OrderPlayers = function(data)
+local OrderPlayers = function(data, localScreenName)
 	local updatedData = {
 		players = {},
 
@@ -155,7 +155,9 @@ local OrderPlayers = function(data)
 	--  Copy over the song info, if any.
 	updatedData.songInfo = data.songInfo
 
-	local firstScreen = nil
+	-- Use the current screen as the baseline to prevent
+	-- incorrectly reporting all players as synchronized.
+	local firstScreen = localScreenName
 	-- Process the scoreScreens first so we can sort the players by score.
 	for player in ivalues(data.players) do
 		if firstScreen == nil then
@@ -227,7 +229,7 @@ local DisplayLobbyState = function(data, actor)
 	local screen = SCREENMAN:GetTopScreen()
 	local screenName = screen and screen:GetName() or "NoScreen"
 
-	local updatedData = OrderPlayers(data)
+	local updatedData = OrderPlayers(data, screenName)
 
 	local lines = {}
 


### PR DESCRIPTION
- Prevent soft lock when 1 player is on EvaluationScreen and other is in SelectMusic
- fix case where sometimes a player would start a song and it would evaluate their ready state based on previous screen instead of current