### PR TITLE
Fix the great wall of errors when reloading scripts in SL.

### DIFF
--- a/Graphics/ScreenSelectMusic header.lua
+++ b/Graphics/ScreenSelectMusic header.lua
@@ -16,7 +16,7 @@ local SecondsToHMMSS = SecondsToHMMSS or function(s)
 end
 
 local UpdateTimer = function(af, dt)
-	local seconds = GetTimeSinceStart() - SL.Global.TimeAtSessionStart
+	local seconds = GetTimeSinceStart() - (SL.Global.TimeAtSessionStart or GetTimeSinceStart())
 
 	-- if this game session is less than 1 hour in duration so far
 	if seconds < 3600 then

--- a/Scripts/SL-OnlineHelpers.lua
+++ b/Scripts/SL-OnlineHelpers.lua
@@ -9,8 +9,8 @@ local readyState = {
 local songSelected = false
 -- Track Start button hold time for disconnect
 local startHoldTime = {
-	["P1"] = nil,
-	["P2"] = nil
+	["P1"] = 0,
+	["P2"] = 0
 }
 -- These screens are the ones we want to display the player's scores for.
 local scoreScreens = {"ScreenGameplay", "ScreenEvaluationStage"}
@@ -55,12 +55,12 @@ local InputHandler = function(event)
 			end
 		elseif event.type == "InputEventType_Repeat" and event.GameButton == "Start" then
 			-- Check if Start has been held for 5 seconds
-			if startHoldTime[pn] ~= nil then
+			if startHoldTime[pn] > 0 then
 				local holdDuration = GetTimeSinceStart() - startHoldTime[pn]
         SM("Continue holding &START; for " .. (5 - math.floor(holdDuration)) .. " more seconds to disconnect...")
 				if holdDuration >= 5.0 then
 					SM("Disconnected from lobby.")
-					startHoldTime[pn] = nil
+					startHoldTime[pn] = 0
 					isWaiting = false
 					if SCREENMAN:GetTopScreen():GetName() == "ScreenGameplay" then
 						SCREENMAN:GetTopScreen():PauseGame(false)
@@ -69,7 +69,7 @@ local InputHandler = function(event)
 				end
 			end
 		elseif event.type == "InputEventType_Release" and event.GameButton == "Start" then
-			startHoldTime[pn] = nil
+			startHoldTime[pn] = 0
 		end
 	end
 


### PR DESCRIPTION
If anyone has ever reloaded scripts at any point aside from the TItle screen you may be acquainted with this wall:


<img width="1914" height="1022" alt="image" src="https://github.com/user-attachments/assets/0a9ac433-7d6e-4fde-9606-62da2c261730" />


Pretty simple fix, TimeAtSessionStart is nil when you reload so we just need a check for it in ``updateTimer`` which we already have elsewhere in the same file