### PR TITLE
Japanese Locale Update

### DIFF
--- a/Languages/ja.ini
+++ b/Languages/ja.ini
@@ -546,6 +546,7 @@ Profiles=🤍  ローカルプロファイルの管理
 Reload Songs=🤍  曲とコースのリロード
 AdvancedOptions=🤍  高度な設定
 ArcadeOptions=🤍  アーケード設定
+Bookkeeping=🤍  売上集計表
 GraphicsSoundOptions=🤍  映像・音声の設定
 Test Input=🤍  入力テスト
 AppearanceOptions=🤍  外観設定
@@ -678,6 +679,7 @@ ThemeOptions=Simply Love固有の設定です。いろいろあります。
 AdvancedOptions=困難スケーリング・クリアーの条件・曲削除、などなど
 USBProfileOptions=USBカスタムソングに関する設定です。そもそもUSBカスタムソングを許可するか否かもこちらから。
 Profiles=プロファイルを制作、編集、管理できます。管理するには、キーボードが必要です。
+Bookkeeping=クレジットとコインの売上台帳。
 MenuTimerOptions=メニュータイマーのオンオフ・それぞれの画面における制限時間の設定ができます。
 InputOptions=ジョイスティックのオートマップ、メニューでのパッド入力の可否、パッドの調整など、入力に関する設定です。
 TournamentModeOptions=トーナメント中に一貫する設定ができます。
@@ -719,6 +721,7 @@ BGBrightness=ゲームプレイ中の背景の明るさを調整します。\n\n
 RandomBackgroundMode=• Off - 楽曲によって指定された背景がなければ、背景を表示しません。\n\n• Random Animations – BGAnimationsフォルダ内の背景をランダムに再生します。\n\n• Random Movies - RandomMoviesフォルダ内の背景をランダム位再生します。
 NumBackgrounds=楽曲あたり、ランダムに選択される背景の数を指定します。\n\nもしRandom Gameplay Backgroundsが'Off'であれば、この項目は無視されます。
 Center1Player='On'にした場合、1プレイヤーモードのときにnotefieldを真ん中に表示します。
+ShowNativeLanguage=母国語とかローマ字で曲タイルを表する。\n\n#TITLEと#TITLETRANSLITがある曲の譜面だけ影響がある。\n\n曲選択中、キーボードのF9でトグル可能。
 ShowDancingCharacters=もしdancing charactersがあれば、プレイヤーは2つ目のPlayerOptionsからキャラクターを選択することができます。\n\n他のテーマでは、これを"Select"にすればキャラクターを選択する画面が出せたかもしれませんが、Simply Loveではできません。\n\nもしキャラクターがインストールされていなければ、この項目は効力を持ちません。
 
 # Arcade Options
@@ -731,6 +734,7 @@ Marathon Time=この長さ以上の楽曲は3ステージを消費するよう�
 AllowMultipleHighScoreWithSameName='Off'にすると、同一の名前のプレイヤーがある楽曲のハイスコアランキングに登録できるスコアが1つまでとなります。\n\nもしあなたが筐体の所有者で、あなたの複数のスコアを保持したい場合は'On'にしてください。
 ComboContinuesBetweenSongs='Off'にすると、ステージ間でコンボが引き継がれなくなります。\n\n'On'の場合、ステージ間でコンボが引き継がれるようになります。\nまた、ゲーム間でも引き継がれるようになります（プロファイルを使用していなくても）。
 Disqualification='On'にすると、あるオプションを有効化したときに(C-Mod・Rate mod・Attack無効化など)スコアが記録されなくなります。\n\n'Off'にすると、これらのオプションに関係なくスコアが記録されるようになります。
+ResetCoinsAtStartup='Yes'なら、再起動とクレジットはゼロになる。
 Premium=CoinModeが'Pay'のときのみ有効なオプションです。\n\n• 'Off' - プレミアムを無効化します。\n• 'Double for 1 Credit' - 1クレジットでダブルプレイが遊べるようになります。\n• '2 Players for 1 Credit' - 1クレジットだけで、ダブルプレイに加え2人プレイも遊べるようになります。
 SongsPerPlay=NORMALモードでプレイする曲数を設定します。
 
@@ -751,6 +755,8 @@ MusicWheelSpeed=選曲画面におけるスクロールの速度を指定しま�
 
 AllowScreenSelectProfile='No'に設定すると、プロファイル選択画面をスキップすることができます。しかも、ミュージック選択の画面のオプションメニューからプロファイル切り替えを無効にします。\n\nプロファイル選択画面は、ローカルに複数のプロファイルがある場合に使います。
 AllowScreenSelectColor='No'に設定すると、テーマ色選択画面をスキップすることができます。\n\nRainbow Modeを有効にした場合、このオプションは無視され、テーマ色選択画面は必ずスキップされます。
+AllowScreenSelectPlayMode='No'を設定すれば、モード選択画面をスキップ。
+AllowScreenSelectPlayMode2='No'を設定すれば、マラソン選択画面をスキップ。
 AllowScreenEvalSummary='No'に設定すると、ゲームプレイ終了後の総合リザルト画面をスキップすることができます。
 AllowScreenNameEntry='No'に設定すると、名前入力画面をスキップすることができます。\n\nCasualモードでは、この値に関係なく名前入力画面はスキップされます。
 AllowScreenGameOver='No'にすると、ゲームオーバー画面をスキップすることができます。
@@ -770,6 +776,7 @@ WriteCustomScores=カスタムのハイスコアを記録する。自分のプ�
 KeyboardFeatures=キーボードを有効化・無効化します。\n\nこれまで曲捜索だけこのオプションを使っています。
 SampleMusicLoops=選曲画面で音楽プリビューをループするかどうか。
 RescoreEarlyHits=早めに踏んでしまったDecentsとWay Offsが繰り返してもっといい判定になれるかもしらません。\n\nこの設定を反映させるには、ITGmaniaの再起動が必要です。
+AnimateBanners=選択画面の曲bannerの動画を流す状態をトグル
 UseImageCache='On'にすると、Casualモードの動作がより快適になります。ただし、ITGmaniaがより多くのRAMを消費するようになります。最低でも8GB以上のRAMを積んでいないマシンでは、この項目は'Off'にしておいたほうが良いでしょう。\n\nこの設定を反映させるには、ITGmaniaの再起動が必要です。
 
 # Tournament Mode Options
@@ -788,10 +795,12 @@ CustomSongsMaxMegabytes=USBカスタムソングの最大ファイルサイズ�
 
 # MenuTimer Options
 MenuTimer='On'にすると、各画面に制限時間が設けられます。各制限時間は以下で設定することができます。\n\n'Off'にすると、以下の設定項目は無視され、各画面の制限時間は無制限となります。
+ScreenGrooveStatsLoginMenuTimer=Groovestatsのログインの制限時間
 ScreenSelectMusicMenuTimer=選曲画面の制限時間を指定します。
 ScreenSelectMusicCasualMenuTimer=Casualモードにおける、選曲画面の制限時間を指定します。
 ScreenPlayerOptionsMenuTimer=選曲後のオプション選択画面の制限時間を指定します。
 ScreenEvaluationMenuTimer=リザルト画面の制限時間を指定します。
+ScreenEvaluationNonstopMenuTimer=コース選択画面の制限時間。
 ScreenEvaluationSummaryMenuTimer=総合リザルト画面の制限時間を指定します。
 ScreenNameEntryMenuTimer=名前入力画面の制限時間を指定します。
 
@@ -903,7 +912,6 @@ ShowLyrics=Hide
 ShowBanners=On
 BGBrightness=もし矢印が見づらければ、この数値を低めに設定しましょう。
 RandomBackgroundMode='Off'が一番無難です。この設定でも、楽曲ごとに指定した背景はちゃんと表示されます。
-ShowNativeLanguage=曲のタイトルはネイティブ言語かローマ字で表示。\n\n譜面は#TITLEと#TITLETRANSLITをあれば反映があり。\n\nゲーム中、F9はこの設定をトグル.
 
 #Graphics/Sound Options
 VideoRenderer=opengl

--- a/Languages/ja.ini
+++ b/Languages/ja.ini
@@ -202,7 +202,7 @@ YesInfo=YES
 NoInfo=NO
 
 [SRPG]
-SelectFaction=国をえんでください
+SelectFaction=国を選んでください
 
 [SongDescription]
 Artist=Artist
@@ -759,8 +759,8 @@ MusicWheelSpeed=選曲画面におけるスクロールの速度を指定しま�
 
 AllowScreenSelectProfile='No'に設定すると、プロファイル選択画面をスキップすることができます。しかも、ミュージック選択の画面のオプションメニューからプロファイル切り替えを無効にします。\n\nプロファイル選択画面は、ローカルに複数のプロファイルがある場合に使います。
 AllowScreenSelectColor='No'に設定すると、テーマ色選択画面をスキップすることができます。\n\nRainbow Modeを有効にした場合、このオプションは無視され、テーマ色選択画面は必ずスキップされます。
-AllowScreenSelectPlayMode='No'を設定すれば、モード選択画面をスキップ。
-AllowScreenSelectPlayMode2='No'を設定すれば、マラソン選択画面をスキップ。
+AllowScreenSelectPlayMode='No'に設定すれば、モード選択画面をスキップ。
+AllowScreenSelectPlayMode2='No'に設定すれば、マラソン選択画面をスキップ。
 AllowScreenEvalSummary='No'に設定すると、ゲームプレイ終了後の総合リザルト画面をスキップすることができます。
 AllowScreenNameEntry='No'に設定すると、名前入力画面をスキップすることができます。\n\nCasualモードでは、この値に関係なく名前入力画面はスキップされます。
 AllowScreenGameOver='No'にすると、ゲームオーバー画面をスキップすることができます。
@@ -799,7 +799,7 @@ CustomSongsMaxMegabytes=USBカスタムソングの最大ファイルサイズ�
 
 # MenuTimer Options
 MenuTimer='On'にすると、各画面に制限時間が設けられます。各制限時間は以下で設定することができます。\n\n'Off'にすると、以下の設定項目は無視され、各画面の制限時間は無制限となります。
-ScreenGrooveStatsLoginMenuTimer=Groovestatsのログインの制限時間
+ScreenGrooveStatsLoginMenuTimer=Groovestatsログインの制限時間。
 ScreenSelectMusicMenuTimer=選曲画面の制限時間を指定します。
 ScreenSelectMusicCasualMenuTimer=Casualモードにおける、選曲画面の制限時間を指定します。
 ScreenPlayerOptionsMenuTimer=選曲後のオプション選択画面の制限時間を指定します。
@@ -855,7 +855,7 @@ HoldJudgment=フリーズアローの見た目を変更します。
 Holds=フリーズアロー・ロールノートを増やします。 [m]
 Mines=Mineノートを無効化したり増やしたりできます。
 Attacks=アタックを有効化・無効化します。"Random Attacks"にすると、\nゲームプレイ中にランダムにModsが適用されます。
-HideLightType=ゲーム中、どの筐体のライトを無効にします。
+HideLightType=ゲーム中、どの筐体ライトを無効にします。
 PlayerAutoPlay=オートプレイを有効化・無効化します。
 Hide=ゲームプレイ中の様々な画面表示を非表示にすることができます。 [m]
 Persp=矢印の流れてくる角度を変更します。

--- a/Languages/ja.ini
+++ b/Languages/ja.ini
@@ -235,7 +235,7 @@ Song Length=Song Length
 Heart Rate=Heart Rate
 
 [ScreenEvaluation]
-Holds=FA
+Holds=ホールド
 Mines=地雷
 Hands=３つ
 Rolls=ロール
@@ -710,6 +710,7 @@ ShowStats=パフォーマンス統計が画面の右上表示出来ます。右�
 GlobalOffsetSeconds= 数ミリ病で音楽のオフセットを調製出来ます。\n\n負の値になったら、オーディオを早く再生する (矢印がもっと遅く来る)、正の値になったら、オーディオを遅く再生する (矢印が早く来る)。
 VisualDelaySeconds=画面表示の遅延を調整します。LCDのレイテンシをなんとかするために、一応残っている設定項目らしいです。
 AttractSoundFrequency=アトラクトデモで音を流す頻度を設定します。Simply_Loveはアトラクトデモがないが他のテームがこの設定使うかも知りまえん。ALWAYSに設定すると毎回音が流れます。N_TIMESに設定するとN回ごとに音が流れます。NEVERに設定すると音が流れません。
+PreferredSampleRate=サンプル周波数を設定。\nデフォルトは44100Hz.\n\n自分のシステムのネイティブサンプルレートを使用したら判定ドリフトを塞げる。変わったら、再起動が必要
 
 # Appearance Options
 ShowLyrics=歌詞を表示するか否かを選択します。\n\n歌詞は楽曲ごとに.lrcファイルで付与することができます。
@@ -880,7 +881,7 @@ SeparateUnlocksByPlayer=プレーヤーごとにロック解除を分離しま�
 ##############################################
 [RecommendedOptionExplanations]
 # Simply Love Options
-Recommended=推奨
+Recommended=おすすめ
 AutoStyle=アーケードで運用するなら、これは'None'にしておくべきでしょう。
 DefaultGameMode=アーケードで運用するなら、'Casual'にしておくのが無難でしょう。
 AllowFailingOutOfSet=客の回転率をなにがなんでも上げたいケチでもない限り、これは'No'が望ましいです。
@@ -902,13 +903,17 @@ ShowLyrics=Hide
 ShowBanners=On
 BGBrightness=もし矢印が見づらければ、この数値を低めに設定しましょう。
 RandomBackgroundMode='Off'が一番無難です。この設定でも、楽曲ごとに指定した背景はちゃんと表示されます。
+ShowNativeLanguage=曲のタイトルはネイティブ言語かローマ字で表示。\n\n譜面は#TITLEと#TITLETRANSLITをあれば反映があり。\n\nゲーム中、F9はこの設定をトグル.
+
 #Graphics/Sound Options
+VideoRenderer=opengl
 DisplayColorDepth=32bit
 HighResolutionTextures=Auto
 TextureColorDepth=32bit
 SmoothLines=実は'Off'のほうが見た目が良いらしい。
 DelayedTextureDelete=On
 FastNoteRendering=もしゲームプレイ中のFPSが低ければ、'On'にしてみましょう。\n\nPreference.ini内のSoundDeviceを指定するのも、FPSの改善に効果的かもしれません。
+GlobalOffsetSeconds=-9msから始まって(2004のITGの判定タイミング).
 # Arcade Options
 AllowMultipleHighScoreWithSameName=Off
 ComboContinuesBetweenSongs=Off

--- a/Languages/ja.ini
+++ b/Languages/ja.ini
@@ -198,11 +198,11 @@ SetSummaryText=記憶を回復する
 
 # prompt players before exiting via LLRRLLRR
 PromptBeforeExiting=もう終わりますか？
-YesInfo=YES
-NoInfo=NO
+YesInfo=はい
+NoInfo=いいえ
 
 [SRPG]
-SelectFaction=国を選んでください
+SelectFaction=党派を選んでください
 
 [SongDescription]
 Artist=Artist

--- a/Languages/ja.ini
+++ b/Languages/ja.ini
@@ -114,11 +114,13 @@ ChangeMode=モード変更
 ChangeStyle=スタイル変更
 Cancel=PRESS &SELECT; TO CANCEL
 Category=その他...
-GoBack=戻る
-CategorySorts=並び替え...
+
+# The following require Wendy and will be left in English
+#GoBack=戻る
+#CategorySorts=並び替え...
 #CategoryModes=Modes...
-CategoryStyles=スタイル...
-CategoryAdvanced=詳細オプション
+#CategoryStyles=スタイル...
+#CategoryAdvanced=詳細オプション
 CategoryProfile=プロフィール...
 CategoryPlaylists=プレイリスト...
 Playlist=プレイリスト
@@ -193,9 +195,9 @@ SetSummary=Set Summary
 SetSummaryText=記憶を回復する
 
 # prompt players before exiting via LLRRLLRR
-PromptBeforeExiting=本当に終了しますか？
-YesInfo=終わる
-NoInfo=もっと遊びたい
+PromptBeforeExiting=もう終わりますか？
+YesInfo=YES
+NoInfo=NO
 
 
 [SongDescription]

--- a/Languages/ja.ini
+++ b/Languages/ja.ini
@@ -7,6 +7,8 @@ PopupDismissText=&START; を押して、通知を閉じる
 # roughly in the order they are encountered
 
 [ScreenInit]
+UnsupportedGame=%sこのゲームモードは非対応。別のゲームを選択ください。
+UnsupportedSMVersion=%s %s はSimply Loveで非対応です。別のテーマとかITGmania %sをつかってください🙇
 
 # Attract Loop
 [ScreenLogo]
@@ -199,6 +201,8 @@ PromptBeforeExiting=もう終わりますか？
 YesInfo=YES
 NoInfo=NO
 
+[SRPG]
+SelectFaction=国をえんでください
 
 [SongDescription]
 Artist=Artist
@@ -235,7 +239,7 @@ Song Length=Song Length
 Heart Rate=Heart Rate
 
 [ScreenEvaluation]
-Holds=ホールド
+Holds=ロング
 Mines=地雷
 Hands=３つ
 Rolls=ロール
@@ -851,6 +855,7 @@ HoldJudgment=フリーズアローの見た目を変更します。
 Holds=フリーズアロー・ロールノートを増やします。 [m]
 Mines=Mineノートを無効化したり増やしたりできます。
 Attacks=アタックを有効化・無効化します。"Random Attacks"にすると、\nゲームプレイ中にランダムにModsが適用されます。
+HideLightType=ゲーム中、どの筐体のライトを無効にします。
 PlayerAutoPlay=オートプレイを有効化・無効化します。
 Hide=ゲームプレイ中の様々な画面表示を非表示にすることができます。 [m]
 Persp=矢印の流れてくる角度を変更します。

--- a/Languages/ja.ini
+++ b/Languages/ja.ini
@@ -397,9 +397,9 @@ MiscHelpLabel=Misc.
 
 # Explanations
 NavigationHelpText=↑/↓:\n     1小節移動\n;/':\n     1小節移動\nHome/End:\n    最初・最後に移動
-NoteWritingHelpText=数字キー:\n     矢印を配置・削除\n←/→:\n     配置単位を選択\n数字 + ↑/↓:\n    Holdノートを配置\nShift + 数字 + ↑/↓:\n    Rollを配置\nN/M: ノートタイプを変更
+NoteWritingHelpText=数字キー:\n     矢印を配置・削除\n←/→:\n     配置単位を選択\n数字 + ↑/↓:\n    ロングノートを配置\nShift + 数字 + ↑/↓:\n    Rollを配置\nN/M: ノートタイプを変更
 MenuHelpText=Escape: メインメニュー\nEnter: 範囲メニュー\nA: アレンジメニュー\nF4: タイミングメニュー
-RecordModeHelpText=Control + R: 記録モードを開始\nQ/W: Holdノートとして記録する時間を変更\nE/R: Holdノートの記録の有効化・無効化
+RecordModeHelpText=Control + R: 記録モードを開始\nQ/W: ロングノートとして記録する時間を変更\nE/R: ロングノートの記録の有効化・無効化
 KeyMappingHelpText=F1: キー配置のヘルプ
 MiscHelpText=Space: 範囲選択\nT: タイミング調整の範囲を切り替え
 
@@ -454,7 +454,7 @@ FailedToLoad=読み込みに失敗 😞
 
 [RadarCategory]
 Hands=3つ押し
-Holds=フリーズ
+Holds=ロング
 Jumps=2つ押し
 Mines=地雷
 Rolls=ロール
@@ -851,8 +851,8 @@ Appearance=矢印が途中で消えたり現れたりします。 [m]
 Turn=矢印の配置を入れ替えます。 [m]
 Insert=矢印を増やします。 [m]
 Scroll=矢印の流れてくる方向を変更します。 [m]
-HoldJudgment=フリーズアローの見た目を変更します。
-Holds=フリーズアロー・ロールノートを増やします。 [m]
+HoldJudgment=ロングノートの見た目を変更します。
+Holds=ロングノート、ロールノートを増やします。 [m]
 Mines=Mineノートを無効化したり増やしたりできます。
 Attacks=アタックを有効化・無効化します。"Random Attacks"にすると、\nゲームプレイ中にランダムにModsが適用されます。
 HideLightType=ゲーム中、どの筐体ライトを無効にします。


### PR DESCRIPTION
## Notes

<img width="421" height="310" alt="image" src="https://github.com/user-attachments/assets/cfc0267a-a15f-401e-8676-26321c048dc0" />

- revert sort menu options to english because the sort headers use wendy font and jp lacks wendy
- In a previous 1.1.0 I set hold notes to be freeze notes but ended up using the awkward F.A. for freeze arrow. We now don't use FA, or Freeze arrow or ホールド but ロング or ロングノート。this fits on the results screen text box (3 chars instead of 4) and is line with the _fallback jp (so historical japanese sm) as well as BMS (they sometimes use LN for long note). I am open to suggestions
- bookkeeping was also a hard one.  I'm not an arcade op but I wonder if they still call it bookkeeping. 売上集計表 just means sales total table and you may find this in a business spreadsheet

I have multiple commits for easier review. I can squash (or if github auto squashes) that would be good.