### PR TITLE
Name Pacemaker and Target actors

### DIFF
--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/TargetScore/Pacemaker.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/TargetScore/Pacemaker.lua
@@ -2,6 +2,7 @@ local player, pss, isTwoPlayers, graph, target_score = unpack(...)
 local pn = ToEnumShortString(player)
 
 local pacemaker = Def.BitmapText{
+	Name="Pacemaker" .. pn,
 	Font="Common Bold",
 	JudgmentMessageCommand=function(self)
 		self:queuecommand("Update")

--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/TargetScore/default.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/TargetScore/default.lua
@@ -38,7 +38,9 @@ local target_score, pos_data, personal_best = LoadActor("./Setup.lua", {player, 
 
 -- ---------------------------------------------------------------
 -- add actors to the ActorFrame as needed
-local af = Def.ActorFrame{}
+local af = Def.ActorFrame{
+	Name="TargetScore" .. pn
+}
 
 if WantsTargetGraph then
 	af[#af+1] = LoadActor("./Graph-Common.lua", {player, pss, isTwoPlayers, pos_data, target_score, personal_best, use_smaller_graph})


### PR DESCRIPTION
I have made myself a module that recolors the pacemaker, however it just was way easier when the actors were named. This would make it so I don't have to keep editing the files with every update.

I will PR the module to the Modules repo once this makes it in.

I have initially tried to PR this to ZMOD, however after thinking about it, it is better suited for upstream. 