### PR TITLE
Fix GrooveStats missing PlayerOptions

### DIFF
--- a/Scripts/SL-Helpers-GrooveStats.lua
+++ b/Scripts/SL-Helpers-GrooveStats.lua
@@ -850,7 +850,7 @@ CreateGrooveStatsPlayerOptionKeys = function()
 				[6]="Emoticon 2x7 (doubleres).png",
 				[7]="Focus 2x7 (doubleres).png",
 				[8]="Grammar 2x7 (doubleres).png",
-				[9]="GrooveNights 2x7.png",
+				[9]="GrooveNights 2x7 (doubleres).png",
 				[10]="ITG2 2x7 (doubleres).png",
 				[11]="Love 2x7 (doubleres).png",
 				[12]="Love Chroma 2x7 (doubleres).png",
@@ -861,6 +861,7 @@ CreateGrooveStatsPlayerOptionKeys = function()
 				[17]="Shift 2x7 (doubleres).png",
 				[18]="Tactics 2x7 (doubleres).png",
 				[19]="Wendy 2x7 (doubleres).png",
+				[20]="Censored 1x7 (doubleres).png",
 				-- Digital Dance
 				[100]="Chalk 2x7 (doubleres).png",
 				[101]="Digital 2x7 (doubleres).png",

--- a/Scripts/SL-Helpers-GrooveStats.lua
+++ b/Scripts/SL-Helpers-GrooveStats.lua
@@ -1095,6 +1095,8 @@ GetPlayerOptionsJsonForGrooveStats = function(player)
 
 	MaybeSetOption(options, "Mini", mini, "number")
 	MaybeSetOption(options, "VisualDelay", visualDelay, "number")
+	MaybeSetOption(options, "BackgroundFilter", backgroundFilter, "number")
+	MaybeSetOption(options, "HideLookahead", hideLookahead, "number")
 
 	MaybeSetOption(options, "Cover", hasCover, "boolean")
 	MaybeSetOption(options, "NoMines", hasNoMines, "boolean")


### PR DESCRIPTION
This allows BackgroundFilter and HideLookahead to get saved on GrooveStats.