### PR TITLE
Fix Groovestats error when MaxHIghScores was anything but the default…

### DIFF
--- a/BGAnimations/ScreenEvaluation common/Panes/Pane4/default.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane4/default.lua
@@ -71,14 +71,14 @@ if (not EarnedMachineRecord and EarnedTop2Personal) then
 	args.RowHeight = 20.25
 
 	-- top 8 machine HighScores
-	args.NumHighScores = 8
+	args.NumHighScores = math.min(8, PREFSMAN:GetPreference("MaxHighScoresPerListForMachine"))
 	pane[#pane+1] = LoadActor(THEME:GetPathB("", "_modules/HighScoreList.lua"), args)
 
 	-- horizontal line visually separating machine HighScores from player HighScores
 	pane[#pane+1] = Def.Quad{ InitCommand=function(self) self:zoomto(100, 1):y(args.RowHeight*9):diffuse(1,1,1,0.33) end }
 
 	-- top 2 player HighScores
-	args.NumHighScores = 2
+	args.NumHighScores = math.min(2, PREFSMAN:GetPreference("MaxHighScoresPerListForPlayer"))
 	args.Profile = PROFILEMAN:GetProfile(player)
 	pane[#pane+1] = LoadActor(THEME:GetPathB("", "_modules/HighScoreList.lua"), args)..{
 		InitCommand=function(self) self:y(args.RowHeight*9) end
@@ -89,7 +89,7 @@ if (not EarnedMachineRecord and EarnedTop2Personal) then
 -- We can also hijack the 10 rows of high scores to display those ones fetched from GrooveStats.
 else
 	-- top 10 machine HighScores
-	args.NumHighScores = 10
+	args.NumHighScores = math.min(10, PREFSMAN:GetPreference("MaxHighScoresPerListForMachine"))
 	pane[#pane+1] = LoadActor(THEME:GetPathB("", "_modules/HighScoreList.lua"), args)
 end
 

--- a/BGAnimations/ScreenEvaluation common/Shared/AutoSubmitScore.lua
+++ b/BGAnimations/ScreenEvaluation common/Shared/AutoSubmitScore.lua
@@ -1,6 +1,6 @@
 if not IsServiceAllowed(SL.GrooveStats.AutoSubmit) or GAMESTATE:IsCourseMode() then return end
 
-local NumEntries = 10
+local NumEntries = math.min(10, PREFSMAN:GetPreference("MaxHighScoresPerListForMachine"))
 
 local SetEntryText = function(rank, name, score, date, actor)
 	if actor == nil then return end


### PR DESCRIPTION
Folks were encountering this error in AutoSubmitScore.lua when loading the Groovestats leaderboard. The issue was that ``NumEntries`` was hard set at 10 which can conflict with the machine's ``MaxHighScoresPerListForMachine`` and max for profiles. If the machine was set to a maximum of 9 then when it went to render the 10th entry we threw an error. Similarly if we exceeded 10, we received an error when attempting to show an 11th

Screenshot from MIT cab
<img width="4000" height="3000" alt="image" src="https://github.com/user-attachments/assets/7380743a-e69f-4811-b7f5-697e894862dd" />

Screenshot from my own testing:
<img width="1922" height="183" alt="image" src="https://github.com/user-attachments/assets/2efd1d7c-5071-4f8c-a3c0-75e6b95c9916" />

