### PR TITLE
Remove red highlight for nullsynced charts

### DIFF
--- a/Graphics/MusicWheelItem Course NormalPart.lua
+++ b/Graphics/MusicWheelItem Course NormalPart.lua
@@ -21,19 +21,5 @@ return Def.ActorFrame {
                 self:diffusealpha(0.5)
             end
         end,
-		SetCommand=function(self, params)
-			if params.Song then
-				local song = params.Song
-				local offset = round(SONGMAN:GetGroup(song):GetSyncOffset(), 3)
-				if offset == -0.009 then
-					self:diffuserightedge(DarkUI() and {1, 1, 1, 0.5} or {10 / 255, 20 / 255, 27 / 255, 1})
-				else
-					self:diffuserightedge(DarkUI() and {1, 0.5, 0.5, 0.5} or {80 / 255, 20 / 255, 27 / 255, 1})
-				end
-				if ThemePrefs.Get("VisualStyle") == "SRPG9" or ThemePrefs.Get("VisualStyle") == "Technique" then
-					self:diffusealpha(0.5)
-				end
-			end
-		end,
     }
 }


### PR DESCRIPTION
While there certainly were problems with pack.ini, it doesn't seem like any of it is tied to if a song is marked as NULL through a pack.ini.

This was originally intended as a debug feature, so I believe it's time to get rid of it now
<img width="571" height="331" alt="image" src="https://github.com/user-attachments/assets/ef98d948-14bf-462e-ae38-930bde69150b" />

Maybe the packsync can still be shown with a bit of text on the side? 
