### PR TITLE
Add Names to TestInput and ScreenSelectMusic out

### DIFF
--- a/BGAnimations/ScreenSelectMusic out.lua
+++ b/BGAnimations/ScreenSelectMusic out.lua
@@ -1,12 +1,15 @@
 return Def.ActorFrame{
+	Name="SplashScreen",
 	InitCommand=function(self) self:draworder(200) end,
 
 	Def.Quad{
+		Name="Background",
 		InitCommand=function(self) self:diffuse(0,0,0,0):FullScreen():cropbottom(1):fadebottom(0.5) end,
 		OffCommand=function(self) self:linear(0.3):cropbottom(-0.5):diffusealpha(1) end
 	},
 
 	LoadFont("Common Bold")..{
+		Name="OptionsText",
 		Text=THEME:GetString("ScreenSelectMusic", "Press Start for Options"),
 		InitCommand=function(self) self:visible(false):Center():zoom(0.75) end,
 		ShowPressStartForOptionsCommand=function(self) self:visible(true) end,

--- a/BGAnimations/ScreenSelectMusic overlay/TestInput.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/TestInput.lua
@@ -4,6 +4,7 @@ local game = GAMESTATE:GetCurrentGame():GetName()
 if not (game=="dance" or game=="pump" or game=="techno") then return end
 
 local af = Def.ActorFrame{
+	Name="TestInput",
 	InitCommand=function(self) self:visible(false) end,
 	ShowTestInputCommand=function(self) self:visible(true) end,
 	HideTestInputCommand=function(self) self:visible(false) end,


### PR DESCRIPTION
Adds name fields to the TestInput Actor and the ScreenSelectMusic out ActorFrame. TestInput can be found by ScreenSelectMusic's GetChild("Overlay"):GetChild("TestInput"), and the out actor frame can be found by ScreenSelectMusic's GetChild("Out"):GetChild("SplashScreen"), which itself has "Background" and "OptionsText"

The use case for this is a module that adds stuff to ScreenSelectMusic; Since modules draw on top of everything, I wanted to make it invisible when Test Input is showing and where ScreenSelectMusic out is showing.