### PR TITLE
Make scroll wheel a little snappier

### DIFF
--- a/metrics.ini
+++ b/metrics.ini
@@ -1522,6 +1522,7 @@ SkipY=_screen.h - 85
 
 
 [MusicWheel]
+SwitchSeconds=0.05
 ShowRoulette=false
 ShowPortal=false
 ShowRandom=false


### PR DESCRIPTION
This slightly speeds up the amount of time to snap to the middle of a row after the user stops scrolling on the scroll wheel.