### PR TITLE
Enable SortMenu in course/marathon mode

### DIFF
--- a/BGAnimations/ScreenEvaluationSummary overlay/Row.lua
+++ b/BGAnimations/ScreenEvaluationSummary overlay/Row.lua
@@ -44,7 +44,9 @@ t[#t+1] = Def.Banner{
 	InitCommand=function(self) self:y(-6) end,
 	DrawStageCommand=function(self)
 		if SongOrCourse then
-			if GAMESTATE:IsCourseMode() then
+			-- We can have both songs and courses in one session now. Check
+			-- which one this is.
+			if SongOrCourse.GetCourseType then
 				self:LoadFromCourse(SongOrCourse)
 			else
 				self:LoadFromSong(SongOrCourse)

--- a/BGAnimations/ScreenSelectMusic overlay/PerPlayer/StepArtist.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/PerPlayer/StepArtist.lua
@@ -78,7 +78,7 @@ return Def.ActorFrame{
 
 	--STEPS label
 	LoadFont("Common Normal")..{
-		Text=GAMESTATE:IsCourseMode() and Screen.String("SongNumber"):format(1) or Screen.String("STEPS"),
+		Text=GAMESTATE:IsCourseMode() and THEME:GetString("ScreenSelectCourse", "SongNumber"):format(1) or Screen.String("STEPS"),
 		InitCommand=function(self)
 			self:diffuse(0,0,0,1):horizalign(left):x(30):maxwidth(40):zoom(0.8)
 		end,

--- a/BGAnimations/ScreenSelectMusic overlay/PreserveMenuTimer.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/PreserveMenuTimer.lua
@@ -13,7 +13,10 @@ local Update = function(self, dt)
 	-- and music wheel exist only on ScreenSelectMusic so there's nothing to do
 	-- in that case.
 	local topscreen = SCREENMAN:GetTopScreen()
-	if topscreen:GetName() ~= 'ScreenSelectMusic' then return end
+	if topscreen:GetName() ~= 'ScreenSelectMusic' and
+		topscreen:GetName() ~= 'ScreenSelectCourse' then
+		return
+	end
 
 	if menuTimerEnabled then
 		SL.Global.MenuTimer.ScreenSelectMusic = topscreen:GetChild("Timer"):GetSeconds()

--- a/BGAnimations/ScreenSelectMusic overlay/SortMenu/SortMenu_InputHandler.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SortMenu/SortMenu_InputHandler.lua
@@ -59,7 +59,23 @@ local input = function(event)
 					screen:SetNextScreenName("ScreenSelectMusicCasual")
 					screen:StartTransitioningScreen("SM_GoToNextScreen")
 				end
-				-- the player wants to change styles, for example from single to double
+
+			-- Change between Course (aka Marathon aka Nonstop) and Regular mode.
+			elseif focus.kind == "ChangePlayMode" then
+				-- Unselect song/course first to avoid getting to a state where
+				-- play mode is Course but a song is selected or vice versa.
+				GAMESTATE:SetCurrentSong(nil)
+				GAMESTATE:SetCurrentCourse(nil)
+				GAMESTATE:SetCurrentPlayMode(focus.change)
+
+				-- Save menu timer value.
+				if PREFSMAN:GetPreference("MenuTimer") then
+					overlay:playcommand("ShowPressStartForOptions")
+				end
+				screen:SetNextScreenName("ScreenReloadSSM")
+				screen:StartTransitioningScreen("SM_GoToNextScreen")
+
+			-- the player wants to change styles, for example from single to double
 			elseif focus.kind == "ChangeStyle" then
 				-- If the MenuTimer is in effect, we need to make sure the current number of seconds
 				-- remaining is preserved so we can reinstate it later. ShowPressStartForOptions

--- a/BGAnimations/ScreenSelectMusic overlay/SortMenu/WheelItemMT.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SortMenu/WheelItemMT.lua
@@ -161,7 +161,7 @@ return {
 
 			if self.kind == "SortBy" then
 				self.sort_by = info[2]
-			elseif self.kind == "ChangeMode" or self.kind == "ChangeStyle" then
+			elseif self.kind == "ChangeMode" or self.kind == "ChangeStyle" or self.kind == "ChangePlayMode" then
 				self.change = info[2]
 			else
 				self.new_overlay = info[2]

--- a/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
@@ -61,6 +61,8 @@ end
 ------------------------------------------------------------
 
 local function AddFavorites()
+	if GAMESTATE:IsCourseMode() then return false end
+
     for player in ivalues(GAMESTATE:GetHumanPlayers()) do
         local path = getFavoritesPath(player)
         if FILEMAN:DoesFileExist(path) then
@@ -86,17 +88,50 @@ local function PracticeModeAvailable()
 	return GAMESTATE:IsEventMode() and GAMESTATE:GetCurrentSong() ~= nil and ThemePrefs.Get("KeyboardFeatures")
 end
 
-local function AddPlayerSortOptions()
-    local player_sort_options = {}
-    for player in ivalues(GAMESTATE:GetHumanPlayers()) do
-        if PROFILEMAN:IsPersistentProfile(player) then
-            table.insert(player_sort_options, {"SortBy", "Top" .. ToEnumShortString(player) .. "Grades"})
-        end
-    end
-    return player_sort_options
+local function ChangePlayModeAvailable()
+	local onlineHandler = GetOnlineHandlerInstance()
+	return GAMESTATE:IsEventMode() and
+		ThemePrefs.Get("AllowScreenSelectPlayMode2") and
+		not (onlineHandler and onlineHandler.connected)
+end
+
+local function AddSorts()
+	-- Most sort orders don't currently work in course mode, they cause the
+	-- wheel to change to song mode instead. The ones that seem work are
+	-- AllCourses, Nonstop, Oni, and Endless. I don't know if those are useful
+	-- so let's just disable the sort orders for course mode.
+	if GAMESTATE:IsCourseMode() then return {} end
+
+	return {
+		{{"SortBy", "Group"} },
+		{ {"SortBy", "Title"} },
+		{ {"SortBy", "Artist"} },
+		{ {"SortBy", "Genre"} },
+		{ {"SortBy", "BPM"} },
+		{ {"SortBy", "Length"} },
+		{ {"SortBy", "Meter"} },
+		{ {"SortBy", "Popularity"} },
+		{ {"SortBy", "Recent"} },
+		{ {"SortBy", "TopGrades"} },
+	}
+end
+
+local function AddProfileEntries()
+	if GAMESTATE:IsCourseMode() then return {} end
+
+	return {
+		{ {"SortBy", "PopularityP1"}, function() return PROFILEMAN:IsPersistentProfile(PLAYER_1) end },
+		{ {"SortBy", "RecentP1"}, function() return PROFILEMAN:IsPersistentProfile(PLAYER_1) end },
+		{ {"SortBy", "TopP1Grades"}, function() return PROFILEMAN:IsPersistentProfile(PLAYER_1) end },
+		{ {"SortBy", "PopularityP2"}, function() return PROFILEMAN:IsPersistentProfile(PLAYER_2) end },
+		{ {"SortBy", "RecentP2"}, function() return PROFILEMAN:IsPersistentProfile(PLAYER_2) end },
+		{ {"SortBy", "TopP2Grades"}, function() return PROFILEMAN:IsPersistentProfile(PLAYER_2) end },
+		{ {"MixTape", "Preferred"}, AddFavorites },
+	}
 end
 
 local function AddPlaylists()
+	if GAMESTATE:IsCourseMode() then return {} end
 
 	-- First add the machine playlists
 	local player_sort_options = {}
@@ -251,6 +286,7 @@ local t = Def.ActorFrame {
 			-- and offer to switch them back to casual mode. This allows them to do so again.
 			-- It's technically not possible to reach the sort menu in Casual Mode, but juuust in case let's still
 			-- include the check.
+			--
 			{ { "", "GoBack" } },
 			{ {"NextPlease", "SwitchProfile"}, ThemePrefs.Get("AllowScreenSelectProfile") },
 			{ {"GrooveStats", "Leaderboard"}, function() return GAMESTATE:GetCurrentSong() ~= nil end },
@@ -258,43 +294,28 @@ local t = Def.ActorFrame {
 			{ {"ImLovinIt", "AddFavorite"}, function() return GAMESTATE:GetCurrentSong() ~= nil end},
 			{ {"MixTape", "Preferred"}, AddFavorites },
 			{ {"ChangeMode", "Casual"}, SL.Global.Stages.PlayedThisGame == 0 and SL.Global.GameMode ~= "Casual" },
+			{ {"ChangePlayMode", "Nonstop"}, not GAMESTATE:IsCourseMode() and ChangePlayModeAvailable() },
+			{ {"ChangePlayMode", "Regular"}, GAMESTATE:IsCourseMode() and ChangePlayModeAvailable() },
 			{
 
 				{"", "CategorySorts"},
-				{
-					{{"SortBy", "Group"} },
-					{ {"SortBy", "Title"} },
-					{ {"SortBy", "Artist"} },
-					{ {"SortBy", "Genre"} },
-					{ {"SortBy", "BPM"} },
-					{ {"SortBy", "Length"} },
-					{ {"SortBy", "Meter"} },
-					{ {"SortBy", "Popularity"} },
-					{ {"SortBy", "Recent"} },
-					{ {"SortBy", "TopGrades"} },
-				}
+				AddSorts(),
 			},
 			{
 				{"", "CategoryProfile"},
-				{
-					{ {"SortBy", "PopularityP1"}, function() return PROFILEMAN:IsPersistentProfile(PLAYER_1) end },
-					{ {"SortBy", "RecentP1"}, function() return PROFILEMAN:IsPersistentProfile(PLAYER_1) end },
-					{ {"SortBy", "TopP1Grades"}, function() return PROFILEMAN:IsPersistentProfile(PLAYER_1) end },
-					{ {"SortBy", "PopularityP2"}, function() return PROFILEMAN:IsPersistentProfile(PLAYER_2) end },
-					{ {"SortBy", "RecentP2"}, function() return PROFILEMAN:IsPersistentProfile(PLAYER_2) end },
-					{ {"SortBy", "TopP2Grades"}, function() return PROFILEMAN:IsPersistentProfile(PLAYER_2) end },
-					{ {"MixTape", "Preferred"}, AddFavorites },
-				}
+				AddProfileEntries(),
 			},
 			{
 				{"", "CategoryAdvanced"},
 				{
 					{ {"FeelingSalty", "TestInput"}, GAMESTATE:IsEventMode() },
 					{ {"HardTime", "PracticeMode"}, PracticeModeAvailable },
-					{ {"TakeABreather", "LoadNewSongs"} },
+					-- Loading songs doesn't work from course mode because it invalidates autogen courses,
+					-- which could delete the currently selected course.
+					{ {"TakeABreather", "LoadNewSongs"}, not GAMESTATE:IsCourseMode() },
 					{ {"NeedMoreRam", "ViewDownloads"}, DownloadsExist },
 					{ {"SetSummaryText", "SetSummary"}, SL.Global.Stages.PlayedThisGame > 0 },
-					{ {"BottomText", "OnlineLobbies"}, ThemePrefs.Get("EnableOnlineLobbies") and GAMESTATE:IsEventMode() },
+					{ {"BottomText", "OnlineLobbies"}, ThemePrefs.Get("EnableOnlineLobbies") and GAMESTATE:IsEventMode() and not GAMESTATE:IsCourseMode() },
 				}
 			},
 			{

--- a/BGAnimations/ScreenSelectMusic overlay/StepsDisplayList/CourseContentsList.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/StepsDisplayList/CourseContentsList.lua
@@ -50,6 +50,10 @@ local af = Def.ActorFrame{
 	-- be hidden by the mask, but that is effectively already called on the
 	-- entire "Display" ActorFrame of the CourseContentsList in the engine's code.
 
+	-- We need to undo the effects of these masks after rendering the course
+	-- contents to avoid hiding parts of other actors rendered on top, such as
+	-- the sort menu and profile select menu.
+
 	-- lower mask
 	Def.Quad{
 		InitCommand=function(self)
@@ -180,6 +184,28 @@ af[#af+1] = Def.CourseContentsList {
 			end
 		}
 	}
+}
+
+-- Undo the masks to avoid hiding parts of other actors rendered on top of them.
+af[#af+1] = Def.Quad{
+	InitCommand=function(self)
+		self:xy(0, 98)
+			:zoomto(PaneWidth, 40)
+			:blend('BlendMode_NoEffect')
+			:zwrite(true)
+			:zbias(-0.1)
+	end
+}
+
+af[#af+1] = Def.Quad{
+	InitCommand=function(self)
+		self:vertalign(bottom)
+			:xy(0, -18)
+			:zoomto(PaneWidth, 100)
+			:blend('BlendMode_NoEffect')
+			:zwrite(true)
+			:zbias(-0.1)
+	end
 }
 
 return af

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -134,6 +134,7 @@ STEPS=STEPS
 SortBy=Sort By
 ChangeMode=Change Mode To
 ChangeStyle=Change Style To
+ChangePlayMode=Change Mode To
 Cancel=PRESS &SELECT; TO CANCEL
 Category=More...
 GoBack=Go Back
@@ -177,6 +178,10 @@ Solo=Solo
 Single8=Single
 Double8=Double
 Versus8=Versus
+
+# SortMenu "Change Mode To" choices
+Regular=Regular
+Nonstop=Marathon
 
 # Test Input overlay in SelectMusic (available from SortMenu)
 FeelingSalty=Feeling salty?

--- a/Scripts/SL-BPMDisplayHelpers.lua
+++ b/Scripts/SL-BPMDisplayHelpers.lua
@@ -54,7 +54,7 @@ GetDisplayBPMs = function(player, StepsOrTrail, MusicRate)
 	-- steps are not always set in the Engine in Casual mode (prior to the first stage being played) so
 	-- GAMESTATE:GetCurrentSteps() will sometimes return nil; but, it's okay. We don't need such rigorous BPM
 	-- analysis there anyway.  Don't worry about split timing and just use BPM values for the first playable chart.
-	if SL.Global.GameMode == "Casual" then
+	if SL.Global.GameMode == "Casual" and GAMESTATE:GetCurrentSong() then
 		-- there is no CourseMode in Casual, so no need to worry about trails here
 		local steps = SongUtil.GetPlayableSteps( GAMESTATE:GetCurrentSong() )
 		if steps and steps[1] then StepsOrTrail = steps[1] end
@@ -64,11 +64,9 @@ GetDisplayBPMs = function(player, StepsOrTrail, MusicRate)
 
 	local bpms
 
-	-- if in CourseMode
-	if GAMESTATE:IsCourseMode() then
+	-- We can have both songs and courses in the evaluation summary. Check which one it is.
+	if StepsOrTrail.GetTrailEntries then
 		bpms = GetTrailBPMs(player, StepsOrTrail)
-
-	-- otherwise, we are not in CourseMode, i.e. in "normal" mode
 	else
 		bpms = StepsOrTrail:GetDisplayBpms()
 	end

--- a/metrics.ini
+++ b/metrics.ini
@@ -237,20 +237,20 @@ TimerSeconds=15
 
 [ScreenViewDownloads]
 Fallback="ScreenWithMenuElements"
-NextScreen="ScreenSelectMusic"
-PrevScreen="ScreenSelectMusic"
+NextScreen=SelectMusicOrCourse()
+PrevScreen=SelectMusicOrCourse()
 
 [ScreenReloadSSM]
 Fallback="ScreenWithMenuElements"
-NextScreen="ScreenSelectMusic"
-PrevScreen="ScreenSelectMusic"
+NextScreen=SelectMusicOrCourse()
+PrevScreen=SelectMusicOrCourse()
 HeaderOnCommand=visible,false
 FooterOnCommand=visible,false
 ShowCreditDisplay=false
 
 [ScreenReloadSongsSSM]
 Fallback="ScreenReloadSongs"
-NextScreen="ScreenSelectMusic"
+NextScreen=SelectMusicOrCourse()
 OnlyLoadAdditions=true
 
 [ScreenHeartEntry]
@@ -1663,7 +1663,7 @@ MusicWheelY=_screen.cy
 MusicWheelOffCommand=linear,0.2;diffusealpha,0;
 
 MusicWheelCodeMessageCommand=%function(self, params) \
-	if not GAMESTATE:IsCourseMode() and (params.Name:match("SortList")) then \
+	if params.Name:match("SortList") then \
 		SCREENMAN:GetTopScreen():GetChild("Overlay"):queuecommand("DirectInputToSortMenu") \
 	end; \
 end
@@ -1676,7 +1676,7 @@ ConfirmExit=PREFSMAN:GetPreference("EventMode")
 [ScreenPractice]
 Fallback="ScreenEdit"
 Class="ScreenEdit"
-NextScreen="ScreenSelectMusic"
+NextScreen=SelectMusicOrCourse()
 PrevScreen="ScreenOptionsEdit"
 EditMode="EditMode_Practice"
 
@@ -1933,8 +1933,8 @@ CodeScreenshot=SL.Global.GameMode=="Casual" and "" or (PREFSMAN:GetPreference("T
 
 [ScreenEvaluationSummarySet]
 Fallback="ScreenEvaluationSummary"
-PrevScreen="ScreenSelectMusic"
-NextScreen="ScreenSelectMusic"
+PrevScreen=SelectMusicOrCourse()
+NextScreen=SelectMusicOrCourse()
 
 [RollingNumbersEvaluation]
 Fallback="RollingNumbers"


### PR DESCRIPTION
Enables SortMenu in ScreenSelectCourse and adds an option to switch between Regular/Marathon. Updates ScreenEvaluationSummary to handle mixed songs and courses.

<img width="1366" height="768" alt="course_sort_menu" src="https://github.com/user-attachments/assets/021888ce-a056-4443-b2fa-edf2d492b574" />

Only shown in event mode when select marathon is allowed in options and not connected to an online lobby.