### PR TITLE
SortMenu: Fix entries after song change

### DIFF
--- a/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
@@ -464,6 +464,13 @@ local t = Def.ActorFrame {
 		-- that we want to have focus when the wheel is displayed
 		sort_wheel:set_info_set(filtered_wheel_options, current_sort_order_index)
 	end,
+
+	CurrentSongChangedMessageCommand=function(self)
+		if self:GetVisible() then
+			self:queuecommand("AssessAvailableChoices")
+		end
+	end,
+
 	-- slightly darken the entire screen
 	Def.Quad {
 		InitCommand=function(self) self:FullScreen():diffuse(Color.Black):diffusealpha(0.8) end


### PR DESCRIPTION
Changes SortMenu to handle the CurrentSongChanged message and refresh the options. Fixes missing menu entries when pressing Left+Right to open the menu so that the Left press momentarily moves the selection from a song to a group. The update of the current song in GAMESTATE happens via a message, so the menu might open before it's set.