### PR TITLE
Misc Patches mainly pertaining to autostyle related bugs

### DIFF
--- a/BGAnimations/ScreenEvaluation common/InputHandler.lua
+++ b/BGAnimations/ScreenEvaluation common/InputHandler.lua
@@ -23,7 +23,7 @@ local mpn = GAMESTATE:GetMasterPlayerNumber()
 --        so this is more like "validation" than validation
 
 local primary_i   = clamp(SL[ToEnumShortString(mpn)].EvalPanePrimary,   1, num_panes)
-local secondary_i = clamp(SL[ToEnumShortString(mpn)].EvalPaneSecondary, 1, num_panes)-1
+local secondary_i = clamp(SL[ToEnumShortString(mpn)].EvalPaneSecondary, 1, num_panes)
 
 -- -----------------------------------------------------------------------
 -- initialize local tables (panes, active_pane) for the the input handling function to use

--- a/BGAnimations/ScreenEvaluation common/Panes/Pane3/Arrows.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane3/Arrows.lua
@@ -7,7 +7,6 @@ local noteskin = GAMESTATE:GetPlayerState(player):GetCurrentPlayerOptions():Note
 -- NOTESKIN:LoadActorForNoteSkin() expects the noteskin name to be all lowercase(?)
 -- so transform the string to be lowercase
 noteskin = noteskin:lower()
-local routineStatus = false
 
 -- -----------------------------------------------------------------------
 local game  = GAMESTATE:GetCurrentGame():GetName()
@@ -35,7 +34,7 @@ local box_height = 146
 -- more space for double and routine
 local styletype = ToEnumShortString(style:GetStyleType())
 
-if (styletype == "OnePlayerTwoSides" or (styletype == "TwoPlayersSharedSides" and routineStatus) ) then
+if (styletype == "OnePlayerTwoSides") then
 	box_width = 520
 end
 
@@ -45,7 +44,7 @@ local row_height = box_height/#rows
 -- -----------------------------------------------------------------------
 
 local af = Def.ActorFrame{}
-af.InitCommand=function(self) self:xy((styletype == "TwoPlayersSharedSides" and not routineStatus) and -102 or -104, _screen.cy-40) end
+af.InitCommand=function(self) self:xy((styletype == "TwoPlayersSharedSides") and -102 or -104, _screen.cy-40) end
 
 
 for i, column in ipairs( cols ) do

--- a/BGAnimations/ScreenEvaluation common/Panes/Pane6/default.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane6/default.lua
@@ -16,7 +16,7 @@ local style = ToEnumShortString(GAMESTATE:GetCurrentStyle():GetStyleType())
 
 local pane = Def.ActorFrame{
 	InitCommand=function(self)
-		if style == "OnePlayerTwoSides" or (style == "TwoPlayersSharedSides" and routineStatus) then
+		if style == "OnePlayerTwoSides" then
 			if controller == PLAYER_2 then self:x(-260)
 			else self:x(50) end
 		end

--- a/BGAnimations/ScreenEvaluation common/Panes/default.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/default.lua
@@ -13,7 +13,7 @@ local offset = {
 -- Note: Some of these Pane actors may be nil. This is not a bug, but
 --       a feature for any panes we want to be conditional.  -teejusb
 
-if #players == 2 or SL.Global.GameMode=="Casual" and not (styletype == "TwoPlayersSharedSides") then
+if #players == 2 or SL.Global.GameMode=="Casual" and not (style == "TwoPlayersSharedSides") then
 	for player in ivalues(players) do
 		-- add Panes for this player to the ActorFrame using a simple, numerical for-loop
 		for i=1, NumPanes do

--- a/BGAnimations/ScreenEvaluation common/PerPlayer/Upper/LetterGrade.lua
+++ b/BGAnimations/ScreenEvaluation common/PerPlayer/Upper/LetterGrade.lua
@@ -3,7 +3,6 @@ local player = ...
 local styletype = ToEnumShortString(GAMESTATE:GetCurrentStyle():GetStyleType())
 
 local playerStats = STATSMAN:GetCurStageStats():GetPlayerStageStats(player)
-local routineStatus = SL.Global.RoutineStatus
 if (styletype == "TwoPlayersSharedSides") then
 	playerStats = STATSMAN:GetCurStageStats():GetRoutineStageStats()
 end

--- a/BGAnimations/ScreenPlayerOptions overlay/default.lua
+++ b/BGAnimations/ScreenPlayerOptions overlay/default.lua
@@ -14,7 +14,8 @@ local speedmod_def = {
 	C = { upper=2000, increment=5 },
 	M = { upper=2000, increment=5 }
 }
-
+-- Style Type is updated as you change difficulties so maintain behavior of the style type we came in with.
+local styleType = GAMESTATE:GetCurrentStyle():GetStyleType()
 -- In Routine (couples) mode, default players to the red and blue couples skins
 -- if they aren't already on a couples noteskin.
 if IsRoutine() then
@@ -102,7 +103,7 @@ local CalculateScrollSpeed = function(player)
 	local mini = 0
 	if SpeedModRowIndex then
 		-- The BitmapText actors for P1 and P2 speedmod are both named "Item", so we need to provide a 1 or 2 to index
-		if GAMESTATE:GetCurrentStyle():GetStyleType() == "StyleType_TwoPlayersSharedSides" then
+		if styleType == "StyleType_TwoPlayersSharedSides" and not autoStyle then
 			miniText = ScreenOptions:GetOptionRow(SpeedModRowIndex):GetChild(""):GetChild("Item"):GetText()
 		else
 			miniText = ScreenOptions:GetOptionRow(SpeedModRowIndex):GetChild(""):GetChild("Item")[ PlayerNumber:Reverse()[player]+1 ]:GetText()
@@ -157,7 +158,7 @@ local ChangeSpeedMod = function(pn, direction)
 	speedmod = increment * math.floor(speedmod/increment + 0.5)
 
 	mods.SpeedMod = speedmod
-	if GAMESTATE:GetCurrentStyle():GetStyleType() == "StyleType_TwoPlayersSharedSides" then
+	if styleType == "StyleType_TwoPlayersSharedSides" then
 		local otherPn = pn == "P1" and "P2" or "P1"
 		SL[otherPn].ActiveModifiers.SpeedMod     = SL[pn].ActiveModifiers.SpeedMod
 		SL[otherPn].ActiveModifiers.SpeedModType = SL[pn].ActiveModifiers.SpeedModType
@@ -209,7 +210,7 @@ local t = Def.ActorFrame{
 
 			local SpeedModRowIndex = FindOptionRowIndex(ScreenOptions,"SpeedMod")
 			local VariantRowIndex = FindOptionRowIndex(ScreenOptions,"NoteSkinVariant")
-			if GAMESTATE:GetCurrentStyle():GetStyleType() == "StyleType_TwoPlayersSharedSides" then
+			if styleType == "StyleType_TwoPlayersSharedSides" then
 				if player == GAMESTATE:GetMasterPlayerNumber() then
 					local otherPn = pn == "P1" and "P2" or "P1"
 					SL[otherPn].ActiveModifiers.SpeedMod     = SL[pn].ActiveModifiers.SpeedMod
@@ -308,7 +309,7 @@ for player in ivalues(GAMESTATE:GetHumanPlayers()) do
 		["SpeedModType" .. pn .. "SetMessageCommand"]=function(self,params)
 			local pn = pn
 			local player = player
-			if GAMESTATE:GetCurrentStyle():GetStyleType() == "StyleType_TwoPlayersSharedSides" then
+			if styleType == "StyleType_TwoPlayersSharedSides" then
 				pn = ToEnumShortString(GAMESTATE:GetMasterPlayerNumber())
 				player = GAMESTATE:GetMasterPlayerNumber()
 			else
@@ -342,7 +343,7 @@ for player in ivalues(GAMESTATE:GetHumanPlayers()) do
 
 			SL[pn].ActiveModifiers.SpeedMod     = speedmod
 			SL[pn].ActiveModifiers.SpeedModType = newtype
-			if GAMESTATE:GetCurrentStyle():GetStyleType() == "StyleType_TwoPlayersSharedSides" then
+			if styleType == "StyleType_TwoPlayersSharedSides" then
 				local otherPn = pn == "P1" and "P2" or "P1"
 				SL[otherPn].ActiveModifiers.SpeedMod     = SL[pn].ActiveModifiers.SpeedMod
 				SL[otherPn].ActiveModifiers.SpeedModType = SL[pn].ActiveModifiers.SpeedModType
@@ -363,11 +364,13 @@ for player in ivalues(GAMESTATE:GetHumanPlayers()) do
 				text = "M" .. tostring(SL[pn].ActiveModifiers.SpeedMod)
 			end
 
-			if GAMESTATE:GetCurrentStyle():GetStyleType() == "StyleType_TwoPlayersSharedSides" then
+			if styleType == "StyleType_TwoPlayersSharedSides" then
 				local otherPn = pn == "P1" and "P2" or "P1"
 				SpeedModBMTs[ToEnumShortString(GAMESTATE:GetMasterPlayerNumber())]:settext( text )
 			else
-				SpeedModBMTs[pn]:settext( text )
+				if SpeedModBMTs[pn] then
+					SpeedModBMTs[pn]:settext( text )
+				end
 			end
 			self:GetParent():queuecommand("Refresh")
 		end,
@@ -384,7 +387,7 @@ for player in ivalues(GAMESTATE:GetHumanPlayers()) do
 
 		["MenuLeft" .. pn .. "MessageCommand"]=function(self)
 			local pn = pn
-			if GAMESTATE:GetCurrentStyle():GetStyleType() == "StyleType_TwoPlayersSharedSides" then
+			if styleType == "StyleType_TwoPlayersSharedSides" then
 				pn = ToEnumShortString(GAMESTATE:GetMasterPlayerNumber())
 			end
 			local topscreen = SCREENMAN:GetTopScreen()
@@ -405,7 +408,7 @@ for player in ivalues(GAMESTATE:GetHumanPlayers()) do
 		end,
 		["MenuRight" .. pn .. "MessageCommand"]=function(self)
 			local pn = pn
-			if GAMESTATE:GetCurrentStyle():GetStyleType() == "StyleType_TwoPlayersSharedSides" then
+			if styleType == "StyleType_TwoPlayersSharedSides" then
 				pn = ToEnumShortString(GAMESTATE:GetMasterPlayerNumber())
 			end
 			local topscreen = SCREENMAN:GetTopScreen()
@@ -434,7 +437,7 @@ for player in ivalues(GAMESTATE:GetHumanPlayers()) do
 			self:zoom(0.5):y(48)
 			self:x(player==PLAYER_1 and WideScale(-77, -100) or WideScale(140,154))
 			-- If we're in TwoPlayersSharedSides, center the text
-			if GAMESTATE:GetCurrentStyle():GetStyleType() == "StyleType_TwoPlayersSharedSides" then
+			if styleType == "StyleType_TwoPlayersSharedSides" then
 				self:x(WideScale(-77, -100) + WideScale(140,154)) :halign(0.65)
 				if pn ~= ToEnumShortString(GAMESTATE:GetMasterPlayerNumber()) then
 					self:visible(false)

--- a/Graphics/OptionsCursor Left.lua
+++ b/Graphics/OptionsCursor Left.lua
@@ -20,7 +20,7 @@ return Def.Quad {
 	Name="CursorLeft",
 	InitCommand=function(self) self:zoomto(2,26) end,
 	OptionRowChangedMessageCommand=function(self, params)
-	if PlayerOnStepChartOptRow(player) then
+		if PlayerOnStepChartOptRow(player) and autoStyle then
 			self:y(player==PLAYER_1 and 1 or 3):zoomto(2,30)
 		else
 			self:y(player==PLAYER_1 and -1 or 1):zoomto(2,26)

--- a/Graphics/OptionsCursor Middle.lua
+++ b/Graphics/OptionsCursor Middle.lua
@@ -1,6 +1,6 @@
 local player = ...
 if not player then return Def.Actor end
-
+local autoStyle = ThemePrefs.Get("PreferredStyle") == "auto"
 local StepchartOptRowIndex = nil
 
 -- get all the LinesNames as a single string from Metrics.ini, split on commas,
@@ -25,7 +25,7 @@ return Def.ActorFrame {
 		Name="CursorBottom",
 		InitCommand=function(self) self:zoomto(1,2):y(12) end,
 		OptionRowChangedMessageCommand=function(self)
-			if PlayerOnStepChartOptRow(player) then
+			if PlayerOnStepChartOptRow(player) and autoStyle then
 				-- self:y(player==PLAYER_1 and 16 or 14)
 				self:y(16)
 			else

--- a/Graphics/OptionsCursor Right.lua
+++ b/Graphics/OptionsCursor Right.lua
@@ -20,7 +20,7 @@ return Def.Quad {
 	Name="CursorRight",
 	InitCommand=function(self) self:zoomto(2,26) end,
 	OptionRowChangedMessageCommand=function(self, params)
-		if PlayerOnStepChartOptRow(player) then
+		if PlayerOnStepChartOptRow(player) and autoStyle then
 			self:y(player==PLAYER_1 and 1 or 3):zoomto(2,30)
 		else
 			self:y(player==PLAYER_1 and -1 or 1):zoomto(2,26)

--- a/Graphics/OptionsUnderlineP1 Middle.lua
+++ b/Graphics/OptionsUnderlineP1 Middle.lua
@@ -7,7 +7,7 @@ for i, name in ipairs(LineNames) do
 	if name == "Stepchart" then StepchartOptRowIndex = i-1; break end
 end
 -- -----------------------------------------------------------------------
-
+local offset = ThemePrefs.Get("PreferredStyle") == "auto" and 4 or 0
 return Def.ActorFrame{
 	Name="OptionsUnderlineMiddle",
 
@@ -36,8 +36,8 @@ return Def.ActorFrame{
 			if not unnamed_children then return end
 
 			for k,v in ipairs(unnamed_children) do
-				-- offset them all by 4px
-				v:y(4)
+				-- offset them all by 4px if PreferredStyle is auto
+				v:y(offset)
 			end
 		end
 	}

--- a/Graphics/OptionsUnderlineP1 Middle.lua
+++ b/Graphics/OptionsUnderlineP1 Middle.lua
@@ -1,5 +1,5 @@
 local StepchartOptRowIndex = nil
-
+local autoStyle = ThemePrefs.Get("PreferredStyle") == "auto"
 -- get all the LinesNames as a single string from Metrics.ini, split on commas,
 local LineNames = split(",", THEME:GetMetric("ScreenPlayerOptions", "LineNames"))
 -- and loop through until we find one that matches "Stepchart" (or, we don't).
@@ -7,7 +7,6 @@ for i, name in ipairs(LineNames) do
 	if name == "Stepchart" then StepchartOptRowIndex = i-1; break end
 end
 -- -----------------------------------------------------------------------
-local offset = ThemePrefs.Get("PreferredStyle") == "auto" and 4 or 0
 return Def.ActorFrame{
 	Name="OptionsUnderlineMiddle",
 
@@ -26,7 +25,7 @@ return Def.ActorFrame{
 			-- OptionRow amidst myriad unnamed children belonging to the topscreen
 			-- each and every time.
 			local optrow = SCREENMAN:GetTopScreen():GetChild("Container"):GetChild("")[StepchartOptRowIndex+1]
-			if not optrow then return end
+			if not optrow or not autoStyle then return end
 
 			local underline_af = optrow:GetChild("")
 			if not underline_af then return end
@@ -36,8 +35,8 @@ return Def.ActorFrame{
 			if not unnamed_children then return end
 
 			for k,v in ipairs(unnamed_children) do
-				-- offset them all by 4px if PreferredStyle is auto
-				v:y(offset)
+				-- offset them all by 4px
+				v:y(4)
 			end
 		end
 	}

--- a/Scripts/SL-PlayerOptions.lua
+++ b/Scripts/SL-PlayerOptions.lua
@@ -355,17 +355,15 @@ local Overrides = {
 		ExportOnChange = true,
 		Choices = function()
 			local choices = {}
+			local show_steps_type = ThemePrefs.Get("PreferredStyle") == "auto"
 
 			if not GAMESTATE:IsCourseMode() then
 				local song = GAMESTATE:GetCurrentSong()
 				if song then
 					for steps in ivalues( SongUtil.GetPlayableSteps(song) ) do
-						local choice
-						if steps:IsAnEdit() then
-							choice = ("%s\n%s %i"):format(steps:GetStepsType():gsub("%w+_%w+_", ""):lower(), steps:GetDescription(), steps:GetMeter())
-						else
-							choice = ("%s\n%s %i"):format(steps:GetStepsType():gsub("%w+_%w+_", ""):lower(), THEME:GetString("Difficulty", ToEnumShortString(steps:GetDifficulty())), steps:GetMeter())
-						end
+						local header = show_steps_type and (steps:GetStepsType():gsub("%w+_%w+_", ""):lower() .. "\n") or ""
+						local difficultyOrDesc = steps:IsAnEdit() and steps:GetDescription() or THEME:GetString("Difficulty", ToEnumShortString(steps:GetDifficulty()))
+						local choice = ("%s%s %i"):format(header, difficultyOrDesc, steps:GetMeter())
 						table.insert(choices, choice)
 					end
 				end

--- a/metrics.ini
+++ b/metrics.ini
@@ -434,7 +434,7 @@ ItemsLongRowP2X=WideScale(_screen.cx+100,_screen.cx+100)
 # pixels between each item when the OptionRow's layout is ShowAllInOneRow
 ItemsGapX=14
 
-ItemOnCommand=zoom,0.75;diffusealpha,1;vertspacing,-10
+ItemOnCommand=zoom,0.75;diffusealpha,1;vertspacing,ThemePrefs.Get("PreferredStyle") == "auto" and -10 or 0
 ItemGainFocusCommand=
 ItemLoseFocusCommand=
 


### PR DESCRIPTION
The StepsType header is intended to only be shown when you're in "All" styles mode which would have the difficulties in player options render w/ the steps type above like:
<img width="1858" height="1106" alt="image" src="https://github.com/user-attachments/assets/441c84bb-cb82-4376-b9dd-a37f87ece5ad" />

When we're not in this mode though it's not needed and the cursor line seemed to render weird?
<img width="1018" height="81" alt="image" src="https://github.com/user-attachments/assets/85e042f3-5b74-44dc-ae71-ca628bdf4aed" />

Anyways should render as it did before now in normal modes:
<img width="1862" height="1067" alt="image" src="https://github.com/user-attachments/assets/ef61ee36-5a67-48d9-8c10-c0b6a955cbca" />

This also addresses an issue with the default pane not being correct. I was originally planning to have it so if you played a Couples chart you could view the "combined" arrow pane (how many judgements on each arrow total as opposed to only per player) this would have shown like it did in doubles but it required a bunch of weird conditions so I ended up scrapping it. This removes the lingering bits from that, most notably the decrementing of secondary_i 

Overall: 
- StepsType only shows when PreferredStyle is auto
- PlayerOptions display as it did in previously otherwise
- no longer decrement secondary_i, remove unused vars.