### PR TITLE
Adjust music wheel text positioning w series icons in 4:3 mode

### DIFF
--- a/metrics.ini
+++ b/metrics.ini
@@ -1572,16 +1572,16 @@ ParentExpandedSetCommand=%function(self) DiffuseEmojis(self) end
 CourseOnCommand=halign,0;x,WideScale(65, 104);maxwidth,WideScale(270,350);zoom,0.85
 
 # ensure that very long titles don't go off-screen
-SectionExpandedOnCommand=halign,0;maxwidth,WideScale(240,310)
-SectionCollapsedOnCommand=halign,0;maxwidth,WideScale(240,310)
-ParentExpandedOnCommand=halign,0;maxwidth,WideScale(240,310)
-ParentCollapsedOnCommand=halign,0;maxwidth,WideScale(240,310)
+SectionExpandedOnCommand=halign,0;maxwidth,WideScale(220,310)
+SectionCollapsedOnCommand=halign,0;maxwidth,WideScale(220,310)
+ParentExpandedOnCommand=halign,0;maxwidth,WideScale(220,310)
+ParentCollapsedOnCommand=halign,0;maxwidth,WideScale(220,310)
 
-SectionExpandedX=WideScale(35, 74)
-SectionCollapsedX=WideScale(35, 74)
-ParentExpandedX=WideScale(35, 74)
-ParentCollapsedX=WideScale(35, 74)
-ChildSectionX=WideScale(45, 84)
+SectionExpandedX=WideScale(65, 74)
+SectionCollapsedX=WideScale(65, 74)
+ParentExpandedX=WideScale(70, 74)
+ParentCollapsedX=WideScale(70, 74)
+ChildSectionX=WideScale(75, 84)
 ChildSectionY=0
 ChildSectionOnCommand=
 RouletteX=WideScale(150, 204)


### PR DESCRIPTION


<img width="1600" height="1137" alt="image" src="https://github.com/user-attachments/assets/fc028ed3-395d-4926-8adf-d40c87d8aa07" />


to


<img width="1595" height="1052" alt="image" src="https://github.com/user-attachments/assets/cb8f1ae1-c57c-4c56-aacd-901c9e4b4eb0" />
