### PR TITLE
Reopen ScreenPlayerOptions from ScreenGameplay on certain conditions

### DIFF
--- a/BGAnimations/ScreenGameplay underlay/Shared/ReopenPlayerOptions.lua
+++ b/BGAnimations/ScreenGameplay underlay/Shared/ReopenPlayerOptions.lua
@@ -1,0 +1,56 @@
+-- reset
+SL.Global.GameplayForcePlayerOptions = false
+
+-- ignore on course mode
+if GAMESTATE:IsCourseMode() then return end
+
+local rate = SL.Global.ActiveModifiers.MusicRate
+local isPayMode = GAMESTATE:GetCoinMode() == "CoinMode_Pay"
+
+local allGuests = true
+local humanPlayers = GAMESTATE:GetHumanPlayers()
+for player in ivalues(humanPlayers) do
+    local pn = ToEnumShortString(player)
+    if PROFILEMAN:IsPersistentProfile(player) or SL[pn].ApiKey ~= "" then
+        allGuests = false
+    end
+end
+
+return Def.ActorFrame {
+    Name = "ReopenPlayerOptions",
+
+    -- change modifiers without loosing credit or get back to select music
+    CodeMessageCommand = function(self, params)
+        if params.Name == "ChangePlayerOptions" then
+            -- ignore if all guests (prop randoms)
+            if isPayMode and allGuests then return end
+
+            local song = GAMESTATE:GetCurrentSong()
+            local songPos = GAMESTATE:GetSongPosition()
+            local songCurrentSecs = songPos:GetMusicSeconds() / rate
+            local songTotalSecs = (song:GetLastSecond() < 0 and 0 or song:GetLastSecond()) / rate
+            local songRemainingSecs = songTotalSecs - songCurrentSecs
+
+            local canChangeOptions = false
+
+            -- EVENTMODE -> until last 5 seconds
+            -- ARCADE -> until first 10 seconds
+            if (isPayMode and songCurrentSecs < 10) or (not isPayMode and songRemainingSecs > 5) then
+                canChangeOptions = true
+            end
+
+            if canChangeOptions then
+                -- avoid music wheel if Pay mode
+                if isPayMode then
+                    SL.Global.GameplayForcePlayerOptions = true
+                end
+
+                SL.Global.GameplayReloadCheck = false
+
+                SCREENMAN:GetTopScreen()
+                    :SetPrevScreenName("ScreenPlayerOptions")
+                    :begin_backing_out()
+            end
+        end
+    end
+}

--- a/BGAnimations/ScreenGameplay underlay/default.lua
+++ b/BGAnimations/ScreenGameplay underlay/default.lua
@@ -92,4 +92,7 @@ end
 -- add to the ActorFrame last; overlapped by StepStatistics otherwise
 t[#t+1] = LoadActor("./Shared/BPMDisplay.lua")
 
+-- change player options on demand
+t[#t + 1] = LoadActor("./Shared/ReopenPlayerOptions.lua")
+
 return t

--- a/Scripts/SL-PlayerOptions.lua
+++ b/Scripts/SL-PlayerOptions.lua
@@ -801,14 +801,14 @@ local Overrides = {
 	ScreenAfterPlayerOptions = {
 		Values = function()
 			local choices = { "Gameplay", "Select Music", "Options2", "Options3"  }
-			if SL.Global.MenuTimer.ScreenSelectMusic < 1  or SL.Global.MusicWheelLocked == true then table.remove(choices, 2) end
+			if SL.Global.MenuTimer.ScreenSelectMusic < 1 or SL.Global.GameplayForcePlayerOptions or SL.Global.MusicWheelLocked == true then table.remove(choices, 2) end
 			return choices
 		end,
 		OneChoiceForAllPlayers = true,
 		SaveSelections = function(self, list, pn)
 			if list[1] then SL.Global.ScreenAfter.PlayerOptions = Branch.GameplayScreen() end
 
-			if SL.Global.MenuTimer.ScreenSelectMusic > 1 and SL.Global.MusicWheelLocked == false then
+			if SL.Global.MenuTimer.ScreenSelectMusic > 1 and not SL.Global.GameplayForcePlayerOptions and SL.Global.MusicWheelLocked == false then
 				if list[2] then SL.Global.ScreenAfter.PlayerOptions = SelectMusicOrCourse() end
 				if list[3] then SL.Global.ScreenAfter.PlayerOptions = "ScreenPlayerOptions2" end
 				if list[4] then SL.Global.ScreenAfter.PlayerOptions = "ScreenPlayerOptions3" end
@@ -822,14 +822,14 @@ local Overrides = {
 	ScreenAfterPlayerOptions2 = {
 		Values = function()
 			local choices = { "Gameplay", "Select Music", "Options1", "Options3"  }
-			if SL.Global.MenuTimer.ScreenSelectMusic < 1  or SL.Global.MusicWheelLocked == true	 then table.remove(choices, 2) end
+			if SL.Global.MenuTimer.ScreenSelectMusic < 1 or SL.Global.GameplayForcePlayerOptions or SL.Global.MusicWheelLocked == true	 then table.remove(choices, 2) end
 			return choices
 		end,
 		OneChoiceForAllPlayers = true,
 		SaveSelections = function(self, list, pn)
 			if list[1] then SL.Global.ScreenAfter.PlayerOptions2 = Branch.GameplayScreen() end
 
-			if SL.Global.MenuTimer.ScreenSelectMusic > 1 and SL.Global.MusicWheelLocked == false then
+			if SL.Global.MenuTimer.ScreenSelectMusic > 1 and not SL.Global.GameplayForcePlayerOptions and SL.Global.MusicWheelLocked == false then
 				if list[2] then SL.Global.ScreenAfter.PlayerOptions2 = SelectMusicOrCourse() end
 				if list[3] then SL.Global.ScreenAfter.PlayerOptions2 = "ScreenPlayerOptions" end
 				if list[4] then SL.Global.ScreenAfter.PlayerOptions2 = "ScreenPlayerOptions3" end
@@ -844,14 +844,14 @@ local Overrides = {
 	ScreenAfterPlayerOptions3 = {
 		Values = function()
 			local choices = { "Gameplay", "Select Music", "Options1", "Options2"  }
-			if SL.Global.MenuTimer.ScreenSelectMusic < 1  or SL.Global.MusicWheelLocked == true then table.remove(choices, 2) end
+			if SL.Global.MenuTimer.ScreenSelectMusic < 1 or SL.Global.GameplayForcePlayerOptions or SL.Global.MusicWheelLocked == true then table.remove(choices, 2) end
 			return choices
 		end,
 		OneChoiceForAllPlayers = true,
 		SaveSelections = function(self, list, pn)
 			if list[1] then SL.Global.ScreenAfter.PlayerOptions3 = Branch.GameplayScreen() end
 
-			if SL.Global.MenuTimer.ScreenSelectMusic > 1 and SL.Global.MusicWheelLocked == false then
+			if SL.Global.MenuTimer.ScreenSelectMusic > 1 and not SL.Global.GameplayForcePlayerOptions and SL.Global.MusicWheelLocked == false then
 				if list[2] then SL.Global.ScreenAfter.PlayerOptions3 = SelectMusicOrCourse() end
 				if list[3] then SL.Global.ScreenAfter.PlayerOptions3 = "ScreenPlayerOptions" end
 				if list[4] then SL.Global.ScreenAfter.PlayerOptions3 = "ScreenPlayerOptions2" end

--- a/Scripts/SL_Init.lua
+++ b/Scripts/SL_Init.lua
@@ -162,6 +162,9 @@ local GlobalDefaults = {
 			self.MusicWheelLocked = false
 			
 			self.GameplayReloadCheck = false
+			-- in pay mode cannot return to music wheel after open PlayerOptions from Gameplay
+			self.GameplayForcePlayerOptions = false
+
 			-- How long to wait before displaying a "cue"
 			self.ColumnCueMinTime = 1.5
 

--- a/metrics.ini
+++ b/metrics.ini
@@ -648,6 +648,7 @@ Holds,5="mod,holdrolls;name,HoldsToRolls"
 Class="ScreenPlayerOptions"
 Fallback="ScreenOptions"
 
+PrevScreen=SL.Global.GameplayForcePlayerOptions and "ScreenPlayerOptions" or Branch.BackOutOfPlayerOptions()
 NextScreen=SL.Global.ScreenAfter.PlayerOptions
 TimerSeconds=SL.Global.MenuTimer.ScreenPlayerOptions
 TimerStealth=false
@@ -1819,6 +1820,9 @@ PlayerP2OnePlayerBothSidesX=_screen.cx
 MinSecondsToStep=6.0 * SL.Global.ActiveModifiers.MusicRate
 MinSecondsToMusic=2.0 * SL.Global.ActiveModifiers.MusicRate
 MinSecondsToStepNextSong=4.0 * SL.Global.ActiveModifiers.MusicRate
+
+CodeNames="ChangePlayerOptions"
+CodeChangePlayerOptions="Start,Start,Start,Start"
 
 FailOnMissCombo=-1
 


### PR DESCRIPTION
# Reopen ScreenPlayerOptions from ScreenGameplay

## How
During gameplay, you can return to Player Options by **pressing "Start" 4 times in a row**.

## Conditions
### Event Mode
Player Options can be open **until last 5 seconds** of song

### Pay Mode
* Player Options can be open **until first 10 seconds** of song
* Disabled return to Music Wheel