### PR TITLE
Fix pump couples strings

### DIFF
--- a/Languages/de.ini
+++ b/Languages/de.ini
@@ -495,19 +495,19 @@ Edit=Edit
 
 
 [StepsType]
-dance-couple=Paar
+dance-couple=Halb Paar
 dance-double=Doppelt
 dance-single=Einzel
 dance-solo=Solo
 dance-threepanel=3panel
-dance-routine=Routine
+dance-routine=Paar
 
 
-pump-couple=Paar
+pump-couple=Halb Paar
 pump-double=Doppelt
 pump-single=Einzel
 pump-halfdouble=Halb Doppelt
-pump-routine=Routine
+pump-routine=Paar
 
 
 techno-single4=Einzel 4-Panel

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -634,7 +634,7 @@ pump-halfdouble=Half\nDouble
 # 2 players share 10 panels; this is actually a thing in current PIU games
 pump-routine=Co-Op
 # like dance-couple, I guess?  does this appear in any real PIU games?
-pump-couple=Couple
+pump-couple=Half\nCouple
 
 # Arcade TechnoMotion allowed players to choose 4 panel, 5 panel, or 8 panel gameplay.  Neat.
 # While StepMania supports all this, Simply Love only allows 8 panel gameplay.

--- a/Languages/es.ini
+++ b/Languages/es.ini
@@ -581,14 +581,14 @@ dance-single=Individual
 dance-double=Dobles
 dance-solo=Solo
 dance-threepanel=3 paneles
-dance-routine=Rutina
-dance-couple=Parejas
+dance-routine=Parejas
+dance-couple=Medio\nParejas
 
 pump-single=Individual
 pump-double=Dobles
 pump-halfdouble=Medio doble
-pump-routine=Rutina
-pump-couple=Pareja
+pump-routine=Parejas
+pump-couple=Medio\nPareja
 
 techno-single4=Individual 4-Paneles
 techno-double4=Dobles 4-Paneles

--- a/Languages/fr.ini
+++ b/Languages/fr.ini
@@ -417,11 +417,11 @@ dance-solo=Solo
 dance-threepanel=3touches
 dance-routine=Routine
 
-pump-couple=Couple
+pump-couple=Demi\nCouple
 pump-double=Double
 pump-single=Single
 pump-halfdouble=Demi Double
-pump-routine=Routine
+pump-routine=Co-Op
 
 techno-single4=Simple 4-Panel
 techno-double4=Double 4-Panel

--- a/Languages/it.ini
+++ b/Languages/it.ini
@@ -563,9 +563,9 @@ pump-double=Double
 # 6 panel pump
 pump-halfdouble=Half Double
 # 2 players share 10 panels; this is actually a thing in current PIU games
-pump-routine=Routine
+pump-routine=Co-Op
 # like dance-couple, I guess?  does this appear in any real PIU games?
-pump-couple=Couple
+pump-couple=Half\nCouple
 
 # Arcade TechnoMotion allowed players to choose 4 panel, 5 panel, or 8 panel gameplay.  Neat.
 # While StepMania supports all this, Simply Love only allows 8 panel gameplay.

--- a/Languages/ja.ini
+++ b/Languages/ja.ini
@@ -511,11 +511,11 @@ dance-solo=Solo
 dance-threepanel=3panel
 dance-routine=Routine
 
-pump-couple=Couple
+pump-couple=Half\nCouple
 pump-double=Double
 pump-single=Single
 pump-halfdouble=Half Double
-pump-routine=Routine
+pump-routine=Co-Op
 
 techno-single4=Single 4-Panel
 techno-double4=Double 4-Panel

--- a/Languages/pl.ini
+++ b/Languages/pl.ini
@@ -562,9 +562,9 @@ pump-double=Double
 # 6 panel pump
 pump-halfdouble=Half Double
 # 2 players share 10 panels; this is actually a thing in current PIU games
-pump-routine=Routine
+pump-routine=Co-op
 # like dance-couple, I guess?  does this appear in any real PIU games?
-pump-couple=Couple
+pump-couple=Half\nCouple
 
 # Arcade TechnoMotion allowed players to choose 4 panel, 5 panel, or 8 panel gameplay.  Neat.
 # While StepMania supports all this, Simply Love only allows 8 panel gameplay.

--- a/Languages/pt-br.ini
+++ b/Languages/pt-br.ini
@@ -720,18 +720,18 @@ Challenge=Profissinal
 Edit=Editado
 
 [StepsType]
-dance-couple=Dupla
+dance-couple=Meia Dupla
 dance-double=Dobro
 dance-single=Único
 dance-solo=Solo
 dance-threepanel=3-Painéis
-dance-routine=Rotina
+dance-routine=Dupla
 
-pump-couple=Dupla
+pump-couple=Meia Dupla
 pump-double=Dobro
 pump-single=Único
 pump-halfdouble=Meio Dobro
-pump-routine=Rotina
+pump-routine=Co-Op
 
 techno-single4=Único 4-Painéis
 techno-double4=Dobro 4-Painéis

--- a/Languages/ru.ini
+++ b/Languages/ru.ini
@@ -542,7 +542,7 @@ dance-routine=Типа Каплы
 # 2 players, each stays on their own 4 panel dance pad, but they have unique steps
 # that artisically complement one another; I don't think most people know this exists.
 #Well they know now! Thanks AGDQ! -TBRK
-dance-couple=Каплы
+dance-couple=Полу-Каплы
 
 # 5 panel pump
 pump-single=Сингл
@@ -553,7 +553,7 @@ pump-halfdouble=Полу-Дабл
 # 2 players share 10 panels; this is actually a thing in current PIU games
 pump-routine=Каплы
 # like dance-couple, I guess?  does this appear in any real PIU games?
-pump-couple=Каплы
+pump-couple=Полу-Каплы
 
 # Arcade TechnoMotion allowed players to choose 4 panel, 5 panel, or 8 panel gameplay.  Neat.
 # While StepMania supports all this, Simply Love only allows 8 panel gameplay.


### PR DESCRIPTION
Just ensures we follow the same naming conventions we established in english for the other languages